### PR TITLE
fix(auth): include drive scope for sheets export

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ Service scope matrix (auto-generated; run `go run scripts/gen-auth-services-md.g
 | docs | yes | Docs API, Drive API | `https://www.googleapis.com/auth/drive`<br>`https://www.googleapis.com/auth/documents` | Export/copy/create via Drive |
 | contacts | yes | People API | `https://www.googleapis.com/auth/contacts`<br>`https://www.googleapis.com/auth/contacts.other.readonly`<br>`https://www.googleapis.com/auth/directory.readonly` | Contacts + other contacts + directory |
 | tasks | yes | Tasks API | `https://www.googleapis.com/auth/tasks` |  |
-| sheets | yes | Sheets API, Drive API | `https://www.googleapis.com/auth/spreadsheets` | Export via Drive |
+| sheets | yes | Sheets API, Drive API | `https://www.googleapis.com/auth/drive`<br>`https://www.googleapis.com/auth/spreadsheets` | Export via Drive |
 | people | yes | People API | `profile` | OIDC profile scope |
 | groups | no | Cloud Identity API | `https://www.googleapis.com/auth/cloud-identity.groups.readonly` | Workspace only |
 | keep | no | Keep API | `https://www.googleapis.com/auth/keep` | Workspace only; service account |

--- a/internal/googleauth/service.go
+++ b/internal/googleauth/service.go
@@ -119,10 +119,13 @@ var serviceInfoByService = map[Service]serviceInfo{
 		note:   "OIDC profile scope",
 	},
 	ServiceSheets: {
-		scopes: []string{"https://www.googleapis.com/auth/spreadsheets"},
-		user:   true,
-		apis:   []string{"Sheets API", "Drive API"},
-		note:   "Export via Drive",
+		scopes: []string{
+			"https://www.googleapis.com/auth/drive",
+			"https://www.googleapis.com/auth/spreadsheets",
+		},
+		user: true,
+		apis: []string{"Sheets API", "Drive API"},
+		note: "Export via Drive",
 	},
 	ServiceGroups: {
 		scopes: []string{"https://www.googleapis.com/auth/cloud-identity.groups.readonly"},
@@ -371,11 +374,12 @@ func scopesForServiceWithOptions(service Service, opts ScopeOptions) ([]string, 
 		// No read-only equivalent; profile is already read-ish.
 		return Scopes(service)
 	case ServiceSheets:
+		sheetsScope := "https://www.googleapis.com/auth/spreadsheets"
 		if opts.Readonly {
-			return []string{"https://www.googleapis.com/auth/spreadsheets.readonly"}, nil
+			sheetsScope = "https://www.googleapis.com/auth/spreadsheets.readonly"
 		}
 
-		return Scopes(service)
+		return []string{driveScopeValue(), sheetsScope}, nil
 	case ServiceGroups:
 		return Scopes(service)
 	case ServiceKeep:

--- a/internal/googleauth/service_test.go
+++ b/internal/googleauth/service_test.go
@@ -282,6 +282,21 @@ func TestScopesForManageWithOptions_InvalidDriveScope(t *testing.T) {
 	}
 }
 
+func TestScopesForManageWithOptions_SheetsReadonlyIncludesDriveReadonly(t *testing.T) {
+	scopes, err := ScopesForManageWithOptions([]Service{ServiceSheets}, ScopeOptions{Readonly: true})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if !containsScope(scopes, "https://www.googleapis.com/auth/spreadsheets.readonly") {
+		t.Fatalf("missing spreadsheets.readonly in %v", scopes)
+	}
+
+	if !containsScope(scopes, "https://www.googleapis.com/auth/drive.readonly") {
+		t.Fatalf("missing drive.readonly in %v", scopes)
+	}
+}
+
 func TestScopes_DocsIncludesDriveAndDocsScopes(t *testing.T) {
 	scopes, err := Scopes(ServiceDocs)
 	if err != nil {


### PR DESCRIPTION
Fixes readonly Sheets export: `gog auth add --services sheets --readonly` now includes `https://www.googleapis.com/auth/drive.readonly`, since `gog sheets export` goes through Drive.

- Sheets service scopes include Drive (export via Drive)
- Scopes selection adds Drive scope for Sheets (respects `--drive-scope`)
- Regression tests for both scope selection + CLI auth add