### PR TITLE
feat(calendar): add lifecycle cleanup commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - YouTube: add subscription listing and management plus playlist create, add, remove, and delete commands with least-privilege OAuth, dry-run support, structured output, and destructive-operation confirmation. (#767) — thanks @beezly.
+- Calendar: add `unsubscribe` for removing calendar-list entries and `delete-calendar` for deleting owned secondary calendars, with dry-run, confirmation, and structured output.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -183,6 +183,8 @@ Docs: [`gog calendar`](docs/commands/gog-calendar.md),
 [`calendar create`](docs/commands/gog-calendar-create.md),
 [`calendar update`](docs/commands/gog-calendar-update.md),
 [`calendar move`](docs/commands/gog-calendar-move.md),
+[`calendar delete-calendar`](docs/commands/gog-calendar-delete-calendar.md),
+[`calendar unsubscribe`](docs/commands/gog-calendar-unsubscribe.md),
 [Zoom setup](docs/zoom-auth-setup.md).
 
 ```bash
@@ -205,6 +207,10 @@ gog calendar create primary --summary "Client sync" \
   --to "2026-05-06T11:30:00+02:00" \
   --with-zoom
 gog calendar move primary <eventId> team-calendar@example.com
+gog calendar create-calendar "Project calendar" --timezone Europe/London
+gog calendar delete-calendar <calendarId> --force
+gog calendar subscribe en.uk#holiday@group.v.calendar.google.com
+gog calendar unsubscribe en.uk#holiday@group.v.calendar.google.com --force
 gog calendar appointments
 ```
 

--- a/docs/commands.generated.md
+++ b/docs/commands.generated.md
@@ -87,6 +87,7 @@ Generated from `gog schema --json`.
     - [`gog calendar (cal) create (add,new) <calendarId> [flags]`](commands/gog-calendar-create.md) - Create an event
     - [`gog calendar (cal) create-calendar (new-calendar) <summary> [flags]`](commands/gog-calendar-create-calendar.md) - Create a new secondary calendar
     - [`gog calendar (cal) delete (rm,del,remove) <calendarId> <eventId> [flags]`](commands/gog-calendar-delete.md) - Delete an event
+    - [`gog calendar (cal) delete-calendar <calendarId>`](commands/gog-calendar-delete-calendar.md) - Delete an owned secondary calendar
     - [`gog calendar (cal) event (get,info,show) <calendarId> <eventId>`](commands/gog-calendar-event.md) - Get event
     - [`gog calendar (cal) events (list,ls) [<calendarId> ...] [flags]`](commands/gog-calendar-events.md) - List events from a calendar or all calendars
     - [`gog calendar (cal) focus-time (focus) --from=STRING --to=STRING [<calendarId>] [flags]`](commands/gog-calendar-focus-time.md) - Create a Focus Time block
@@ -100,6 +101,7 @@ Generated from `gog schema --json`.
     - [`gog calendar (cal) subscribe (sub,add-calendar) <calendarId> [flags]`](commands/gog-calendar-subscribe.md) - Add a calendar to your calendar list
     - [`gog calendar (cal) team <group-email> [flags]`](commands/gog-calendar-team.md) - Show events for Workspace group members (service account, direct token, or ADC)
     - [`gog calendar (cal) time [flags]`](commands/gog-calendar-time.md) - Show server time
+    - [`gog calendar (cal) unsubscribe (unsub) <calendarId>`](commands/gog-calendar-unsubscribe.md) - Remove a calendar from your calendar list
     - [`gog calendar (cal) update (edit,set) <calendarId> <eventId> [flags]`](commands/gog-calendar-update.md) - Update an event
     - [`gog calendar (cal) users [flags]`](commands/gog-calendar-users.md) - List workspace users (use their email as calendar ID)
     - [`gog calendar (cal) working-location (wl) --from=STRING --to=STRING --type=STRING [<calendarId>] [flags]`](commands/gog-calendar-working-location.md) - Set working location (home/office/custom)

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -2,7 +2,7 @@
 
 Every `gog` command has a generated docs page. The source of truth is the live CLI schema; run `make docs-commands` after changing command names, flags, help text, aliases, or arguments.
 
-Generated pages: 642.
+Generated pages: 644.
 
 ## Top-level Commands
 
@@ -138,6 +138,7 @@ Generated pages: 642.
     - [gog calendar create](gog-calendar-create.md) - Create an event
     - [gog calendar create-calendar](gog-calendar-create-calendar.md) - Create a new secondary calendar
     - [gog calendar delete](gog-calendar-delete.md) - Delete an event
+    - [gog calendar delete-calendar](gog-calendar-delete-calendar.md) - Delete an owned secondary calendar
     - [gog calendar event](gog-calendar-event.md) - Get event
     - [gog calendar events](gog-calendar-events.md) - List events from a calendar or all calendars
     - [gog calendar focus-time](gog-calendar-focus-time.md) - Create a Focus Time block
@@ -151,6 +152,7 @@ Generated pages: 642.
     - [gog calendar subscribe](gog-calendar-subscribe.md) - Add a calendar to your calendar list
     - [gog calendar team](gog-calendar-team.md) - Show events for Workspace group members (service account, direct token, or ADC)
     - [gog calendar time](gog-calendar-time.md) - Show server time
+    - [gog calendar unsubscribe](gog-calendar-unsubscribe.md) - Remove a calendar from your calendar list
     - [gog calendar update](gog-calendar-update.md) - Update an event
     - [gog calendar users](gog-calendar-users.md) - List workspace users (use their email as calendar ID)
     - [gog calendar working-location](gog-calendar-working-location.md) - Set working location (home/office/custom)

--- a/docs/commands/gog-calendar-delete-calendar.md
+++ b/docs/commands/gog-calendar-delete-calendar.md
@@ -1,48 +1,18 @@
-# `gog calendar`
+# `gog calendar delete-calendar`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Google Calendar
+Delete an owned secondary calendar
 
 ## Usage
 
 ```bash
-gog calendar (cal) <command> [flags]
+gog calendar (cal) delete-calendar <calendarId>
 ```
 
 ## Parent
 
-- [gog](gog.md)
-
-## Subcommands
-
-- [gog calendar acl](gog-calendar-acl.md) - List calendar ACL
-- [gog calendar alias](gog-calendar-alias.md) - Manage calendar aliases
-- [gog calendar appointments](gog-calendar-appointments.md) - Report Calendar appointment schedule API limitation
-- [gog calendar calendars](gog-calendar-calendars.md) - List calendars
-- [gog calendar colors](gog-calendar-colors.md) - Show calendar colors
-- [gog calendar conflicts](gog-calendar-conflicts.md) - Find busy-time overlaps across calendars
-- [gog calendar create](gog-calendar-create.md) - Create an event
-- [gog calendar create-calendar](gog-calendar-create-calendar.md) - Create a new secondary calendar
-- [gog calendar delete](gog-calendar-delete.md) - Delete an event
-- [gog calendar delete-calendar](gog-calendar-delete-calendar.md) - Delete an owned secondary calendar
-- [gog calendar event](gog-calendar-event.md) - Get event
-- [gog calendar events](gog-calendar-events.md) - List events from a calendar or all calendars
-- [gog calendar focus-time](gog-calendar-focus-time.md) - Create a Focus Time block
-- [gog calendar freebusy](gog-calendar-freebusy.md) - Get free/busy
-- [gog calendar move](gog-calendar-move.md) - Move an event to another calendar
-- [gog calendar out-of-office](gog-calendar-out-of-office.md) - Create an Out of Office event
-- [gog calendar propose-time](gog-calendar-propose-time.md) - Generate URL to propose a new meeting time (browser-only feature)
-- [gog calendar raw](gog-calendar-raw.md) - Dump raw Google Calendar API response as JSON (Events.Get; lossless; for scripting and LLM consumption)
-- [gog calendar respond](gog-calendar-respond.md) - Respond to an event invitation
-- [gog calendar search](gog-calendar-search.md) - Search events
-- [gog calendar subscribe](gog-calendar-subscribe.md) - Add a calendar to your calendar list
-- [gog calendar team](gog-calendar-team.md) - Show events for Workspace group members (service account, direct token, or ADC)
-- [gog calendar time](gog-calendar-time.md) - Show server time
-- [gog calendar unsubscribe](gog-calendar-unsubscribe.md) - Remove a calendar from your calendar list
-- [gog calendar update](gog-calendar-update.md) - Update an event
-- [gog calendar users](gog-calendar-users.md) - List workspace users (use their email as calendar ID)
-- [gog calendar working-location](gog-calendar-working-location.md) - Set working location (home/office/custom)
+- [gog calendar](gog-calendar.md)
 
 ## Flags
 
@@ -71,5 +41,5 @@ gog calendar (cal) <command> [flags]
 
 ## See Also
 
-- [gog](gog.md)
+- [gog calendar](gog-calendar.md)
 - [Command index](README.md)

--- a/docs/commands/gog-calendar-unsubscribe.md
+++ b/docs/commands/gog-calendar-unsubscribe.md
@@ -1,48 +1,18 @@
-# `gog calendar`
+# `gog calendar unsubscribe`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Google Calendar
+Remove a calendar from your calendar list
 
 ## Usage
 
 ```bash
-gog calendar (cal) <command> [flags]
+gog calendar (cal) unsubscribe (unsub) <calendarId>
 ```
 
 ## Parent
 
-- [gog](gog.md)
-
-## Subcommands
-
-- [gog calendar acl](gog-calendar-acl.md) - List calendar ACL
-- [gog calendar alias](gog-calendar-alias.md) - Manage calendar aliases
-- [gog calendar appointments](gog-calendar-appointments.md) - Report Calendar appointment schedule API limitation
-- [gog calendar calendars](gog-calendar-calendars.md) - List calendars
-- [gog calendar colors](gog-calendar-colors.md) - Show calendar colors
-- [gog calendar conflicts](gog-calendar-conflicts.md) - Find busy-time overlaps across calendars
-- [gog calendar create](gog-calendar-create.md) - Create an event
-- [gog calendar create-calendar](gog-calendar-create-calendar.md) - Create a new secondary calendar
-- [gog calendar delete](gog-calendar-delete.md) - Delete an event
-- [gog calendar delete-calendar](gog-calendar-delete-calendar.md) - Delete an owned secondary calendar
-- [gog calendar event](gog-calendar-event.md) - Get event
-- [gog calendar events](gog-calendar-events.md) - List events from a calendar or all calendars
-- [gog calendar focus-time](gog-calendar-focus-time.md) - Create a Focus Time block
-- [gog calendar freebusy](gog-calendar-freebusy.md) - Get free/busy
-- [gog calendar move](gog-calendar-move.md) - Move an event to another calendar
-- [gog calendar out-of-office](gog-calendar-out-of-office.md) - Create an Out of Office event
-- [gog calendar propose-time](gog-calendar-propose-time.md) - Generate URL to propose a new meeting time (browser-only feature)
-- [gog calendar raw](gog-calendar-raw.md) - Dump raw Google Calendar API response as JSON (Events.Get; lossless; for scripting and LLM consumption)
-- [gog calendar respond](gog-calendar-respond.md) - Respond to an event invitation
-- [gog calendar search](gog-calendar-search.md) - Search events
-- [gog calendar subscribe](gog-calendar-subscribe.md) - Add a calendar to your calendar list
-- [gog calendar team](gog-calendar-team.md) - Show events for Workspace group members (service account, direct token, or ADC)
-- [gog calendar time](gog-calendar-time.md) - Show server time
-- [gog calendar unsubscribe](gog-calendar-unsubscribe.md) - Remove a calendar from your calendar list
-- [gog calendar update](gog-calendar-update.md) - Update an event
-- [gog calendar users](gog-calendar-users.md) - List workspace users (use their email as calendar ID)
-- [gog calendar working-location](gog-calendar-working-location.md) - Set working location (home/office/custom)
+- [gog calendar](gog-calendar.md)
 
 ## Flags
 
@@ -71,5 +41,5 @@ gog calendar (cal) <command> [flags]
 
 ## See Also
 
-- [gog](gog.md)
+- [gog calendar](gog-calendar.md)
 - [Command index](README.md)

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -266,7 +266,10 @@ Drive hierarchy semantics:
 
 - `gog slides thumbnail <presentationId> <slideId> [--size small|medium|large] [--format png|jpeg] [--out PATH]`
 - `gog calendar calendars`
+- `gog calendar subscribe <calendarId>`
+- `gog calendar unsubscribe <calendarId>`
 - `gog calendar create-calendar <summary> [--description D] [--timezone TZ] [--location L]`
+- `gog calendar delete-calendar <ownedSecondaryCalendarId>`
 - `gog calendar acl <calendarId>`
 - `gog calendar events <calendarId> [--cal ID_OR_NAME] [--calendars CSV] [--all] [--from RFC3339] [--to RFC3339] [--max N] [--page TOKEN] [--query Q] [--weekday]`
 - `gog calendar appointments` (reports that Google Calendar appointment schedules are not currently exposed by the Calendar API)
@@ -278,6 +281,12 @@ Drive hierarchy semantics:
 - `gog calendar freebusy [calendarIds] [--cal ID_OR_NAME] [--calendars CSV] [--all] --from RFC3339 --to RFC3339`
 - `gog calendar conflicts [--cal ID_OR_NAME] [--calendars CSV] [--all] [--from RFC3339|date|relative] [--to RFC3339|date|relative] [--today|--week|--days N]`
 - `gog calendar respond <calendarId> <eventId> --status accepted|declined|tentative [--send-updates all|none|externalOnly]`
+
+`calendar unsubscribe` removes only the selected entry from the caller's
+calendar list. `calendar delete-calendar` permanently deletes an owned
+secondary calendar; Google may briefly retain a stale calendar-list row after
+the authoritative calendar resource is gone.
+
 - `gog maps places search <query> [--language LANG] [--region REGION] [--fields FIELD_MASK] [--max N]`
 - `gog maps places details <placeId> [--language LANG] [--region REGION] [--fields FIELD_MASK]`
 - `gog maps directions --origin ORIGIN --destination DESTINATION [--mode driving|walking|bicycling|transit] [--language LANG] [--region REGION]`

--- a/internal/cmd/calendar.go
+++ b/internal/cmd/calendar.go
@@ -3,7 +3,9 @@ package cmd
 type CalendarCmd struct {
 	Calendars       CalendarCalendarsCmd       `cmd:"" name:"calendars" help:"List calendars"`
 	Subscribe       CalendarSubscribeCmd       `cmd:"" name:"subscribe" aliases:"sub,add-calendar" help:"Add a calendar to your calendar list"`
+	Unsubscribe     CalendarUnsubscribeCmd     `cmd:"" name:"unsubscribe" aliases:"unsub" help:"Remove a calendar from your calendar list"`
 	CreateCalendar  CalendarCreateCalendarCmd  `cmd:"" name:"create-calendar" aliases:"new-calendar" help:"Create a new secondary calendar"`
+	DeleteCalendar  CalendarDeleteCalendarCmd  `cmd:"" name:"delete-calendar" help:"Delete an owned secondary calendar"`
 	ACL             CalendarAclCmd             `cmd:"" name:"acl" aliases:"permissions,perms" help:"List calendar ACL"`
 	Alias           CalendarAliasCmd           `cmd:"" name:"alias" help:"Manage calendar aliases"`
 	Events          CalendarEventsCmd          `cmd:"" name:"events" aliases:"list,ls" help:"List events from a calendar or all calendars"`

--- a/internal/cmd/calendar_lifecycle.go
+++ b/internal/cmd/calendar_lifecycle.go
@@ -19,10 +19,19 @@ func (c *CalendarUnsubscribeCmd) Run(ctx context.Context, flags *RootFlags) erro
 		return usage("calendarId required")
 	}
 
-	if err := dryRunAndConfirmDestructive(ctx, flags, "calendar.unsubscribe", map[string]any{
-		"calendar_id": calendarID,
-	}, fmt.Sprintf("unsubscribe from calendar %s", calendarID)); err != nil {
+	store, err := commandConfigStore(ctx)
+	if err != nil {
 		return err
+	}
+	preparedID, err := prepareCalendarID(store, calendarID, false)
+	if err != nil {
+		return err
+	}
+
+	if confirmErr := dryRunAndConfirmDestructive(ctx, flags, "calendar.unsubscribe", map[string]any{
+		"calendar_id": preparedID,
+	}, fmt.Sprintf("unsubscribe from calendar %s", preparedID)); confirmErr != nil {
+		return confirmErr
 	}
 
 	account, err := requireAccount(flags)
@@ -33,11 +42,7 @@ func (c *CalendarUnsubscribeCmd) Run(ctx context.Context, flags *RootFlags) erro
 	if err != nil {
 		return err
 	}
-	store, err := commandConfigStore(ctx)
-	if err != nil {
-		return err
-	}
-	resolvedID, err := resolveCalendarSelector(ctx, store, svc, calendarID, false)
+	resolvedID, err := resolveCalendarID(ctx, svc, preparedID)
 	if err != nil {
 		return err
 	}
@@ -63,10 +68,19 @@ func (c *CalendarDeleteCalendarCmd) Run(ctx context.Context, flags *RootFlags) e
 		return usage("calendarId required")
 	}
 
-	if err := dryRunAndConfirmDestructive(ctx, flags, "calendar.delete-calendar", map[string]any{
-		"calendar_id": calendarID,
-	}, fmt.Sprintf("permanently delete secondary calendar %s", calendarID)); err != nil {
+	store, err := commandConfigStore(ctx)
+	if err != nil {
 		return err
+	}
+	preparedID, err := prepareCalendarID(store, calendarID, false)
+	if err != nil {
+		return err
+	}
+
+	if confirmErr := dryRunAndConfirmDestructive(ctx, flags, "calendar.delete-calendar", map[string]any{
+		"calendar_id": preparedID,
+	}, fmt.Sprintf("permanently delete secondary calendar %s", preparedID)); confirmErr != nil {
+		return confirmErr
 	}
 
 	account, err := requireAccount(flags)
@@ -77,11 +91,7 @@ func (c *CalendarDeleteCalendarCmd) Run(ctx context.Context, flags *RootFlags) e
 	if err != nil {
 		return err
 	}
-	store, err := commandConfigStore(ctx)
-	if err != nil {
-		return err
-	}
-	resolvedID, err := resolveCalendarSelector(ctx, store, svc, calendarID, false)
+	resolvedID, err := resolveCalendarID(ctx, svc, preparedID)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/calendar_lifecycle.go
+++ b/internal/cmd/calendar_lifecycle.go
@@ -1,0 +1,97 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+type CalendarUnsubscribeCmd struct {
+	CalendarID string `arg:"" name:"calendarId" help:"Calendar ID or alias to remove from your calendar list"`
+}
+
+func (c *CalendarUnsubscribeCmd) Run(ctx context.Context, flags *RootFlags) error {
+	u := ui.FromContext(ctx)
+	calendarID := strings.TrimSpace(c.CalendarID)
+	if calendarID == "" {
+		return usage("calendarId required")
+	}
+
+	if err := dryRunAndConfirmDestructive(ctx, flags, "calendar.unsubscribe", map[string]any{
+		"calendar_id": calendarID,
+	}, fmt.Sprintf("unsubscribe from calendar %s", calendarID)); err != nil {
+		return err
+	}
+
+	account, err := requireAccount(flags)
+	if err != nil {
+		return err
+	}
+	svc, err := calendarService(ctx, account)
+	if err != nil {
+		return err
+	}
+	store, err := commandConfigStore(ctx)
+	if err != nil {
+		return err
+	}
+	resolvedID, err := resolveCalendarSelector(ctx, store, svc, calendarID, false)
+	if err != nil {
+		return err
+	}
+
+	if err := svc.CalendarList.Delete(resolvedID).Context(ctx).Do(); err != nil {
+		return fmt.Errorf("unsubscribe from calendar %s: %w", resolvedID, err)
+	}
+
+	return writeResult(ctx, u,
+		kv("unsubscribed", true),
+		kv("calendarId", resolvedID),
+	)
+}
+
+type CalendarDeleteCalendarCmd struct {
+	CalendarID string `arg:"" name:"calendarId" help:"Owned secondary calendar ID or alias"`
+}
+
+func (c *CalendarDeleteCalendarCmd) Run(ctx context.Context, flags *RootFlags) error {
+	u := ui.FromContext(ctx)
+	calendarID := strings.TrimSpace(c.CalendarID)
+	if calendarID == "" {
+		return usage("calendarId required")
+	}
+
+	if err := dryRunAndConfirmDestructive(ctx, flags, "calendar.delete-calendar", map[string]any{
+		"calendar_id": calendarID,
+	}, fmt.Sprintf("permanently delete secondary calendar %s", calendarID)); err != nil {
+		return err
+	}
+
+	account, err := requireAccount(flags)
+	if err != nil {
+		return err
+	}
+	svc, err := calendarService(ctx, account)
+	if err != nil {
+		return err
+	}
+	store, err := commandConfigStore(ctx)
+	if err != nil {
+		return err
+	}
+	resolvedID, err := resolveCalendarSelector(ctx, store, svc, calendarID, false)
+	if err != nil {
+		return err
+	}
+
+	if err := svc.Calendars.Delete(resolvedID).Context(ctx).Do(); err != nil {
+		return fmt.Errorf("delete secondary calendar %s: %w", resolvedID, err)
+	}
+
+	return writeResult(ctx, u,
+		kv("deleted", true),
+		kv("calendarId", resolvedID),
+	)
+}

--- a/internal/cmd/calendar_lifecycle_test.go
+++ b/internal/cmd/calendar_lifecycle_test.go
@@ -1,0 +1,187 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/calendar/v3"
+)
+
+func TestExecuteCalendarUnsubscribeJSON(t *testing.T) {
+	deleteCalls := 0
+	svc, closeSvc := newCalendarServiceForTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete || !strings.Contains(r.URL.Path, "/users/me/calendarList/team@example.com") {
+			http.NotFound(w, r)
+			return
+		}
+		deleteCalls++
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer closeSvc()
+
+	result := executeWithCalendarTestService(t, []string{
+		"--json",
+		"--force",
+		"--account", "a@b.com",
+		"calendar", "unsubscribe", "team@example.com",
+	}, svc)
+	if result.err != nil {
+		t.Fatalf("unsubscribe: %v", result.err)
+	}
+	if deleteCalls != 1 {
+		t.Fatalf("delete calls = %d, want 1", deleteCalls)
+	}
+
+	var payload struct {
+		Unsubscribed bool   `json:"unsubscribed"`
+		CalendarID   string `json:"calendarId"`
+	}
+	if err := json.Unmarshal([]byte(result.stdout), &payload); err != nil {
+		t.Fatalf("decode output: %v", err)
+	}
+	if !payload.Unsubscribed || payload.CalendarID != "team@example.com" {
+		t.Fatalf("unexpected output: %#v", payload)
+	}
+}
+
+func TestExecuteCalendarDeleteCalendarJSON(t *testing.T) {
+	deleteCalls := 0
+	svc, closeSvc := newCalendarServiceForTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete || !strings.Contains(r.URL.Path, "/calendars/owned@example.com") {
+			http.NotFound(w, r)
+			return
+		}
+		deleteCalls++
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer closeSvc()
+
+	result := executeWithCalendarTestService(t, []string{
+		"--json",
+		"--force",
+		"--account", "a@b.com",
+		"calendar", "delete-calendar", "owned@example.com",
+	}, svc)
+	if result.err != nil {
+		t.Fatalf("delete calendar: %v", result.err)
+	}
+	if deleteCalls != 1 {
+		t.Fatalf("delete calls = %d, want 1", deleteCalls)
+	}
+
+	var payload struct {
+		Deleted    bool   `json:"deleted"`
+		CalendarID string `json:"calendarId"`
+	}
+	if err := json.Unmarshal([]byte(result.stdout), &payload); err != nil {
+		t.Fatalf("decode output: %v", err)
+	}
+	if !payload.Deleted || payload.CalendarID != "owned@example.com" {
+		t.Fatalf("unexpected output: %#v", payload)
+	}
+}
+
+func TestCalendarLifecycleDryRunSkipsService(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		op   string
+	}{
+		{
+			name: "unsubscribe",
+			args: []string{"calendar", "unsubscribe", "team@example.com"},
+			op:   "calendar.unsubscribe",
+		},
+		{
+			name: "delete calendar",
+			args: []string{"calendar", "delete-calendar", "owned@example.com"},
+			op:   "calendar.delete-calendar",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := executeWithCalendarTestServiceFactory(t,
+				append([]string{"--json", "--dry-run", "--account", "a@b.com"}, tc.args...),
+				func(context.Context, string) (*calendar.Service, error) {
+					t.Fatal("calendar service opened during dry-run")
+					return nil, errors.New("unexpected calendar service call")
+				},
+			)
+			if result.err != nil {
+				t.Fatalf("dry-run error = %v, want success", result.err)
+			}
+
+			var payload struct {
+				DryRun bool   `json:"dry_run"`
+				Op     string `json:"op"`
+			}
+			if err := json.Unmarshal([]byte(result.stdout), &payload); err != nil {
+				t.Fatalf("decode dry-run: %v", err)
+			}
+			if !payload.DryRun || payload.Op != tc.op {
+				t.Fatalf("unexpected dry-run output: %#v", payload)
+			}
+		})
+	}
+}
+
+func TestCalendarLifecycleRequiresForceNonInteractive(t *testing.T) {
+	tests := [][]string{
+		{"--no-input", "--account", "a@b.com", "calendar", "unsubscribe", "team@example.com"},
+		{"--no-input", "--account", "a@b.com", "calendar", "delete-calendar", "owned@example.com"},
+	}
+	for _, args := range tests {
+		result := executeWithCalendarTestServiceFactory(t, args, func(context.Context, string) (*calendar.Service, error) {
+			t.Fatal("calendar service opened before confirmation")
+			return nil, errors.New("unexpected calendar service call")
+		})
+		if result.err == nil || ExitCode(result.err) != 2 || !strings.Contains(result.err.Error(), "--force") {
+			t.Fatalf("unexpected confirmation error: %v", result.err)
+		}
+	}
+}
+
+func TestCalendarLifecycleAPIErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		args []string
+	}{
+		{
+			name: "unsubscribe",
+			path: "/users/me/calendarList/team@example.com",
+			args: []string{"calendar", "unsubscribe", "team@example.com"},
+		},
+		{
+			name: "delete calendar",
+			path: "/calendars/owned@example.com",
+			args: []string{"calendar", "delete-calendar", "owned@example.com"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			svc, closeSvc := newCalendarServiceForTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodDelete || !strings.Contains(r.URL.Path, tc.path) {
+					http.NotFound(w, r)
+					return
+				}
+				http.Error(w, "denied", http.StatusForbidden)
+			}))
+			defer closeSvc()
+
+			result := executeWithCalendarTestService(t,
+				append([]string{"--force", "--account", "a@b.com"}, tc.args...),
+				svc,
+			)
+			if result.err == nil || ExitCode(result.err) != exitCodePermissionDenied {
+				t.Fatalf("error = %v, want permission denied", result.err)
+			}
+		})
+	}
+}

