### PR TITLE
fix(classroom): wait for visible course state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Drive: preserve repeated folder placements in tree, inventory, and size summaries; reject cyclic folder graphs instead of collapsing paths or scanning indefinitely.
 - Backup: bind configuration, legacy fallback, and home expansion to the selected runtime layout instead of process-global path state.
 - Classroom: require an archived course before deletion with actionable lifecycle guidance, and prevent live tests from leaving consumer-account courses behind.
+- Classroom: wait for course state changes to become readable before reporting success, so immediate archive-then-delete workflows do not fail on stale state.
 - Forms: validate scale question bounds locally and document the Forms API's accepted minimum and maximum values.
 - Groups and Calendar team: reject consumer accounts and stored user OAuth before Cloud Identity API calls, require an explicit account for identity-based direct-token/ADC searches, keep ADC precedence consistent across services, and provide recovery guidance for service-account, direct-token, and ADC auth.
 - Gmail: bind watch state to the selected runtime state directory and serialize atomic updates across concurrent watch processes.

--- a/docs/commands.generated.md
+++ b/docs/commands.generated.md
@@ -130,14 +130,14 @@ Generated from `gog schema --json`.
       - [`gog classroom (class) announcements (announcement,ann) list (ls) <courseId> [flags]`](commands/gog-classroom-announcements-list.md) - List announcements
       - [`gog classroom (class) announcements (announcement,ann) update (edit,set) <courseId> <announcementId> [flags]`](commands/gog-classroom-announcements-update.md) - Update an announcement
     - [`gog classroom (class) courses (course) <command>`](commands/gog-classroom-courses.md) - Courses
-      - [`gog classroom (class) courses (course) archive (arch) <courseId>`](commands/gog-classroom-courses-archive.md) - Archive a course
+      - [`gog classroom (class) courses (course) archive (arch) <courseId>`](commands/gog-classroom-courses-archive.md) - Archive a course and wait until the state is visible
       - [`gog classroom (class) courses (course) create (add,new) --name=STRING [flags]`](commands/gog-classroom-courses-create.md) - Create a course
       - [`gog classroom (class) courses (course) delete (rm,del,remove) <courseId>`](commands/gog-classroom-courses-delete.md) - Delete an archived course
       - [`gog classroom (class) courses (course) get (info,show) <courseId>`](commands/gog-classroom-courses-get.md) - Get a course
       - [`gog classroom (class) courses (course) join (enroll) <courseId> [flags]`](commands/gog-classroom-courses-join.md) - Join a course
       - [`gog classroom (class) courses (course) leave (unenroll) <courseId> [flags]`](commands/gog-classroom-courses-leave.md) - Leave a course
       - [`gog classroom (class) courses (course) list (ls) [flags]`](commands/gog-classroom-courses-list.md) - List courses
-      - [`gog classroom (class) courses (course) unarchive (unarch,restore) <courseId>`](commands/gog-classroom-courses-unarchive.md) - Unarchive a course
+      - [`gog classroom (class) courses (course) unarchive (unarch,restore) <courseId>`](commands/gog-classroom-courses-unarchive.md) - Unarchive a course and wait until the state is visible
       - [`gog classroom (class) courses (course) update (edit,set) <courseId> [flags]`](commands/gog-classroom-courses-update.md) - Update a course
       - [`gog classroom (class) courses (course) url (link) <courseId> ...`](commands/gog-classroom-courses-url.md) - Print Classroom web URLs for courses
     - [`gog classroom (class) coursework (work) <command>`](commands/gog-classroom-coursework.md) - Coursework

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -181,14 +181,14 @@ Generated pages: 642.
       - [gog classroom announcements list](gog-classroom-announcements-list.md) - List announcements
       - [gog classroom announcements update](gog-classroom-announcements-update.md) - Update an announcement
     - [gog classroom courses](gog-classroom-courses.md) - Courses
-      - [gog classroom courses archive](gog-classroom-courses-archive.md) - Archive a course
+      - [gog classroom courses archive](gog-classroom-courses-archive.md) - Archive a course and wait until the state is visible
       - [gog classroom courses create](gog-classroom-courses-create.md) - Create a course
       - [gog classroom courses delete](gog-classroom-courses-delete.md) - Delete an archived course
       - [gog classroom courses get](gog-classroom-courses-get.md) - Get a course
       - [gog classroom courses join](gog-classroom-courses-join.md) - Join a course
       - [gog classroom courses leave](gog-classroom-courses-leave.md) - Leave a course
       - [gog classroom courses list](gog-classroom-courses-list.md) - List courses
