### PR TITLE
test(auth): cover sheets scope matrix

### DIFF
--- a/internal/cmd/auth_add_test.go
+++ b/internal/cmd/auth_add_test.go
@@ -413,6 +413,62 @@ func TestAuthAddCmd_SheetsReadonlyIncludesDriveReadonly(t *testing.T) {
 	}
 }
 
+func TestAuthAddCmd_SheetsDriveScopeFile(t *testing.T) {
+	origAuth := authorizeGoogle
+	origOpen := openSecretsStore
+	origKeychain := ensureKeychainAccess
+	origFetch := fetchAuthorizedEmail
+	t.Cleanup(func() {
+		authorizeGoogle = origAuth
+		openSecretsStore = origOpen
+		ensureKeychainAccess = origKeychain
+		fetchAuthorizedEmail = origFetch
+	})
+
+	ensureKeychainAccess = func() error { return nil }
+
+	store := newMemSecretsStore()
+	openSecretsStore = func() (secrets.Store, error) { return store, nil }
+
+	var gotOpts googleauth.AuthorizeOptions
+	authorizeGoogle = func(ctx context.Context, opts googleauth.AuthorizeOptions) (string, error) {
+		gotOpts = opts
+		gotOpts.Services = append([]googleauth.Service(nil), opts.Services...)
+		gotOpts.Scopes = append([]string(nil), opts.Scopes...)
+		return "rt", nil
+	}
+	fetchAuthorizedEmail = func(context.Context, string, []string, time.Duration) (string, error) {
+		return "user@example.com", nil
+	}
+
+	_ = captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{
+				"--json",
+				"auth",
+				"add",
+				"user@example.com",
+				"--services",
+				"sheets",
+				"--drive-scope",
+				"file",
+			}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	if !containsStringInSlice(gotOpts.Scopes, "https://www.googleapis.com/auth/drive.file") {
+		t.Fatalf("missing drive.file in %v", gotOpts.Scopes)
+	}
+	if !containsStringInSlice(gotOpts.Scopes, "https://www.googleapis.com/auth/spreadsheets") {
+		t.Fatalf("missing spreadsheets in %v", gotOpts.Scopes)
+	}
+	if containsStringInSlice(gotOpts.Scopes, "https://www.googleapis.com/auth/drive") {
+		t.Fatalf("unexpected drive in %v", gotOpts.Scopes)
+	}
+}
+
 func containsStringInSlice(items []string, want string) bool {
 	for _, it := range items {
 		if it == want {

--- a/internal/googleauth/service_test.go
+++ b/internal/googleauth/service_test.go
@@ -297,6 +297,57 @@ func TestScopesForManageWithOptions_SheetsReadonlyIncludesDriveReadonly(t *testi
 	}
 }
 
+func TestScopesForManageWithOptions_SheetsHonorsDriveScopeMode(t *testing.T) {
+	tests := []struct {
+		name      string
+		opts      ScopeOptions
+		wantDrive string
+		wantSheet string
+	}{
+		{
+			name:      "default",
+			opts:      ScopeOptions{},
+			wantDrive: "https://www.googleapis.com/auth/drive",
+			wantSheet: "https://www.googleapis.com/auth/spreadsheets",
+		},
+		{
+			name:      "drive_readonly",
+			opts:      ScopeOptions{DriveScope: DriveScopeReadonly},
+			wantDrive: "https://www.googleapis.com/auth/drive.readonly",
+			wantSheet: "https://www.googleapis.com/auth/spreadsheets",
+		},
+		{
+			name:      "drive_file",
+			opts:      ScopeOptions{DriveScope: DriveScopeFile},
+			wantDrive: "https://www.googleapis.com/auth/drive.file",
+			wantSheet: "https://www.googleapis.com/auth/spreadsheets",
+		},
+		{
+			name:      "readonly",
+			opts:      ScopeOptions{Readonly: true, DriveScope: DriveScopeFull},
+			wantDrive: "https://www.googleapis.com/auth/drive.readonly",
+			wantSheet: "https://www.googleapis.com/auth/spreadsheets.readonly",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			scopes, err := ScopesForManageWithOptions([]Service{ServiceSheets}, tc.opts)
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
+
+			if !containsScope(scopes, tc.wantDrive) {
+				t.Fatalf("missing %q in %v", tc.wantDrive, scopes)
+			}
+
+			if !containsScope(scopes, tc.wantSheet) {
+				t.Fatalf("missing %q in %v", tc.wantSheet, scopes)
+			}
+		})
+	}
+}
+
 func TestScopes_DocsIncludesDriveAndDocsScopes(t *testing.T) {
 	scopes, err := Scopes(ServiceDocs)
 	if err != nil {


### PR DESCRIPTION
More regression coverage for the Sheets auth surface:

- Scope selection: Sheets honors drive-scope full|readonly|file and readonly mode
- CLI wiring: `gog auth add --services sheets --drive-scope file` includes drive.file + spreadsheets

This protects `gog sheets export` (Drive-backed) from future scope regressions.