### PR TITLE
fix(cli): classify local validation as usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- CLI: classify invalid Docs batch IDs and incomplete Gmail filter definitions as usage errors with exit code 2.
 - Docs: keep batch list/show, batch target validation, and batch end dry-runs read-only without creating state directories or lock files.
 - Gmail: make `watch status` read atomic watch state without creating state directories or lock files.
 - Gmail: make `watch serve --dry-run` return a secret-free daemon plan without creating/locking/updating watch state, saving hook settings, creating clients, or opening a socket.

--- a/internal/cmd/batch.go
+++ b/internal/cmd/batch.go
@@ -101,7 +101,7 @@ type BatchShowCmd struct {
 
 func (c *BatchShowCmd) Run(ctx context.Context) error {
 	batchID := strings.TrimSpace(c.BatchID)
-	if err := validateDocsBatchID(batchID); err != nil {
+	if err := validateDocsBatchIDArg(batchID); err != nil {
 		return err
 	}
 	store, err := openDocsBatchStore(ctx)
@@ -135,7 +135,7 @@ type BatchAbortCmd struct {
 
 func (c *BatchAbortCmd) Run(ctx context.Context, flags *RootFlags) error {
 	batchID := strings.TrimSpace(c.BatchID)
-	if err := validateDocsBatchID(batchID); err != nil {
+	if err := validateDocsBatchIDArg(batchID); err != nil {
 		return err
 	}
 	if err := dryRunExit(ctx, flags, "batch.abort", map[string]any{"batch_id": batchID}); err != nil {
@@ -212,7 +212,7 @@ func (c *BatchEndCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return usage("--continue-on-error and --auto-split are mutually exclusive")
 	}
 	batchID := strings.TrimSpace(c.BatchID)
-	if err := validateDocsBatchID(batchID); err != nil {
+	if err := validateDocsBatchIDArg(batchID); err != nil {
 		return err
 	}
 	if flags != nil && flags.DryRun {
@@ -352,6 +352,9 @@ func validateDocsBatchTarget(ctx context.Context, flags *RootFlags, batchID, doc
 	if batchID == "" {
 		return nil
 	}
+	if err := validateDocsBatchIDArg(batchID); err != nil {
+		return err
+	}
 	account, err := requireAccount(flags)
 	if err != nil {
 		return err
@@ -395,6 +398,9 @@ func queueDocsBatchRequests(ctx context.Context, flags *RootFlags, batchID, docu
 	if batchID == "" {
 		return false, nil
 	}
+	if err := validateDocsBatchIDArg(batchID); err != nil {
+		return true, err
+	}
 	if len(requests) == 0 {
 		return true, errors.New("no Docs requests to append")
 	}
@@ -428,4 +434,8 @@ func queueDocsBatchRequests(ctx context.Context, flags *RootFlags, batchID, docu
 	}
 
 	return true, err
+}
+
+func validateDocsBatchIDArg(batchID string) error {
+	return newUsageError(validateDocsBatchID(batchID))
 }

--- a/internal/cmd/docs_batch_store_test.go
+++ b/internal/cmd/docs_batch_store_test.go
@@ -322,11 +322,14 @@ func TestBatchListAndShowReadWithoutLock(t *testing.T) {
 	}
 }
 
-func TestBatchShowAndEndValidateBeforeCreatingState(t *testing.T) {
+func TestBatchCommandsValidateBeforeCreatingState(t *testing.T) {
 	stateDir := t.TempDir()
 	ctx := withDocsBatchStateDir(newCmdRuntimeOutputContext(t, io.Discard, io.Discard), stateDir)
 
 	for name, run := range map[string]func() error{
+		"abort": func() error {
+			return (&BatchAbortCmd{BatchID: "placeholder"}).Run(ctx, &RootFlags{DryRun: true})
+		},
 		"show": func() error {
 			return (&BatchShowCmd{BatchID: "placeholder"}).Run(ctx)
 		},
@@ -336,13 +339,26 @@ func TestBatchShowAndEndValidateBeforeCreatingState(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			err := run()
-			if err == nil || !strings.Contains(err.Error(), "invalid batch ID: placeholder") {
+			if err == nil || ExitCode(err) != 2 || !strings.Contains(err.Error(), "invalid batch ID: placeholder") {
 				t.Fatalf("error = %v", err)
 			}
 			if _, statErr := os.Stat(filepath.Join(stateDir, "batches")); !os.IsNotExist(statErr) {
 				t.Fatalf("batch directory unexpectedly created: %v", statErr)
 			}
 		})
+	}
+}
+
+func TestValidateDocsBatchTargetRejectsInvalidIDBeforeAccountResolution(t *testing.T) {
+	stateDir := t.TempDir()
+	ctx := withDocsBatchStateDir(newCmdRuntimeOutputContext(t, io.Discard, io.Discard), stateDir)
+
+	err := validateDocsBatchTarget(ctx, &RootFlags{}, "placeholder", "doc1")
+	if err == nil || ExitCode(err) != 2 || !strings.Contains(err.Error(), "invalid batch ID: placeholder") {
+		t.Fatalf("error = %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(stateDir, "batches")); !os.IsNotExist(statErr) {
+		t.Fatalf("batch directory unexpectedly created: %v", statErr)
 	}
 }
 

--- a/internal/cmd/gmail_filters.go
+++ b/internal/cmd/gmail_filters.go
@@ -75,7 +75,7 @@ type GmailFiltersCreateCmd struct {
 func (c *GmailFiltersCreateCmd) Run(ctx context.Context, flags *RootFlags) error {
 	forwardTarget, err := c.validate()
 	if err != nil {
-		return err
+		return newUsageError(err)
 	}
 
 	if dryRunErr := dryRunExit(ctx, flags, "gmail.filters.create", c.dryRunPayload(forwardTarget)); dryRunErr != nil {

--- a/internal/cmd/gmail_filters_cmd_test.go
+++ b/internal/cmd/gmail_filters_cmd_test.go
@@ -22,13 +22,13 @@ func TestGmailFiltersCreate_Validation(t *testing.T) {
 	flags := &RootFlags{Account: "a@b.com", Force: true}
 
 	cmd := &GmailFiltersCreateCmd{}
-	if err := runKong(t, cmd, []string{}, context.Background(), flags); err == nil {
-		t.Fatalf("expected missing criteria error")
+	if err := runKong(t, cmd, []string{}, context.Background(), flags); err == nil || ExitCode(err) != 2 {
+		t.Fatalf("expected missing criteria usage error, got %v", err)
 	}
 
 	cmd = &GmailFiltersCreateCmd{}
-	if err := runKong(t, cmd, []string{"--from", "a@example.com"}, context.Background(), flags); err == nil {
-		t.Fatalf("expected missing action error")
+	if err := runKong(t, cmd, []string{"--from", "a@example.com"}, context.Background(), flags); err == nil || ExitCode(err) != 2 {
+		t.Fatalf("expected missing action usage error, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- classify invalid Docs batch UUID arguments as usage errors before account or state access
- cover direct batch commands and Docs mutation `--batch` validation
- classify incomplete Gmail filter criteria/action definitions as usage errors on canonical and hidden paths
- preserve existing messages and valid-command behavior

## Verification

- focused batch and Gmail validation tests
- structured Codex autoreview: no actionable findings
- `make ci`
- isolated binary smoke: seven canonical/hidden cases now return exit 2
- complete 556-path replay: zero timeouts; only the expected five rows moved from error to usage

No agent transcript attached pending maintainer opt-in.