### PR TITLE
fix(docs): keep batch reads side-effect-free

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- Docs: keep batch list/show, batch target validation, and batch end dry-runs read-only without creating state directories or lock files.
 - Gmail: make `watch status` read atomic watch state without creating state directories or lock files.
 - Gmail: make `watch serve --dry-run` return a secret-free daemon plan without creating/locking/updating watch state, saving hook settings, creating clients, or opening a socket.
 - Backup: make status, verify, cat, and export use read-only repository setup and file-free dry-run plans, support pre-created empty repository directories, keep failed clones clean, disable Git credential prompts under `--no-input`, redact credentials from Git errors, preserve clone failures instead of initializing a new repository, and give status/verify the existing `--no-pull` flags while retaining hidden compatibility for legacy write-only options.

--- a/docs/docs-batch.md
+++ b/docs/docs-batch.md
@@ -58,6 +58,6 @@ Use `batch abort <batchId>` to discard a batch and `batch prune --older-than 72h
 
 ## Local state
 
-Batch files live under the state directory described in [Paths and State](paths.md), in the `batches/` subdirectory. Directories use mode `0700`; batch files and the lock file use mode `0600`.
+Batch files live under the state directory described in [Paths and State](paths.md), in the `batches/` subdirectory. Directories use mode `0700`; batch files and the lock file use mode `0600`. `batch list`, `batch show`, and `batch end --dry-run` read atomic state without creating the directory or lock file. Commands that create, queue, submit, abort, or prune batches retain the cross-process mutation lock.
 
 Requests can contain document text, links, email addresses, and other content. Treat the state directory as sensitive. `batch show` exposes both request metadata and the exact wire payload.

--- a/internal/cmd/batch.go
+++ b/internal/cmd/batch.go
@@ -75,7 +75,7 @@ func (c *BatchBeginCmd) Run(ctx context.Context, flags *RootFlags) error {
 type BatchListCmd struct{}
 
 func (c *BatchListCmd) Run(ctx context.Context) error {
-	store, err := newDocsBatchStore(ctx)
+	store, err := openDocsBatchStore(ctx)
 	if err != nil {
 		return err
 	}
@@ -100,11 +100,15 @@ type BatchShowCmd struct {
 }
 
 func (c *BatchShowCmd) Run(ctx context.Context) error {
-	store, err := newDocsBatchStore(ctx)
+	batchID := strings.TrimSpace(c.BatchID)
+	if err := validateDocsBatchID(batchID); err != nil {
+		return err
+	}
+	store, err := openDocsBatchStore(ctx)
 	if err != nil {
 		return err
 	}
-	state, err := store.get(strings.TrimSpace(c.BatchID))
+	state, err := store.get(batchID)
 	if err != nil {
 		return err
 	}
@@ -207,24 +211,44 @@ func (c *BatchEndCmd) Run(ctx context.Context, flags *RootFlags) error {
 	if c.ContinueOnError && c.AutoSplit {
 		return usage("--continue-on-error and --auto-split are mutually exclusive")
 	}
+	batchID := strings.TrimSpace(c.BatchID)
+	if err := validateDocsBatchID(batchID); err != nil {
+		return err
+	}
+	if flags != nil && flags.DryRun {
+		store, err := openDocsBatchStore(ctx)
+		if err != nil {
+			return err
+		}
+		state, err := store.get(batchID)
+		if err != nil {
+			return err
+		}
+		if len(state.Requests) == 0 {
+			return errors.New("batch has no requests")
+		}
+
+		return writeDocsBatchEndResult(ctx, docsBatchEndResult{
+			BatchID:  state.BatchID,
+			Requests: len(state.Requests),
+			Atomic:   !c.AutoSplit,
+			DryRun:   true,
+			Payload:  docsBatchWirePayload(state, state.Requests),
+		})
+	}
 	store, err := newDocsBatchStore(ctx)
 	if err != nil {
 		return err
 	}
 
 	var result docsBatchEndResult
-	err = store.withLockedState(strings.TrimSpace(c.BatchID), func(state *docsBatchState) error {
+	err = store.withLockedState(batchID, func(state *docsBatchState) error {
 		if len(state.Requests) == 0 {
 			return errors.New("batch has no requests")
 		}
 		result.BatchID = state.BatchID
 		result.Requests = len(state.Requests)
 		result.Atomic = !c.AutoSplit
-		if flags != nil && flags.DryRun {
-			result.DryRun = true
-			result.Payload = docsBatchWirePayload(state, state.Requests)
-			return nil
-		}
 		if len(state.Requests) > docsBatchUpdateRequestCap && !c.AutoSplit {
 			return usagef("batch has %d requests; Docs allows at most %d per atomic update (use --auto-split for non-atomic submission)", len(state.Requests), docsBatchUpdateRequestCap)
 		}
@@ -336,7 +360,7 @@ func validateDocsBatchTarget(ctx context.Context, flags *RootFlags, batchID, doc
 	if err != nil {
 		return err
 	}
-	store, err := newDocsBatchStore(ctx)
+	store, err := openDocsBatchStore(ctx)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/docs_batch_store.go
+++ b/internal/cmd/docs_batch_store.go
@@ -76,16 +76,24 @@ type docsBatchStore struct {
 }
 
 func newDocsBatchStore(ctx context.Context) (*docsBatchStore, error) {
+	store, err := openDocsBatchStore(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(store.dir, 0o700); err != nil {
+		return nil, fmt.Errorf("ensure batch dir: %w", err)
+	}
+
+	return store, nil
+}
+
+func openDocsBatchStore(ctx context.Context) (*docsBatchStore, error) {
 	layout, err := commandLayout(ctx, config.PathKindState)
 	if err != nil {
 		return nil, err
 	}
-	dir := layout.BatchDir()
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		return nil, fmt.Errorf("ensure batch dir: %w", err)
-	}
 
-	return newDocsBatchStoreAt(dir), nil
+	return newDocsBatchStoreAt(layout.BatchDir()), nil
 }
 
 func newDocsBatchStoreAt(dir string) *docsBatchStore {
@@ -120,47 +128,31 @@ func (s *docsBatchStore) create(state docsBatchState) (*docsBatchState, error) {
 }
 
 func (s *docsBatchStore) list() ([]docsBatchSummary, error) {
-	var summaries []docsBatchSummary
-	err := s.lock.WithExclusive(func() error {
-		states, err := s.listStatesUnlocked()
-		if err != nil {
-			return err
-		}
+	states, err := s.listStatesUnlocked()
+	if err != nil {
+		return nil, err
+	}
 
-		summaries = make([]docsBatchSummary, 0, len(states))
-		for _, state := range states {
-			summaries = append(summaries, docsBatchSummary{
-				BatchID:    state.BatchID,
-				Name:       state.Name,
-				Service:    state.Service,
-				DocumentID: state.DocumentID,
-				Account:    state.Account,
-				Client:     state.Client,
-				CreatedAt:  state.CreatedAt,
-				UpdatedAt:  state.UpdatedAt,
-				Requests:   len(state.Requests),
-			})
-		}
+	summaries := make([]docsBatchSummary, 0, len(states))
+	for _, state := range states {
+		summaries = append(summaries, docsBatchSummary{
+			BatchID:    state.BatchID,
+			Name:       state.Name,
+			Service:    state.Service,
+			DocumentID: state.DocumentID,
+			Account:    state.Account,
+			Client:     state.Client,
+			CreatedAt:  state.CreatedAt,
+			UpdatedAt:  state.UpdatedAt,
+			Requests:   len(state.Requests),
+		})
+	}
 
-		return nil
-	})
-
-	return summaries, err
+	return summaries, nil
 }
 
 func (s *docsBatchStore) get(batchID string) (*docsBatchState, error) {
-	var state *docsBatchState
-	err := s.lock.WithExclusive(func() error {
-		loaded, err := s.readUnlocked(batchID)
-		if err != nil {
-			return err
-		}
-		state = loaded
-
-		return nil
-	})
-
-	return state, err
+	return s.readUnlocked(batchID)
 }
 
 func (s *docsBatchStore) appendRequests(batchID, command, documentID, account, client, revisionID string, requests []*docs.Request, requireEmpty bool) (int, error) {
@@ -289,6 +281,9 @@ func (s *docsBatchStore) persistOrDeleteUnlocked(state *docsBatchState) error {
 func (s *docsBatchStore) listStatesUnlocked() ([]*docsBatchState, error) {
 	entries, err := os.ReadDir(s.dir)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return []*docsBatchState{}, nil
+		}
 		return nil, fmt.Errorf("read batch directory: %w", err)
 	}
 
@@ -297,8 +292,12 @@ func (s *docsBatchStore) listStatesUnlocked() ([]*docsBatchState, error) {
 		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
 			continue
 		}
-		state, readErr := s.readPathUnlocked(filepath.Join(s.dir, entry.Name()))
+		path := filepath.Join(s.dir, entry.Name())
+		state, readErr := s.readPathUnlocked(path)
 		if readErr != nil {
+			if _, statErr := os.Stat(path); os.IsNotExist(statErr) {
+				continue
+			}
 			return nil, readErr
 		}
 		states = append(states, state)

--- a/internal/cmd/docs_batch_store_test.go
+++ b/internal/cmd/docs_batch_store_test.go
@@ -216,12 +216,31 @@ func TestBatchEndDryRunKeepsStateWithoutHTTP(t *testing.T) {
 		t.Fatal("dry run created HTTP client")
 		return nil, errors.New("unexpected HTTP client request")
 	})
-
-	if err := (&BatchEndCmd{BatchID: state.BatchID}).Run(ctx, &RootFlags{DryRun: true}); err != nil {
-		t.Fatalf("dry-run end: %v", err)
+	statePath := store.path(state.BatchID)
+	before, readErr := os.ReadFile(statePath)
+	if readErr != nil {
+		t.Fatalf("read state before dry run: %v", readErr)
 	}
-	if _, err := store.get(state.BatchID); err != nil {
-		t.Fatalf("dry run removed state: %v", err)
+	lockPath := filepath.Join(store.dir, ".lock")
+	if removeErr := os.Remove(lockPath); removeErr != nil {
+		t.Fatalf("remove setup lock: %v", removeErr)
+	}
+
+	if runErr := (&BatchEndCmd{BatchID: state.BatchID}).Run(ctx, &RootFlags{DryRun: true}); runErr != nil {
+		t.Fatalf("dry-run end: %v", runErr)
+	}
+	if _, getErr := store.get(state.BatchID); getErr != nil {
+		t.Fatalf("dry run removed state: %v", getErr)
+	}
+	after, readErr := os.ReadFile(statePath)
+	if readErr != nil {
+		t.Fatalf("read state after dry run: %v", readErr)
+	}
+	if !bytes.Equal(after, before) {
+		t.Fatal("dry run changed batch state")
+	}
+	if _, statErr := os.Stat(lockPath); !os.IsNotExist(statErr) {
+		t.Fatalf("dry run created lock: %v", statErr)
 	}
 }
 
@@ -243,7 +262,7 @@ func TestBatchJSONUsesRuntimeOutput(t *testing.T) {
 	}
 }
 
-func TestBatchListUsesRuntimeStateDir(t *testing.T) {
+func TestBatchListUsesRuntimeStateDirWithoutCreatingIt(t *testing.T) {
 	runtimeStateDir := t.TempDir()
 	ambientStateDir := filepath.Join(t.TempDir(), "ambient")
 	t.Setenv("GOG_STATE_DIR", ambientStateDir)
@@ -252,11 +271,78 @@ func TestBatchListUsesRuntimeStateDir(t *testing.T) {
 	if err := (&BatchListCmd{}).Run(ctx); err != nil {
 		t.Fatalf("list: %v", err)
 	}
-	if _, err := os.Stat(filepath.Join(runtimeStateDir, "batches")); err != nil {
-		t.Fatalf("runtime batch directory: %v", err)
+	if _, err := os.Stat(filepath.Join(runtimeStateDir, "batches")); !os.IsNotExist(err) {
+		t.Fatalf("runtime batch directory unexpectedly created: %v", err)
 	}
 	if _, err := os.Stat(ambientStateDir); !os.IsNotExist(err) {
 		t.Fatalf("ambient state directory unexpectedly touched: %v", err)
+	}
+}
+
+func TestBatchListAndShowReadWithoutLock(t *testing.T) {
+	ctx := batchTestContext(t)
+	store, err := newDocsBatchStore(ctx)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	state, err := store.create(docsBatchState{
+		Service:    docsBatchService,
+		DocumentID: "doc1",
+		Account:    "a@b.com",
+		Client:     "default",
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	statePath := store.path(state.BatchID)
+	before, readErr := os.ReadFile(statePath)
+	if readErr != nil {
+		t.Fatalf("read state before commands: %v", readErr)
+	}
+	lockPath := filepath.Join(store.dir, ".lock")
+	if removeErr := os.Remove(lockPath); removeErr != nil {
+		t.Fatalf("remove setup lock: %v", removeErr)
+	}
+
+	if listErr := (&BatchListCmd{}).Run(ctx); listErr != nil {
+		t.Fatalf("list: %v", listErr)
+	}
+	if showErr := (&BatchShowCmd{BatchID: state.BatchID}).Run(ctx); showErr != nil {
+		t.Fatalf("show: %v", showErr)
+	}
+	after, readErr := os.ReadFile(statePath)
+	if readErr != nil {
+		t.Fatalf("read state after commands: %v", readErr)
+	}
+	if !bytes.Equal(after, before) {
+		t.Fatal("read command changed batch state")
+	}
+	if _, statErr := os.Stat(lockPath); !os.IsNotExist(statErr) {
+		t.Fatalf("read command created lock: %v", statErr)
+	}
+}
+
+func TestBatchShowAndEndValidateBeforeCreatingState(t *testing.T) {
+	stateDir := t.TempDir()
+	ctx := withDocsBatchStateDir(newCmdRuntimeOutputContext(t, io.Discard, io.Discard), stateDir)
+
+	for name, run := range map[string]func() error{
+		"show": func() error {
+			return (&BatchShowCmd{BatchID: "placeholder"}).Run(ctx)
+		},
+		"end dry-run": func() error {
+			return (&BatchEndCmd{BatchID: "placeholder"}).Run(ctx, &RootFlags{DryRun: true})
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			err := run()
+			if err == nil || !strings.Contains(err.Error(), "invalid batch ID: placeholder") {
+				t.Fatalf("error = %v", err)
+			}
+			if _, statErr := os.Stat(filepath.Join(stateDir, "batches")); !os.IsNotExist(statErr) {
+				t.Fatalf("batch directory unexpectedly created: %v", statErr)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- keep `batch list`, `batch show`, and batch target validation on lock-free atomic reads
- validate batch IDs before local state access
- make `batch end --dry-run` read and render the persisted payload without creating directories or lock files
- retain exclusive locking for every real batch mutation

## Verification

- focused batch tests
- structured Codex autoreview: no actionable findings
- `make ci`
- isolated binary smoke: absent/invalid list/show/end paths created zero files
- isolated existing-state smoke: list/show/end dry-run preserved state bytes and created no lock
- complete 556-path visible/hidden replay: unchanged classifications, zero timeouts, file rows reduced from eight to five intentional keyring locks

No agent transcript attached pending maintainer opt-in.