### PR TITLE
fix(cli): classify token and tracking errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- CLI: classify malformed OAuth token imports as usage errors and missing Gmail tracking setup as configuration errors.
 - CLI: classify invalid Docs batch IDs and incomplete Gmail filter definitions as usage errors with exit code 2.
 - Docs: keep batch list/show, batch target validation, and batch end dry-runs read-only without creating state directories or lock files.
 - Gmail: make `watch status` read atomic watch state without creating state directories or lock files.

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -124,6 +124,10 @@ gog auth doctor --check --json --no-input
 | 11 | `orphaned` | Requested Docs comment is no longer attached to content |
 | 130 | `cancelled` | Interrupted with Ctrl-C or context cancellation |
 
+Malformed local payloads, such as invalid token-import JSON or timestamps, use
+`usage` (`2`). Commands that cannot run because their required local setup is
+absent or incomplete use `config` (`10`).
+
 The same classifications apply to direct HTTP integrations such as Photos
 Library, Photos Picker, and Places. For example, an expired or deleted Picker
 session returns `not_found` (`5`) instead of a generic error.

--- a/internal/cmd/auth_tokens.go
+++ b/internal/cmd/auth_tokens.go
@@ -265,7 +265,7 @@ func (c *AuthTokensImportCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 	var ex export
 	if unmarshalErr := json.Unmarshal(b, &ex); unmarshalErr != nil {
-		return unmarshalErr
+		return usagef("invalid token JSON: %v", unmarshalErr)
 	}
 	ex.Email = strings.TrimSpace(ex.Email)
 	if ex.Email == "" {
@@ -274,20 +274,12 @@ func (c *AuthTokensImportCmd) Run(ctx context.Context, flags *RootFlags) error {
 	if strings.TrimSpace(ex.RefreshToken) == "" {
 		return usage("missing refresh_token in token file")
 	}
-	clientOverride := authclient.ClientOverrideFromContext(ctx)
-	if strings.TrimSpace(clientOverride) == "" {
-		clientOverride = strings.TrimSpace(ex.Client)
-	}
-	client, err := resolveClientForEmailWithContext(ctx, ex.Email, clientOverride)
-	if err != nil {
-		return err
-	}
 
 	var createdAt time.Time
 	if strings.TrimSpace(ex.CreatedAt) != "" {
 		parsed, parseErr := time.Parse(time.RFC3339, strings.TrimSpace(ex.CreatedAt))
 		if parseErr != nil {
-			return parseErr
+			return usagef("invalid created_at %q (expected RFC3339)", ex.CreatedAt)
 		}
 		createdAt = parsed
 	}
@@ -295,9 +287,18 @@ func (c *AuthTokensImportCmd) Run(ctx context.Context, flags *RootFlags) error {
 	if strings.TrimSpace(ex.AccessTokenExpiresAt) != "" {
 		parsed, parseErr := time.Parse(time.RFC3339, strings.TrimSpace(ex.AccessTokenExpiresAt))
 		if parseErr != nil {
-			return parseErr
+			return usagef("invalid access_token_expires_at %q (expected RFC3339)", ex.AccessTokenExpiresAt)
 		}
 		accessTokenExpiresAt = parsed
+	}
+
+	clientOverride := authclient.ClientOverrideFromContext(ctx)
+	if strings.TrimSpace(clientOverride) == "" {
+		clientOverride = strings.TrimSpace(ex.Client)
+	}
+	client, err := resolveClientForEmailWithContext(ctx, ex.Email, clientOverride)
+	if err != nil {
+		return err
 	}
 
 	if dryRunErr := dryRunExit(ctx, flags, "auth.tokens.import", map[string]any{

--- a/internal/cmd/auth_validation_more_test.go
+++ b/internal/cmd/auth_validation_more_test.go
@@ -186,6 +186,8 @@ func TestAuthTokensImport_ErrorsAndStdin(t *testing.T) {
 	}
 	if err := (&AuthTokensImportCmd{InPath: tmp}).Run(ctx, &RootFlags{}); err == nil {
 		t.Fatalf("expected unmarshal error")
+	} else if ExitCode(err) != 2 || !strings.Contains(err.Error(), "invalid token JSON") {
+		t.Fatalf("unmarshal error = %v, exit = %d", err, ExitCode(err))
 	}
 
 	missing := filepath.Join(t.TempDir(), "missing.json")
@@ -202,9 +204,23 @@ func TestAuthTokensImport_ErrorsAndStdin(t *testing.T) {
 	}
 	if err := (&AuthTokensImportCmd{InPath: badDate}).Run(ctx, &RootFlags{}); err == nil {
 		t.Fatalf("expected date parse error")
+	} else if ExitCode(err) != 2 || !strings.Contains(err.Error(), "invalid created_at") {
+		t.Fatalf("created_at error = %v, exit = %d", err, ExitCode(err))
 	}
 	if err := (&AuthTokensImportCmd{InPath: badDate}).Run(ctx, &RootFlags{DryRun: true}); err == nil {
 		t.Fatalf("expected dry-run date parse error")
+	} else if ExitCode(err) != 2 {
+		t.Fatalf("dry-run created_at exit = %d, err = %v", ExitCode(err), err)
+	}
+
+	badExpiry := filepath.Join(t.TempDir(), "bad-expiry.json")
+	if err := os.WriteFile(badExpiry, []byte(`{"email":"a@b.com","refresh_token":"rt","access_token_expires_at":"bad"}`), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := (&AuthTokensImportCmd{InPath: badExpiry}).Run(ctx, &RootFlags{}); err == nil {
+		t.Fatalf("expected access-token expiry parse error")
+	} else if ExitCode(err) != 2 || !strings.Contains(err.Error(), "invalid access_token_expires_at") {
+		t.Fatalf("access_token_expires_at error = %v, exit = %d", err, ExitCode(err))
 	}
 
 	store := newMemStore()

--- a/internal/cmd/gmail_send.go
+++ b/internal/cmd/gmail_send.go
@@ -222,7 +222,7 @@ func (c *GmailSendCmd) resolveTrackingConfig(ctx context.Context, account string
 	}
 
 	if strings.TrimSpace(htmlBody) == "" {
-		return nil, fmt.Errorf("--track requires an HTML body (use --body-html or --quote)")
+		return nil, usage("--track requires an HTML body (use --body-html or --quote)")
 	}
 
 	trackingCfg, _, _, err := loadTrackingConfig(ctx, account, true)
@@ -230,7 +230,7 @@ func (c *GmailSendCmd) resolveTrackingConfig(ctx context.Context, account string
 		return nil, fmt.Errorf("load tracking config: %w", err)
 	}
 	if !trackingCfg.IsConfigured() {
-		return nil, fmt.Errorf("tracking not configured; run 'gog gmail track setup' first")
+		return nil, trackingConfigError("tracking not configured; run 'gog gmail track setup' first")
 	}
 
 	return trackingCfg, nil

--- a/internal/cmd/gmail_send_tracking_test.go
+++ b/internal/cmd/gmail_send_tracking_test.go
@@ -31,11 +31,15 @@ func TestResolveTrackingConfig(t *testing.T) {
 	cmd.BodyHTML = ""
 	if _, err := cmd.resolveTrackingConfig(ctx, "a@b.com", []string{"a@b.com"}, nil, nil, cmd.BodyHTML); err == nil {
 		t.Fatalf("expected error for missing body html")
+	} else if ExitCode(err) != 2 {
+		t.Fatalf("missing HTML exit = %d, want 2: %v", ExitCode(err), err)
 	}
 
 	cmd.BodyHTML = "<html></html>"
 	if _, err := cmd.resolveTrackingConfig(ctx, "a@b.com", []string{"a@b.com"}, nil, nil, cmd.BodyHTML); err == nil {
 		t.Fatalf("expected error for unconfigured tracking")
+	} else if ExitCode(err) != exitCodeConfig {
+		t.Fatalf("unconfigured tracking exit = %d, want %d: %v", ExitCode(err), exitCodeConfig, err)
 	}
 
 	key, err := tracking.GenerateKey()

--- a/internal/cmd/gmail_track_cmd_test.go
+++ b/internal/cmd/gmail_track_cmd_test.go
@@ -738,6 +738,53 @@ func TestGmailTrackOpens_NotConfigured(t *testing.T) {
 
 	if err := Execute([]string{"--account", "a@b.com", "gmail", "track", "opens"}); err == nil {
 		t.Fatalf("expected error for unconfigured tracking")
+	} else if ExitCode(err) != exitCodeConfig {
+		t.Fatalf("exit = %d, want %d: %v", ExitCode(err), exitCodeConfig, err)
+	}
+}
+
+func TestGmailTrackMissingConfigurationUsesConfigExit(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *tracking.Config
+		args []string
+	}{
+		{
+			name: "opens admin key",
+			cfg:  &tracking.Config{Enabled: true, WorkerURL: "https://example.com", TrackingKey: "track"},
+			args: []string{"gmail", "track", "opens"},
+		},
+		{
+			name: "rotate setup",
+			cfg:  &tracking.Config{},
+			args: []string{"gmail", "track", "key", "rotate", "--no-deploy"},
+		},
+		{
+			name: "rotate admin key",
+			cfg:  &tracking.Config{Enabled: true, WorkerURL: "https://example.com", TrackingKey: "track"},
+			args: []string{"gmail", "track", "key", "rotate", "--no-deploy"},
+		},
+		{
+			name: "rotate worker name",
+			cfg:  &tracking.Config{Enabled: true, WorkerURL: "https://example.com", TrackingKey: "track", AdminKey: "admin"},
+			args: []string{"gmail", "track", "key", "rotate"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setupTrackingEnv(t)
+			saveTrackingConfigForTest(t, tt.cfg)
+
+			args := append([]string{"--account", "a@b.com", "--no-input"}, tt.args...)
+			err := Execute(args)
+			if err == nil {
+				t.Fatalf("expected configuration error")
+			}
+			if ExitCode(err) != exitCodeConfig {
+				t.Fatalf("exit = %d, want %d: %v", ExitCode(err), exitCodeConfig, err)
+			}
+		})
 	}
 }
 

--- a/internal/cmd/gmail_track_helpers.go
+++ b/internal/cmd/gmail_track_helpers.go
@@ -12,6 +12,10 @@ import (
 
 var errTrackingSecretStoreRequired = errors.New("tracking secret store is required")
 
+func trackingConfigError(msg string) error {
+	return &ExitError{Code: exitCodeConfig, Err: errors.New(msg)}
+}
+
 func newTrackingConfigStore(ctx context.Context, secretStore *tracking.SecretStore) (*tracking.ConfigStore, error) {
 	layout, err := commandLayout(ctx, config.PathKindConfig, config.PathKindState)
 	if err != nil {

--- a/internal/cmd/gmail_track_key.go
+++ b/internal/cmd/gmail_track_key.go
@@ -39,10 +39,10 @@ func (c *GmailTrackKeyRotateCmd) Run(ctx context.Context, flags *RootFlags) erro
 		return err
 	}
 	if !cfg.IsConfigured() {
-		return fmt.Errorf("tracking not configured; run 'gog gmail track setup' first")
+		return trackingConfigError("tracking not configured; run 'gog gmail track setup' first")
 	}
 	if strings.TrimSpace(cfg.AdminKey) == "" {
-		return fmt.Errorf("tracking admin key not configured; run 'gog gmail track setup' again")
+		return trackingConfigError("tracking admin key not configured; run 'gog gmail track setup' again")
 	}
 	secretStore, err = ensureTrackingSecretStore(ctx, secretStore)
 	if err != nil {
@@ -86,7 +86,7 @@ func (c *GmailTrackKeyRotateCmd) Run(ctx context.Context, flags *RootFlags) erro
 	if !c.NoDeploy {
 		workerName := strings.TrimSpace(cfg.WorkerName)
 		if workerName == "" {
-			return fmt.Errorf("tracking worker name not configured; run 'gog gmail track setup' again")
+			return trackingConfigError("tracking worker name not configured; run 'gog gmail track setup' again")
 		}
 		dbName := strings.TrimSpace(cfg.DatabaseName)
 		if dbName == "" {

--- a/internal/cmd/gmail_track_opens.go
+++ b/internal/cmd/gmail_track_opens.go
@@ -31,7 +31,7 @@ func (c *GmailTrackOpensCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return err
 	}
 	if !cfg.IsConfigured() {
-		return fmt.Errorf("tracking not configured; run 'gog gmail track setup' first")
+		return trackingConfigError("tracking not configured; run 'gog gmail track setup' first")
 	}
 
 	// Query by tracking ID
@@ -116,7 +116,7 @@ func (c *GmailTrackOpensCmd) queryByTrackingID(ctx context.Context, cfg *trackin
 
 func (c *GmailTrackOpensCmd) queryAdmin(ctx context.Context, cfg *tracking.Config, u *ui.UI) error {
 	if strings.TrimSpace(cfg.AdminKey) == "" {
-		return fmt.Errorf("tracking admin key not configured; run 'gog gmail track setup' again")
+		return trackingConfigError("tracking admin key not configured; run 'gog gmail track setup' again")
 	}
 
 	reqURL, _ := url.Parse(cfg.WorkerURL + "/opens")


### PR DESCRIPTION
## Summary

- classify malformed `auth tokens import` JSON and RFC3339 fields as usage errors (exit 2)
- classify absent/incomplete Gmail tracking setup as configuration errors (exit 10)
- validate token payload timestamps before client/account resolution
- document the stable distinction and add changelog coverage

## Verification

- focused auth/tracking tests
- full `go test ./internal/cmd -count=1`
- `make docs-check`
- full `make ci`
- structured autoreview: clean, no actionable findings
- rebuilt-binary smoke: malformed JSON, `created_at`, and `access_token_expires_at` all exit 2; tracking opens/key paths exit 10
- 556-path isolated replay: zero timeouts; only intended class changes (`auth tokens import` 1→2, `gmail track opens` 1→10); no new file-writing rows
- live `clawdbot@gmail.com` Gmail sender preflight with isolated tracking state: auth valid, real Gmail API path reached, exited 10 before send; no message sent
