### PR TITLE
feat(auth): add --readonly and --drive-scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Gmail: allow drafts without a recipient; drafts update preserves existing `To` when `--to` is omitted. (#57) — thanks @antons.
 
+### Added
+
+- Auth: `gog auth add --readonly` and `--drive-scope` for least-privilege tokens. (#58) — thanks @jeremys.
+
 ### Fixed
 
 - Paths: expand leading `~` in user-provided file paths (e.g. `--out "~/Downloads/file.pdf"`). (#56) — thanks @salmonumbrella.

--- a/README.md
+++ b/README.md
@@ -197,6 +197,18 @@ To request fewer scopes:
 gog auth add you@gmail.com --services drive,calendar
 ```
 
+To request read-only scopes (write operations will fail with 403 insufficient scopes):
+
+```bash
+gog auth add you@gmail.com --services drive,calendar --readonly
+```
+
+To use Drive's file-limited scope (write-capable, but limited to files created/opened by this app):
+
+```bash
+gog auth add you@gmail.com --services drive --drive-scope file
+```
+
 If you need to add services later and Google doesn't return a refresh token, re-run with `--force-consent`:
 
 ```bash

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -103,7 +103,7 @@ Scope selection note:
 
 - The consent screen shows the scopes the CLI requested.
 - Users cannot selectively un-check individual requested scopes in the consent screen; they either approve all requested scopes or cancel.
-- To request fewer scopes, choose fewer services via `gog auth add --services ...`.
+- To request fewer scopes, choose fewer services via `gog auth add --services ...` or use `gog auth add --readonly` where applicable.
 
 ## Config layout
 
@@ -134,7 +134,7 @@ Flag aliases:
 ### Implemented
 
 - `gog auth credentials <credentials.json|->`
-- `gog auth add <email> [--services user|all|gmail,calendar,drive,docs,contacts,tasks,sheets,people,groups] [--manual] [--force-consent]`
+- `gog auth add <email> [--services user|all|gmail,calendar,drive,docs,contacts,tasks,sheets,people,groups] [--readonly] [--drive-scope full|readonly|file] [--manual] [--force-consent]`
 - `gog auth services [--markdown]`
 - `gog auth keep <email> --key <service-account.json>` (Google Keep; Workspace only)
 - `gog auth list`


### PR DESCRIPTION
Closes #58.

- Adds `gog auth add --readonly` (read-only equivalents per service where available)
- Adds `gog auth add --drive-scope full|readonly|file` (Drive scope only; file = write-limited)
- Regression tests for scope selection + CLI wiring