### PR TITLE
test(backup): skip POSIX mode assertions on Windows

### DIFF
--- a/internal/backup/gmail/planner_test.go
+++ b/internal/backup/gmail/planner_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -112,7 +113,7 @@ func TestBuildMessageShardsWritesPrivatePlaintextAndProgress(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Stat(%q): %v", shard.PlaintextPath, err)
 		}
-		if info.Mode().Perm() != 0o600 {
+		if runtime.GOOS != "windows" && info.Mode().Perm() != 0o600 {
 			t.Fatalf("mode = %o, want 600", info.Mode().Perm())
 		}
 	}
@@ -221,7 +222,7 @@ func TestBuildCheckpointShardsTightensExistingFileModeBeforeRewrite(t *testing.T
 	if err != nil {
 		t.Fatalf("Stat: %v", err)
 	}
-	if info.Mode().Perm() != 0o600 {
+	if runtime.GOOS != "windows" && info.Mode().Perm() != 0o600 {
 		t.Fatalf("mode = %o, want 600", info.Mode().Perm())
 	}
 }


### PR DESCRIPTION
## Summary

- keep Gmail backup plaintext mode assertions on POSIX platforms
- skip synthesized permission-bit equality checks on Windows
- restore Windows CI after the shard-planner extraction

## Verification

- reproduced in both Windows jobs on PR #788:
  - `TestBuildMessageShardsWritesPrivatePlaintextAndProgress`: mode `0666`, expected `0600`
  - `TestBuildCheckpointShardsTightensExistingFileModeBeforeRewrite`: mode `0666`, expected `0600`
- `go test ./internal/backup/gmail -count=1`
- `make ci`
- structured autoreview: clean, no actionable findings