--- a/internal/cmd/calendar_lifecycle_test.go
+++ b/internal/cmd/calendar_lifecycle_test.go
@@ -86,20 +86,29 @@ func TestExecuteCalendarDeleteCalendarJSON(t *testing.T) {
 }
 
 func TestCalendarLifecycleDryRunSkipsService(t *testing.T) {
+	setupCalendarAliasHome(t)
+	const resolvedID = "resolved@group.calendar.google.com"
+	if err := defaultConfigStoreForTest(t).SetCalendarAlias("shortcut", resolvedID); err != nil {
+		t.Fatalf("SetCalendarAlias: %v", err)
+	}
+
 	tests := []struct {
 		name string
 		args []string
 		op   string
+		id   string
 	}{
 		{
 			name: "unsubscribe",
-			args: []string{"calendar", "unsubscribe", "team@example.com"},
+			args: []string{"calendar", "unsubscribe", "shortcut"},
 			op:   "calendar.unsubscribe",
+			id:   resolvedID,
 		},
 		{
 			name: "delete calendar",
-			args: []string{"calendar", "delete-calendar", "owned@example.com"},
+			args: []string{"calendar", "delete-calendar", "shortcut"},
 			op:   "calendar.delete-calendar",
+			id:   resolvedID,
 		},
 	}
 
@@ -117,13 +126,16 @@ func TestCalendarLifecycleDryRunSkipsService(t *testing.T) {
 			}
 
 			var payload struct {
-				DryRun bool   `json:"dry_run"`
-				Op     string `json:"op"`
+				DryRun  bool   `json:"dry_run"`
+				Op      string `json:"op"`
+				Request struct {
+					CalendarID string `json:"calendar_id"`
+				} `json:"request"`
 			}
 			if err := json.Unmarshal([]byte(result.stdout), &payload); err != nil {
 				t.Fatalf("decode dry-run: %v", err)
 			}
-			if !payload.DryRun || payload.Op != tc.op {
+			if !payload.DryRun || payload.Op != tc.op || payload.Request.CalendarID != tc.id {
 				t.Fatalf("unexpected dry-run output: %#v", payload)
 			}
 		})
