### PR TITLE
fix(gmail): keep watch status read-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- Gmail: make `watch status` read atomic watch state without creating state directories or lock files.
 - Gmail: make `watch serve --dry-run` return a secret-free daemon plan without creating/locking/updating watch state, saving hook settings, creating clients, or opening a socket.
 - Backup: make status, verify, cat, and export use read-only repository setup and file-free dry-run plans, support pre-created empty repository directories, keep failed clones clean, disable Git credential prompts under `--no-input`, redact credentials from Git errors, preserve clone failures instead of initializing a new repository, and give status/verify the existing `--no-pull` flags while retaining hidden compatibility for legacy write-only options.
 - Auth: make `auth manage --dry-run` preview the browser flow without touching the keyring or server, and fail fast when real execution uses `--no-input`.

--- a/docs/watch.md
+++ b/docs/watch.md
@@ -93,6 +93,8 @@ gog gmail history --since <historyId> [--max <n>] [--page <token>]
 
 Notes:
 - `watch start` stores `{historyId, expirationMs, topic, labels}` for account.
+- `watch status` reads atomic state without creating state directories or lock
+  files.
 - `watch renew` reuses stored topic/labels.
 - `watch stop` calls Gmail stop + clears state.
 - `watch serve` and `watch pull` use stored hook config if `--hook-url` is not

--- a/internal/cmd/gmail_watch_cmds.go
+++ b/internal/cmd/gmail_watch_cmds.go
@@ -117,11 +117,11 @@ func (c *GmailWatchStatusCmd) Run(ctx context.Context, flags *RootFlags) error {
 	if err != nil {
 		return err
 	}
-	store, err := loadGmailWatchStore(ctx, account)
+	state, err := readGmailWatchState(ctx, account)
 	if err != nil {
 		return err
 	}
-	return writeWatchState(ctx, store.Get(), c.ShowSecrets)
+	return writeWatchState(ctx, state, c.ShowSecrets)
 }
 
 type GmailWatchRenewCmd struct {

--- a/internal/cmd/gmail_watch_cmds_more_test.go
+++ b/internal/cmd/gmail_watch_cmds_more_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -100,4 +101,69 @@ func TestGmailWatchStatusAndStop_Text(t *testing.T) {
 	if !strings.Contains(out.String(), "account") || !strings.Contains(out.String(), "stopped") {
 		t.Fatalf("unexpected output: %q", out.String())
 	}
+}
+
+func TestGmailWatchStatusCmd_ReadOnlyStateAccess(t *testing.T) {
+	t.Run("missing state", func(t *testing.T) {
+		setWatchTestConfigHome(t)
+		layout := gmailWatchTestLayout(t)
+		ctx := newCmdRuntimeJSONOutputContext(t, io.Discard, io.Discard)
+
+		err := runKong(t, &GmailWatchStatusCmd{}, nil, ctx, &RootFlags{
+			Account: "a@b.com",
+			DryRun:  true,
+			NoInput: true,
+		})
+		if err == nil || ExitCode(err) != 1 || err.Error() != "watch state not found; run gmail watch start" {
+			t.Fatalf("missing state error = %v", err)
+		}
+		for _, path := range []string{layout.PrimaryGmailWatchDir(), layout.LegacyGmailWatchDir()} {
+			if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+				t.Fatalf("status touched watch state path %q: %v", path, statErr)
+			}
+		}
+	})
+
+	t.Run("existing state", func(t *testing.T) {
+		setWatchTestConfigHome(t)
+		layout := gmailWatchTestLayout(t)
+		statePath := filepath.Join(layout.GmailWatchDir(), sanitizeAccountForPath("a@b.com")+".json")
+		if err := os.MkdirAll(filepath.Dir(statePath), 0o700); err != nil {
+			t.Fatalf("mkdir watch state: %v", err)
+		}
+		stateBytes, marshalErr := json.Marshal(gmailWatchState{
+			Account:   "a@b.com",
+			Topic:     "projects/p/topics/t",
+			HistoryID: "100",
+		})
+		if marshalErr != nil {
+			t.Fatalf("marshal watch state: %v", marshalErr)
+		}
+		if writeErr := os.WriteFile(statePath, stateBytes, 0o600); writeErr != nil {
+			t.Fatalf("write watch state: %v", writeErr)
+		}
+
+		var stdout bytes.Buffer
+		ctx := newCmdRuntimeJSONOutputContext(t, &stdout, io.Discard)
+		if runErr := runKong(t, &GmailWatchStatusCmd{}, nil, ctx, &RootFlags{
+			Account: "a@b.com",
+			DryRun:  true,
+			NoInput: true,
+		}); runErr != nil {
+			t.Fatalf("status: %v", runErr)
+		}
+		if !strings.Contains(stdout.String(), `"account": "a@b.com"`) {
+			t.Fatalf("unexpected status output: %s", stdout.String())
+		}
+		if _, statErr := os.Stat(filepath.Join(filepath.Dir(statePath), ".lock")); !os.IsNotExist(statErr) {
+			t.Fatalf("status created watch lock: %v", statErr)
+		}
+		after, readErr := os.ReadFile(statePath)
+		if readErr != nil {
+			t.Fatalf("read watch state: %v", readErr)
+		}
+		if !bytes.Equal(after, stateBytes) {
+			t.Fatalf("status changed watch state:\nwant=%s\ngot=%s", stateBytes, after)
+		}
+	})
 }

--- a/internal/cmd/gmail_watch_state.go
+++ b/internal/cmd/gmail_watch_state.go
@@ -137,6 +137,17 @@ func readGmailWatchStateOptional(ctx context.Context, account string) (gmailWatc
 	return readGmailWatchStateOptionalForLayout(layout, account)
 }
 
+func readGmailWatchState(ctx context.Context, account string) (gmailWatchState, error) {
+	state, found, err := readGmailWatchStateOptional(ctx, account)
+	if err != nil {
+		return gmailWatchState{}, err
+	}
+	if !found {
+		return gmailWatchState{}, errors.New("watch state not found; run gmail watch start")
+	}
+	return state, nil
+}
+
 func readGmailWatchStateOptionalForLayout(layout config.Layout, account string) (gmailWatchState, bool, error) {
 	name := sanitizeAccountForPath(account) + ".json"
 	paths := []string{filepath.Join(layout.GmailWatchDir(), name)}


### PR DESCRIPTION
## Summary

- make Gmail watch status read atomic state without creating directories or lock files
- preserve missing-state errors, output, secret redaction, and primary/legacy layout selection
- document the read-only contract and add regression coverage

## Verification

- `make ci`
- structured autoreview: clean
- isolated binary smoke with `clawdbot@gmail.com`: canonical and hidden alias preserve the missing-state error and create no files
- full hidden-command offline matrix: 556 executable paths, zero timeouts, expected lock rows reduced from 10 to 8

Evidence:

- `/tmp/gog-watch-status-fixed-canonical.SMVTpg`
- `/tmp/gog-watch-status-fixed-alias.V1AN1E`
- `/tmp/gog-offline-results-hidden-watch-status.tsv`