### PR TITLE
fix(gmail): make watch serve dry-run side-effect-free

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- Gmail: make `watch serve --dry-run` return a secret-free daemon plan without creating/locking/updating watch state, saving hook settings, creating clients, or opening a socket.
 - Backup: make status, verify, cat, and export use read-only repository setup and file-free dry-run plans, support pre-created empty repository directories, keep failed clones clean, disable Git credential prompts under `--no-input`, redact credentials from Git errors, preserve clone failures instead of initializing a new repository, and give status/verify the existing `--no-pull` flags while retaining hidden compatibility for legacy write-only options.
 - Auth: make `auth manage --dry-run` preview the browser flow without touching the keyring or server, and fail fast when real execution uses `--no-input`.
 - Docs: make `docs cell-style` table, row, and column coordinates one-based like adjacent table commands, with negative table indexes counting from the end.

--- a/docs/watch.md
+++ b/docs/watch.md
@@ -100,6 +100,10 @@ Notes:
 - `watch pull` needs Google credentials that can consume the Pub/Sub
   subscription.
 - `watch serve` needs an HTTP endpoint reachable by Pub/Sub.
+- `watch serve --dry-run` validates flags and prints a secret-free listen/auth/
+  hook plan. It may read existing atomic watch state to resolve stored hook
+  settings, but does not create/lock/update state, create clients, or open a
+  socket.
 - `watch serve` and `watch pull` default `--exclude-labels` to `SPAM,TRASH`; set to an empty string to disable.
 - Exclude label IDs are matched exactly (case-sensitive opaque IDs).
 - `watch serve --fetch-delay` and `watch pull --fetch-delay` delay Gmail

--- a/internal/cmd/gmail_watch_cmds.go
+++ b/internal/cmd/gmail_watch_cmds.go
@@ -276,6 +276,64 @@ func (c *GmailWatchServeCmd) Run(ctx context.Context, kctx *kong.Context, flags 
 		return usage("--fetch-delay must be >= 0")
 	}
 