@@ -131,18 +143,38 @@ func TestCalendarLifecycleDryRunSkipsService(t *testing.T) {
 }
 
 func TestCalendarLifecycleRequiresForceNonInteractive(t *testing.T) {
-	tests := [][]string{
-		{"--no-input", "--account", "a@b.com", "calendar", "unsubscribe", "team@example.com"},
-		{"--no-input", "--account", "a@b.com", "calendar", "delete-calendar", "owned@example.com"},
+	setupCalendarAliasHome(t)
+	const resolvedID = "resolved@group.calendar.google.com"
+	if err := defaultConfigStoreForTest(t).SetCalendarAlias("shortcut", resolvedID); err != nil {
+		t.Fatalf("SetCalendarAlias: %v", err)
 	}
-	for _, args := range tests {
-		result := executeWithCalendarTestServiceFactory(t, args, func(context.Context, string) (*calendar.Service, error) {
-			t.Fatal("calendar service opened before confirmation")
-			return nil, errors.New("unexpected calendar service call")
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "unsubscribe",
+			args: []string{"--no-input", "--account", "a@b.com", "calendar", "unsubscribe", "shortcut"},
+		},
+		{
+			name: "delete calendar",
+			args: []string{"--no-input", "--account", "a@b.com", "calendar", "delete-calendar", "shortcut"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := executeWithCalendarTestServiceFactory(t, tc.args, func(context.Context, string) (*calendar.Service, error) {
+				t.Fatal("calendar service opened before confirmation")
+				return nil, errors.New("unexpected calendar service call")
+			})
+			if result.err == nil || ExitCode(result.err) != 2 || !strings.Contains(result.err.Error(), "--force") {
+				t.Fatalf("unexpected confirmation error: %v", result.err)
+			}
+			if !strings.Contains(result.err.Error(), resolvedID) {
+				t.Fatalf("confirmation target = %q, want resolved ID %q", result.err, resolvedID)
+			}
 		})
-		if result.err == nil || ExitCode(result.err) != 2 || !strings.Contains(result.err.Error(), "--force") {
-			t.Fatalf("unexpected confirmation error: %v", result.err)
-		}
 	}
 }
 

--- a/internal/cmd/dryrun_e2e_test.go
+++ b/internal/cmd/dryrun_e2e_test.go
@@ -297,6 +297,16 @@ func TestDryRunE2E_MutatingCommandsSkipAuthAndAPI(t *testing.T) {
 			op:   "calendar.subscribe",
 		},
 		{
+			name: "calendar unsubscribe",
+			args: []string{"calendar", "unsubscribe", "other@example.com"},
+			op:   "calendar.unsubscribe",
+		},
+		{
+			name: "calendar delete-calendar",
+			args: []string{"calendar", "delete-calendar", "owned@example.com"},
+			op:   "calendar.delete-calendar",
+		},
+		{
 			name: "calendar focus time",
 			args: []string{"calendar", "focus-time", "primary", "--from", "2030-01-01T10:00:00Z", "--to", "2030-01-01T11:00:00Z"},
 			op:   "calendar.focus-time",


### PR DESCRIPTION
## Summary

- add `gog calendar unsubscribe <calendarId>` to remove a calendar-list entry
- add `gog calendar delete-calendar <calendarId>` to delete an owned secondary calendar
- resolve calendar aliases before mutation
- require confirmation unless `--force`; support `--dry-run`, JSON, and plain output
- document the distinction between deleting a calendar and removing a list entry

## Proof

- `make ci`
- structured autoreview: no accepted/actionable findings
- unit coverage: success output, dry-run without auth/API, non-interactive confirmation, API error classification
- live E2E with `clawdbot@gmail.com`:
  - created disposable owned calendar
  - verified `calendar.delete-calendar` dry-run
  - deleted it and verified authoritative `Calendars.Get` returns HTTP 404
  - removed the existing UK holiday calendar-list entry
  - verified absence, resubscribed, verified presence, then unsubscribed and verified final absence

Google retained a stale owned `CalendarList` row after the authoritative calendar resource was deleted and rejected unsubscribing that tombstone with `cannotUnsubscribeFromOwnedCalendar`; docs call out this API consistency behavior.