-      - [gog classroom courses unarchive](gog-classroom-courses-unarchive.md) - Unarchive a course
+      - [gog classroom courses unarchive](gog-classroom-courses-unarchive.md) - Unarchive a course and wait until the state is visible
       - [gog classroom courses update](gog-classroom-courses-update.md) - Update a course
       - [gog classroom courses url](gog-classroom-courses-url.md) - Print Classroom web URLs for courses
     - [gog classroom coursework](gog-classroom-coursework.md) - Coursework

--- a/docs/commands/gog-classroom-courses-archive.md
+++ b/docs/commands/gog-classroom-courses-archive.md
@@ -2,7 +2,7 @@
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Archive a course
+Archive a course and wait until the state is visible
 
 ## Usage
 

--- a/docs/commands/gog-classroom-courses-unarchive.md
+++ b/docs/commands/gog-classroom-courses-unarchive.md
@@ -2,7 +2,7 @@
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Unarchive a course
+Unarchive a course and wait until the state is visible
 
 ## Usage
 

--- a/docs/commands/gog-classroom-courses.md
+++ b/docs/commands/gog-classroom-courses.md
@@ -16,14 +16,14 @@ gog classroom (class) courses (course) <command>
 
 ## Subcommands
 
-- [gog classroom courses archive](gog-classroom-courses-archive.md) - Archive a course
+- [gog classroom courses archive](gog-classroom-courses-archive.md) - Archive a course and wait until the state is visible
 - [gog classroom courses create](gog-classroom-courses-create.md) - Create a course
 - [gog classroom courses delete](gog-classroom-courses-delete.md) - Delete an archived course
 - [gog classroom courses get](gog-classroom-courses-get.md) - Get a course
 - [gog classroom courses join](gog-classroom-courses-join.md) - Join a course
 - [gog classroom courses leave](gog-classroom-courses-leave.md) - Leave a course
 - [gog classroom courses list](gog-classroom-courses-list.md) - List courses
-- [gog classroom courses unarchive](gog-classroom-courses-unarchive.md) - Unarchive a course
+- [gog classroom courses unarchive](gog-classroom-courses-unarchive.md) - Unarchive a course and wait until the state is visible
 - [gog classroom courses update](gog-classroom-courses-update.md) - Update a course
 - [gog classroom courses url](gog-classroom-courses-url.md) - Print Classroom web URLs for courses
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -305,6 +305,11 @@ Drive hierarchy semantics:
 - `gog classroom courses join <courseId> [--role student|teacher] [--user me]`
 - `gog classroom courses leave <courseId> [--role student|teacher] [--user me]`
 - `gog classroom courses url <courseId...>`
+
+Course state mutations wait for the requested state to become visible through
+the Classroom API before returning success. If Google still serves stale state
+after the bounded retry window, the command exits with retryable code `8`.
+
 - `gog classroom students <courseId> [--max N] [--page TOKEN]`
 - `gog classroom students get <courseId> <userId>`
 - `gog classroom students add <courseId> <userId> [--enrollment-code CODE]`

--- a/internal/cmd/classroom_courses.go
+++ b/internal/cmd/classroom_courses.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"google.golang.org/api/classroom/v1"
 