+	if flags != nil && flags.DryRun {
+		dryRunState, stateFound, stateErr := readGmailWatchStateOptional(ctx, account)
+		if stateErr != nil {
+			return stateErr
+		}
+		dryRunHook, hookErr := resolveWatchHookFromFlags(kctx, dryRunState, watchHookFlagValues{
+			URL:         c.HookURL,
+			Token:       c.HookToken,
+			IncludeBody: c.IncludeBody,
+			MaxBytes:    c.MaxBytes,
+		}, true)
+		if hookErr != nil {
+			if !errors.Is(hookErr, errNoHookConfigured) {
+				return hookErr
+			}
+			dryRunHook = nil
+		}
+		hookSource := "none"
+		if strings.TrimSpace(c.HookURL) != "" {
+			hookSource = "flags"
+		} else if stateFound && dryRunState.Hook != nil {
+			hookSource = "stored"
+		}
+		maxBodyBytes := defaultHookMaxBytes
+		includeBody := c.IncludeBody
+		hookTokenSet := c.HookToken != ""
+		if dryRunHook != nil {
+			includeBody = dryRunHook.IncludeBody
+			hookTokenSet = dryRunHook.Token != ""
+			if dryRunHook.MaxBytes > 0 {
+				maxBodyBytes = dryRunHook.MaxBytes
+			}
+		}
+		return dryRunExit(ctx, flags, "gmail.watch.serve", map[string]any{
+			"account": account,
+			"listen":  net.JoinHostPort(c.Bind, strconv.Itoa(c.Port)),
+			"path":    c.Path,
+			"auth": map[string]any{
+				"verify_oidc":       c.VerifyOIDC,
+				"oidc_email_set":    strings.TrimSpace(c.OIDCEmail) != "",
+				"oidc_audience_set": strings.TrimSpace(c.OIDCAudience) != "",
+				"shared_token_set":  c.SharedToken != "",
+			},
+			"hook": map[string]any{
+				"source":       hookSource,
+				"url_set":      dryRunHook != nil,
+				"token_set":    hookTokenSet,
+				"include_body": includeBody,
+				"max_bytes":    maxBodyBytes,
+				"save":         c.SaveHook,
+			},
+			"fetch_delay_seconds": fetchDelay.Seconds(),
+			"timezone":            loc.String(),
+			"history_types":       historyTypes,
+			"exclude_labels":      splitCommaList(c.ExcludeLabels),
+		})
+	}
+
 	store, err := loadGmailWatchStore(ctx, account)
 	if err != nil {
 		return err

--- a/internal/cmd/gmail_watch_helpers_test.go
+++ b/internal/cmd/gmail_watch_helpers_test.go
@@ -41,6 +41,42 @@ func newGmailWatchTestStore(t *testing.T, account string) *gmailWatchStore {
 	return store
 }
 
+func TestReadGmailWatchStateOptionalMatchesLayoutSelection(t *testing.T) {
+	root := t.TempDir()
+	layout := config.Layout{
+		ConfigDir: filepath.Join(root, "config"),
+		StateDir:  filepath.Join(root, "state"),
+	}
+	account := "a@b.com"
+	name := sanitizeAccountForPath(account) + ".json"
+	for path, maxBytes := range map[string]int{
+		filepath.Join(layout.PrimaryGmailWatchDir(), name): 111,
+		filepath.Join(layout.LegacyGmailWatchDir(), name):  222,
+	} {
+		if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+			t.Fatalf("mkdir state: %v", err)
+		}
+		payload, err := json.Marshal(gmailWatchState{
+			Account: account,
+			Hook:    &gmailWatchHook{URL: "https://example.com/hook", MaxBytes: maxBytes},
+		})
+		if err != nil {
+			t.Fatalf("marshal state: %v", err)
+		}
+		if err := os.WriteFile(path, payload, 0o600); err != nil {
+			t.Fatalf("write state: %v", err)
+		}
+	}
+
+	state, found, err := readGmailWatchStateOptionalForLayout(layout, account)
+	if err != nil {
+		t.Fatalf("read optional state: %v", err)
+	}
+	if !found || state.Hook == nil || state.Hook.MaxBytes != 222 {
+		t.Fatalf("state = %#v, found=%t; want legacy layout state", state, found)
+	}
+}
+
 func loadGmailWatchTestStore(t *testing.T, account string) *gmailWatchStore {
 	t.Helper()
 	store, err := loadGmailWatchStoreForLayout(gmailWatchTestLayout(t), account)

--- a/internal/cmd/gmail_watch_serve_test.go
+++ b/internal/cmd/gmail_watch_serve_test.go
@@ -1,9 +1,14 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -12,6 +17,178 @@ import (
 
 	"github.com/steipete/gogcli/internal/authclient"
 )
+
+func TestGmailWatchServeCmd_DryRunDoesNotTouchStateOrListen(t *testing.T) {
+	origListen := listenAndServe
+	origOIDC := newOIDCValidator
+	t.Cleanup(func() {
+		listenAndServe = origListen
+		newOIDCValidator = origOIDC
+	})
+
+	setWatchTestConfigHome(t)
+	layout := gmailWatchTestLayout(t)
+	listenAndServe = func(*http.Server) error {
+		t.Fatal("dry-run started server")
+		return nil
+	}
+	newOIDCValidator = func(context.Context, ...idtoken.ClientOption) (*idtoken.Validator, error) {
+		t.Fatal("dry-run created OIDC validator")
+		return nil, errors.New("dry-run created OIDC validator")
+	}
+
+	var stdout bytes.Buffer
+	ctx := newCmdRuntimeJSONOutputContext(t, &stdout, io.Discard)
+	err := runKong(t, &GmailWatchServeCmd{}, []string{
+		"--bind", "0.0.0.0",
+		"--port", "9999",
+		"--path", "/hook",
+		"--fetch-delay", "750ms",
+		"--timezone", "UTC",
+		"--verify-oidc",
+		"--oidc-email", "push@example.com",
+		"--oidc-audience", "https://example.com/hook?secret=value",
+		"--token", "shared-secret",
+		"--hook-url", "https://example.com/downstream?secret=value",
+		"--hook-token", "hook-secret",
+		"--include-body",
+		"--max-bytes", "42",
+		"--history-types", "messageAdded,labelRemoved",
+		"--exclude-labels", "SPAM,Label_123",
+		"--save-hook",
+	}, ctx, &RootFlags{Account: "a@b.com", DryRun: true, NoInput: true})
+	if ExitCode(err) != 0 {
+		t.Fatalf("exit code = %d, want 0: %v", ExitCode(err), err)
+	}
+
+	for _, path := range []string{layout.PrimaryGmailWatchDir(), layout.LegacyGmailWatchDir()} {
+		if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+			t.Fatalf("dry-run touched watch state path %q: %v", path, statErr)
+		}
+	}
+
+	var got struct {
+		DryRun  bool   `json:"dry_run"`
+		Op      string `json:"op"`
+		Request struct {
+			Account string `json:"account"`
+			Listen  string `json:"listen"`
+			Path    string `json:"path"`
+			Auth    struct {
+				VerifyOIDC      bool `json:"verify_oidc"`
+				OIDCEmailSet    bool `json:"oidc_email_set"`
+				OIDCAudienceSet bool `json:"oidc_audience_set"`
+				SharedTokenSet  bool `json:"shared_token_set"`
+			} `json:"auth"`
+			Hook struct {
+				Source      string `json:"source"`
+				URLSet      bool   `json:"url_set"`
+				TokenSet    bool   `json:"token_set"`
+				IncludeBody bool   `json:"include_body"`
+				MaxBytes    int    `json:"max_bytes"`
+				Save        bool   `json:"save"`
+			} `json:"hook"`
+			FetchDelaySeconds float64  `json:"fetch_delay_seconds"`
+			Timezone          string   `json:"timezone"`
+			HistoryTypes      []string `json:"history_types"`
+			ExcludeLabels     []string `json:"exclude_labels"`
+		} `json:"request"`
+	}
+	if decodeErr := json.Unmarshal(stdout.Bytes(), &got); decodeErr != nil {
+		t.Fatalf("decode dry-run: %v\noutput=%q", decodeErr, stdout.String())
+	}
+	if !got.DryRun || got.Op != "gmail.watch.serve" {
+		t.Fatalf("unexpected dry-run envelope: %#v", got)
+	}
+	if got.Request.Account != "a@b.com" ||
+		got.Request.Listen != "0.0.0.0:9999" ||
+		got.Request.Path != "/hook" ||
+		!got.Request.Auth.VerifyOIDC ||
+		!got.Request.Auth.OIDCEmailSet ||
+		!got.Request.Auth.OIDCAudienceSet ||
+		!got.Request.Auth.SharedTokenSet ||
+		got.Request.Hook.Source != "flags" ||
+		!got.Request.Hook.URLSet ||
+		!got.Request.Hook.TokenSet ||
+		!got.Request.Hook.IncludeBody ||
+		got.Request.Hook.MaxBytes != 42 ||
+		!got.Request.Hook.Save ||
+		got.Request.FetchDelaySeconds != 0.75 ||
+		got.Request.Timezone != "UTC" ||
+		len(got.Request.HistoryTypes) != 2 ||
+		len(got.Request.ExcludeLabels) != 2 {
+		t.Fatalf("unexpected dry-run request: %#v", got.Request)
+	}
+	if bytes.Contains(stdout.Bytes(), []byte("shared-secret")) ||
+		bytes.Contains(stdout.Bytes(), []byte("hook-secret")) ||
+		bytes.Contains(stdout.Bytes(), []byte("secret=value")) {
+		t.Fatalf("dry-run exposed secret input: %s", stdout.String())
+	}
+}
+
+func TestGmailWatchServeCmd_DryRunReadsStoredHookWithoutLocking(t *testing.T) {
+	setWatchTestConfigHome(t)
+	layout := gmailWatchTestLayout(t)
+	statePath := filepath.Join(layout.GmailWatchDir(), sanitizeAccountForPath("a@b.com")+".json")
+	if err := os.MkdirAll(filepath.Dir(statePath), 0o700); err != nil {
+		t.Fatalf("mkdir watch state: %v", err)
+	}
+	stateBytes, marshalErr := json.Marshal(gmailWatchState{
+		Account:   "a@b.com",
+		HistoryID: "100",
+		Hook: &gmailWatchHook{
+			URL:         "https://example.com/hook",
+			Token:       "stored-secret",
+			IncludeBody: false,
+			MaxBytes:    123,
+		},
+	})
+	if marshalErr != nil {
+		t.Fatalf("marshal state: %v", marshalErr)
+	}
+	if writeErr := os.WriteFile(statePath, stateBytes, 0o600); writeErr != nil {
+		t.Fatalf("write state: %v", writeErr)
+	}
+
+	ctx := newCmdRuntimeJSONOutputContext(t, io.Discard, io.Discard)
+	invalidErr := runKong(t, &GmailWatchServeCmd{}, []string{
+		"--max-bytes", "0",
+	}, ctx, &RootFlags{Account: "a@b.com", DryRun: true, NoInput: true})
+	if ExitCode(invalidErr) != 2 {
+		t.Fatalf("invalid override exit code = %d, want 2: %v", ExitCode(invalidErr), invalidErr)
+	}
+
+	var stdout bytes.Buffer
+	ctx = newCmdRuntimeJSONOutputContext(t, &stdout, io.Discard)
+	if runErr := runKong(t, &GmailWatchServeCmd{}, nil, ctx, &RootFlags{Account: "a@b.com", DryRun: true, NoInput: true}); ExitCode(runErr) != 0 {
+		t.Fatalf("stored-hook dry-run: %v", runErr)
+	}
+	var got struct {
+		Request struct {
+			Hook struct {
+				Source   string `json:"source"`
+				TokenSet bool   `json:"token_set"`
+				MaxBytes int    `json:"max_bytes"`
+			} `json:"hook"`
+		} `json:"request"`
+	}
+	if decodeErr := json.Unmarshal(stdout.Bytes(), &got); decodeErr != nil {
+		t.Fatalf("decode dry-run: %v\noutput=%q", decodeErr, stdout.String())
+	}
+	if got.Request.Hook.Source != "stored" || !got.Request.Hook.TokenSet || got.Request.Hook.MaxBytes != 123 {
+		t.Fatalf("unexpected stored hook plan: %#v", got.Request.Hook)
+	}
+	if _, statErr := os.Stat(filepath.Join(filepath.Dir(statePath), ".lock")); !os.IsNotExist(statErr) {
+		t.Fatalf("dry-run created watch lock: %v", statErr)
+	}
+	after, readErr := os.ReadFile(statePath)
+	if readErr != nil {
+		t.Fatalf("read state after dry-run: %v", readErr)
+	}
+	if !bytes.Equal(after, stateBytes) {
+		t.Fatalf("dry-run changed watch state:\nwant=%s\ngot=%s", stateBytes, after)
+	}
+}
 
 func TestGmailWatchServeCmd_UsesStoredHook(t *testing.T) {
 	origListen := listenAndServe

--- a/internal/cmd/gmail_watch_serve_validation_test.go
+++ b/internal/cmd/gmail_watch_serve_validation_test.go
@@ -49,4 +49,15 @@ func TestGmailWatchServeCmd_ValidationErrors(t *testing.T) {
 			t.Fatalf("expected error")
 		}
 	})
+
+	t.Run("dry-run validates explicit hook options", func(t *testing.T) {
+		dryRunFlags := &RootFlags{Account: "a@b.com", DryRun: true}
+		if err := runKong(t, &GmailWatchServeCmd{}, []string{
+			"--hook-url", "https://example.com/hook",
+			"--max-bytes", "0",
+			"--port", "9999",
+		}, context.Background(), dryRunFlags); err == nil {
+			t.Fatalf("expected error")
+		}
+	})
 }

--- a/internal/cmd/gmail_watch_state.go
+++ b/internal/cmd/gmail_watch_state.go
@@ -129,6 +129,41 @@ func loadGmailWatchStoreForLayout(layout config.Layout, account string) (*gmailW
 	return store, nil
 }
 
+func readGmailWatchStateOptional(ctx context.Context, account string) (gmailWatchState, bool, error) {
+	layout, err := commandLayout(ctx, config.PathKindConfig, config.PathKindState)
+	if err != nil {
+		return gmailWatchState{}, false, err
+	}
+	return readGmailWatchStateOptionalForLayout(layout, account)
+}
+
+func readGmailWatchStateOptionalForLayout(layout config.Layout, account string) (gmailWatchState, bool, error) {
+	name := sanitizeAccountForPath(account) + ".json"
+	paths := []string{filepath.Join(layout.GmailWatchDir(), name)}
+	if !layout.ExplicitState {
+		legacyPath := filepath.Join(layout.LegacyGmailWatchDir(), name)
+		if legacyPath != paths[0] {
+			paths = append(paths, legacyPath)
+		}
+	}
+
+	for _, path := range paths {
+		data, err := os.ReadFile(path) //nolint:gosec // path is derived from the configured state directory and sanitized account.
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return gmailWatchState{}, false, err
+		}
+		var state gmailWatchState
+		if err := json.Unmarshal(data, &state); err != nil {
+			return gmailWatchState{}, false, err
+		}
+		return state, true, nil
+	}
+	return gmailWatchState{}, false, nil
+}
+
 func (s *gmailWatchStore) Get() gmailWatchState {
 	s.mu.Lock()
 	defer s.mu.Unlock()


### PR DESCRIPTION
## Summary

- make `gmail settings watch serve --dry-run` and its hidden alias emit a validated daemon plan
- resolve stored hook overrides through a lock-free atomic state read
- keep secrets out of the plan and avoid state creation, locks, clients, and sockets
- document the contract and add the changelog entry

## Verification

- `make ci`
- structured autoreview: clean
- isolated binary smoke with `clawdbot@gmail.com`: canonical and hidden alias exit 0, no state/lock/socket, no secret output
- full hidden-command offline matrix: 556 executable paths, 200 dry-run plans, zero timeouts, 10 expected lock rows

Evidence:

- `/tmp/gog-watch-serve-smoke.KMYlw9`
- `/tmp/gog-offline-results-hidden-watch-serve.tsv`