@@ -24,8 +25,8 @@ type ClassroomCoursesCmd struct {
 	Create    ClassroomCoursesCreateCmd    `cmd:"" aliases:"add,new" help:"Create a course"`
 	Update    ClassroomCoursesUpdateCmd    `cmd:"" aliases:"edit,set" help:"Update a course"`
 	Delete    ClassroomCoursesDeleteCmd    `cmd:"" aliases:"rm,del,remove" help:"Delete an archived course"`
-	Archive   ClassroomCoursesArchiveCmd   `cmd:"" aliases:"arch" help:"Archive a course"`
-	Unarchive ClassroomCoursesUnarchiveCmd `cmd:"" aliases:"unarch,restore" help:"Unarchive a course"`
+	Archive   ClassroomCoursesArchiveCmd   `cmd:"" aliases:"arch" help:"Archive a course and wait until the state is visible"`
+	Unarchive ClassroomCoursesUnarchiveCmd `cmd:"" aliases:"unarch,restore" help:"Unarchive a course and wait until the state is visible"`
 	Join      ClassroomCoursesJoinCmd      `cmd:"" aliases:"enroll" help:"Join a course"`
 	Leave     ClassroomCoursesLeaveCmd     `cmd:"" aliases:"unenroll" help:"Leave a course"`
 	URL       ClassroomCoursesURLCmd       `cmd:"" name:"url" aliases:"link" help:"Print Classroom web URLs for courses"`
@@ -280,6 +281,12 @@ func (c *ClassroomCoursesUpdateCmd) Run(ctx context.Context, flags *RootFlags) e
 	if err != nil {
 		return wrapClassroomError(err)
 	}
+	if plan.Course.CourseState != "" {
+		updated, err = waitForClassroomCourseState(ctx, svc, plan.CourseID, plan.Course.CourseState)
+		if err != nil {
+			return err
+		}
+	}
 
 	if outfmt.IsJSON(ctx) {
 		return outfmt.WriteJSON(ctx, stdoutWriter(ctx), map[string]any{"course": updated})
@@ -409,9 +416,12 @@ func updateCourseState(ctx context.Context, flags *RootFlags, courseID, state st
 		return wrapClassroomError(err)
 	}
 
-	updated, err := svc.Courses.Patch(courseID, course).UpdateMask("courseState").Context(ctx).Do()
-	if err != nil {
+	if _, err = svc.Courses.Patch(courseID, course).UpdateMask("courseState").Context(ctx).Do(); err != nil {
 		return wrapClassroomError(err)
+	}
+	updated, err := waitForClassroomCourseState(ctx, svc, courseID, state)
+	if err != nil {
+		return err
 	}
 
 	if outfmt.IsJSON(ctx) {
@@ -420,6 +430,82 @@ func updateCourseState(ctx context.Context, flags *RootFlags, courseID, state st
 	u.Out().Linef("id\t%s", updated.Id)
 	u.Out().Linef("state\t%s", updated.CourseState)
 	return nil
+}
+
+func waitForClassroomCourseState(
+	ctx context.Context,
+	svc *classroom.Service,
+	courseID string,
+	wantState string,
+) (*classroom.Course, error) {
+	return pollClassroomCourseState(
+		ctx,
+		courseID,
+		wantState,
+		defaultClassroomCourseStateVisibilityDelays(),
+		waitForPollInterval,
+		func(ctx context.Context) (*classroom.Course, error) {
+			return svc.Courses.Get(courseID).Context(ctx).Do()
+		},
+	)
+}
+
+func defaultClassroomCourseStateVisibilityDelays() []time.Duration {
+	return []time.Duration{
+		0,
+		200 * time.Millisecond,
+		500 * time.Millisecond,
+		time.Second,
+		2 * time.Second,
+		3 * time.Second,
+		4 * time.Second,
+		5 * time.Second,
+	}
+}
+
+func pollClassroomCourseState(
+	ctx context.Context,
+	courseID string,
+	wantState string,
+	delays []time.Duration,
+	wait func(context.Context, time.Duration) error,
+	fetch func(context.Context) (*classroom.Course, error),
+) (*classroom.Course, error) {
+	var lastState string
+	for _, delay := range delays {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if delay > 0 {
+			if err := wait(ctx, delay); err != nil {
+				return nil, err
+			}
+		}
+
+		course, err := fetch(ctx)
+		if err != nil {
+			return nil, wrapClassroomError(err)
+		}
+		if course != nil {
+			lastState = course.CourseState
+			if lastState == wantState {
+				return course, nil
+			}
+		}
+	}
+
+	if lastState == "" {
+		lastState = "(not returned)"
+	}
+	return nil, &ExitError{
+		Code: exitCodeRetryable,
+		Err: fmt.Errorf(
+			"course %s update was accepted, but reads still show state %s instead of %s; retry shortly",
+			courseID,
+			lastState,
+			wantState,
+		),
+	}
 }
 
 type ClassroomCoursesJoinCmd struct {

--- a/internal/cmd/classroom_courses_state_visibility_test.go
+++ b/internal/cmd/classroom_courses_state_visibility_test.go
@@ -1,0 +1,155 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"google.golang.org/api/classroom/v1"
+)
+
+func TestPollClassroomCourseStateEventuallyVisible(t *testing.T) {
+	states := []string{classroomCourseStateActive, classroomCourseStateActive, classroomCourseStateArchived}
+	fetchCalls := 0
+	waitCalls := 0
+
+	course, err := pollClassroomCourseState(
+		context.Background(),
+		"c1",
+		classroomCourseStateArchived,
+		[]time.Duration{0, time.Millisecond, time.Millisecond},
+		func(context.Context, time.Duration) error {
+			waitCalls++
+			return nil
+		},
+		func(context.Context) (*classroom.Course, error) {
+			state := states[fetchCalls]
+			fetchCalls++
+			return &classroom.Course{Id: "c1", CourseState: state}, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("poll state: %v", err)
+	}
+	if course.CourseState != classroomCourseStateArchived {
+		t.Fatalf("state = %q, want %q", course.CourseState, classroomCourseStateArchived)
+	}
+	if fetchCalls != 3 || waitCalls != 2 {
+		t.Fatalf("fetch calls = %d, wait calls = %d; want 3 and 2", fetchCalls, waitCalls)
+	}
+}
+
+func TestPollClassroomCourseStateExhaustedIsRetryable(t *testing.T) {
+	_, err := pollClassroomCourseState(
+		context.Background(),
+		"c1",
+		classroomCourseStateArchived,
+		[]time.Duration{0, time.Millisecond},
+		func(context.Context, time.Duration) error { return nil },
+		func(context.Context) (*classroom.Course, error) {
+			return &classroom.Course{Id: "c1", CourseState: classroomCourseStateActive}, nil
+		},
+	)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if ExitCode(err) != exitCodeRetryable {
+		t.Fatalf("exit code = %d, want %d: %v", ExitCode(err), exitCodeRetryable, err)
+	}
+	if !strings.Contains(err.Error(), "reads still show state ACTIVE instead of ARCHIVED") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestPollClassroomCourseStateCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	fetchCalled := false
+
+	_, err := pollClassroomCourseState(
+		ctx,
+		"c1",
+		classroomCourseStateArchived,
+		[]time.Duration{0},
+		func(context.Context, time.Duration) error { return nil },
+		func(context.Context) (*classroom.Course, error) {
+			fetchCalled = true
+			return &classroom.Course{}, nil
+		},
+	)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context canceled", err)
+	}
+	if fetchCalled {
+		t.Fatal("fetch called after cancellation")
+	}
+}
+
+func TestPollClassroomCourseStateFetchError(t *testing.T) {
+	apiErr := errors.New("get course failed")
+	_, err := pollClassroomCourseState(
+		context.Background(),
+		"c1",
+		classroomCourseStateArchived,
+		[]time.Duration{0},
+		func(context.Context, time.Duration) error { return nil },
+		func(context.Context) (*classroom.Course, error) {
+			return nil, apiErr
+		},
+	)
+	if !errors.Is(err, apiErr) {
+		t.Fatalf("error = %v, want wrapped fetch error", err)
+	}
+}
+
+func TestClassroomCoursesArchiveReturnsVisibleCourse(t *testing.T) {
+	patchCalls := 0
+	getCalls := 0
+	svc, closeService := newClassroomTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodPatch:
+			patchCalls++
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":          "c1",
+				"courseState": classroomCourseStateArchived,
+			})
+		case http.MethodGet:
+			getCalls++
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":          "c1",
+				"name":        "Visible Course",
+				"courseState": classroomCourseStateArchived,
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer closeService()
+
+	result := executeWithClassroomTestService(t, []string{
+		"--json",
+		"--account", "a@b.com",
+		"classroom", "courses", "archive", "c1",
+	}, svc)
+	if result.err != nil {
+		t.Fatalf("archive course: %v", result.err)
+	}
+	if patchCalls != 1 || getCalls != 1 {
+		t.Fatalf("patch calls = %d, get calls = %d; want 1 and 1", patchCalls, getCalls)
+	}
+
+	var payload struct {
+		Course classroom.Course `json:"course"`
+	}
+	if err := json.Unmarshal([]byte(result.stdout), &payload); err != nil {
+		t.Fatalf("decode output: %v", err)
+	}
+	if payload.Course.Name != "Visible Course" || payload.Course.CourseState != classroomCourseStateArchived {
+		t.Fatalf("unexpected visible course: %#v", payload.Course)
+	}
+}

--- a/internal/cmd/execute_classroom_more_commands_test.go
+++ b/internal/cmd/execute_classroom_more_commands_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestExecute_ClassroomMoreCommands_JSON(t *testing.T) {
+	courseState := "ACTIVE"
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		writeJSON := func(data any) {
 			w.Header().Set("Content-Type", "application/json")
@@ -382,7 +383,7 @@ func TestExecute_ClassroomMoreCommands_JSON(t *testing.T) {
 		case strings.Contains(path, "/courses/"):
 			switch r.Method {
 			case http.MethodGet:
-				state := "ACTIVE"
+				state := courseState
 				if strings.HasSuffix(path, "/c-delete") {
 					state = "ARCHIVED"
 				}
@@ -393,7 +394,14 @@ func TestExecute_ClassroomMoreCommands_JSON(t *testing.T) {
 				if mask != "name,courseState" && mask != "courseState" {
 					t.Fatalf("unexpected updateMask %q", mask)
 				}
-				writeJSON(map[string]any{"id": "c1", "name": "Updated Course", "courseState": "ARCHIVED"})
+				var body classroom.Course
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					t.Fatalf("decode course patch: %v", err)
+				}
+				if body.CourseState != "" {
+					courseState = body.CourseState
+				}
+				writeJSON(map[string]any{"id": "c1", "name": "Updated Course", "courseState": courseState})
 				return
 			case http.MethodDelete:
 				w.WriteHeader(http.StatusNoContent)

--- a/internal/secrets/backend.go
+++ b/internal/secrets/backend.go
@@ -53,6 +53,7 @@ const (
 	keyringBackendSourceConfig  = "config"
 	keyringBackendSourceDefault = "default"
 	keyringBackendAuto          = "auto"
+	keyringBackendKeychain      = "keychain"
 )
 
 func systemOpenOptions(layout config.Layout, store *config.ConfigStore) OpenOptions {
@@ -136,7 +137,7 @@ func allowedBackends(info KeyringBackendInfo) ([]keyring.BackendType, error) {
 	switch info.Value {
 	case "", keyringBackendAuto:
 		return nil, nil
-	case "keychain":
+	case keyringBackendKeychain:
 		return []keyring.BackendType{keyring.KeychainBackend}, nil
 	case "file":
 		return []keyring.BackendType{keyring.FileBackend}, nil
@@ -217,7 +218,7 @@ func shouldUseKeyringTimeout(goos string, backendInfo KeyringBackendInfo, dbusAd
 
 func shouldUseKeyringOperationTimeout(goos string, backendInfo KeyringBackendInfo, dbusAddr string) bool {
 	if goos == goosDarwin {
-		return backendInfo.Value == keyringBackendAuto || backendInfo.Value == "keychain"
+		return backendInfo.Value == keyringBackendAuto || backendInfo.Value == keyringBackendKeychain
 	}
 
 	return goos == goosLinux && backendInfo.Value == keyringBackendAuto && dbusAddr != ""


### PR DESCRIPTION
## Summary

- wait for Classroom course state mutations to become visible through `Courses.Get`
- apply the visibility check to archive, unarchive, and `courses update --state`
- return retryable exit code 8 when Google keeps serving stale state after bounded backoff
- document the behavior and generated command help
- name the existing keychain backend constant so current `main` passes the lint gate

## Proof

- `make ci`
- structured autoreview: no accepted/actionable findings
- unit coverage: delayed visibility, retry exhaustion, cancellation, fetch failure, final JSON readback
- live E2E with `clawdbot@gmail.com`:
  - created disposable course `867845827167`
  - accepted the PROVISIONED teaching invitation in the real Classroom browser session
  - confirmed ACTIVE
  - archived and received visible ARCHIVED readback
  - immediately deleted successfully
  - confirmed post-delete `courses get` exits 5
