### PR TITLE
feat(gmail): add first-class reply commands

### DIFF
--- a/.agents/skills/gog/SKILL.md
+++ b/.agents/skills/gog/SKILL.md
@@ -164,6 +164,19 @@ For larger Sheets writes, prefer `sheets batch-update` over loops of
 `sheets update`; it sends multiple value ranges in one Sheets API request and
 accepts inline JSON or `@file` input.
 
+For normal Gmail replies, use the first-class commands instead of rebuilding
+reply MIME through `gmail send`:
+
+```bash
+gog --account user@example.com gmail reply <messageId> --body-file reply.txt
+gog --account user@example.com gmail reply-all <messageId> --body-file reply.txt \
+  --bcc introducer@example.com --remove former-participant@example.com
+```
+
+They inherit the subject, quote by default, preserve display names and inline
+images, and treat `--to`/`--cc`/`--bcc` as additive placement or moves. Use
+`--no-quote` to omit the original.
+
 ## Discovery
 
 Use generated command docs and schema instead of guessing flags:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.26.1 - Unreleased
 
+### Added
+
+- Gmail: add first-class `gmail reply` and `gmail reply-all` commands with inherited `Re:` subjects, quoted originals by default, preserved display names and CID inline images, additive recipient placement, automatic moves between To/Cc/Bcc, and repeatable `--remove`; reply-mode `gmail send` also inherits omitted subjects, while forwards preserve inline images without incorrectly claiming the original reply thread.
+
 ## 0.26.0 - 2026-06-14
 
 ### Added

--- a/docs/commands.generated.md
+++ b/docs/commands.generated.md
@@ -398,6 +398,8 @@ Generated from `gog schema --json`.
       - [`gog gmail (mail,email) messages (message,msg,msgs) modify (update,edit,set) <messageId> [flags]`](commands/gog-gmail-messages-modify.md) - Modify labels on a single message
       - [`gog gmail (mail,email) messages (message,msg,msgs) search (find,query,ls,list) <query> ... [flags]`](commands/gog-gmail-messages-search.md) - Search messages using Gmail query syntax
     - [`gog gmail (mail,email) raw <messageId> [flags]`](commands/gog-gmail-raw.md) - Dump raw Gmail API response as JSON (Users.Messages.Get; lossless; for scripting and LLM consumption)
+    - [`gog gmail (mail,email) reply <messageId> [flags]`](commands/gog-gmail-reply.md) - Reply to a message
+    - [`gog gmail (mail,email) reply-all (replyall) <messageId> [flags]`](commands/gog-gmail-reply-all.md) - Reply to all message participants
     - [`gog gmail (mail,email) search (find,query,ls,list) <query> ... [flags]`](commands/gog-gmail-search.md) - Search threads using Gmail query syntax
     - [`gog gmail (mail,email) send [flags]`](commands/gog-gmail-send.md) - Send an email
     - [`gog gmail (mail,email) settings <command>`](commands/gog-gmail-settings.md) - Settings and admin

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -2,7 +2,7 @@
 
 Every `gog` command has a generated docs page. The source of truth is the live CLI schema; run `make docs-commands` after changing command names, flags, help text, aliases, or arguments.
 
-Generated pages: 642.
+Generated pages: 644.
 
 ## Top-level Commands
 
@@ -449,6 +449,8 @@ Generated pages: 642.
       - [gog gmail messages modify](gog-gmail-messages-modify.md) - Modify labels on a single message
       - [gog gmail messages search](gog-gmail-messages-search.md) - Search messages using Gmail query syntax
     - [gog gmail raw](gog-gmail-raw.md) - Dump raw Gmail API response as JSON (Users.Messages.Get; lossless; for scripting and LLM consumption)
+    - [gog gmail reply](gog-gmail-reply.md) - Reply to a message
+    - [gog gmail reply-all](gog-gmail-reply-all.md) - Reply to all message participants
     - [gog gmail search](gog-gmail-search.md) - Search threads using Gmail query syntax
     - [gog gmail send](gog-gmail-send.md) - Send an email
     - [gog gmail settings](gog-gmail-settings.md) - Settings and admin

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -2,7 +2,7 @@
 
 Every `gog` command has a generated docs page. The source of truth is the live CLI schema; run `make docs-commands` after changing command names, flags, help text, aliases, or arguments.
 
-Generated pages: 644.
+Generated pages: 646.
 
 ## Top-level Commands
 

--- a/docs/commands/gog-gmail-reply-all.md
+++ b/docs/commands/gog-gmail-reply-all.md
@@ -1,13 +1,13 @@
-# `gog gmail send`
+# `gog gmail reply-all`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Send an email
+Reply to all message participants
 
 ## Usage
 
 ```bash
-gog gmail (mail,email) send [flags]
+gog gmail (mail,email) reply-all (replyall) <messageId> [flags]
 ```
 
 ## Parent
@@ -21,12 +21,12 @@ gog gmail (mail,email) send [flags]
 | `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email, alias, or auto for authenticated Google API commands |
 | `--attach` | `[]string` |  | Attachment file path (repeatable) |
-| `--bcc` | `string` |  | BCC recipients (comma-separated) |
+| `--bcc` | `[]string` |  | Add or move recipients to Bcc (repeatable) |
 | `--body` | `string` |  | Body (plain text; required unless --body-html is set) |
 | `--body-file` | `string` |  | Body file path (plain text; '-' for stdin) |
 | `--body-html` | `string` |  | Body (HTML; optional) |
 | `--body-html-file` | `string` |  | HTML body file path ('-' for stdin) |
-| `--cc` | `string` |  | CC recipients (comma-separated) |
+| `--cc` | `[]string` |  | Add or move recipients to Cc (repeatable) |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
@@ -40,21 +40,16 @@ gog gmail (mail,email) send [flags]
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `--no-quote` | `bool` |  | Do not include the original message below the reply |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
-| `--quote` | `bool` |  | Include quoted original message in reply (requires --reply-to-message-id or --thread-id) |
-| `--reply-all` | `bool` |  | Auto-populate recipients from original message (requires --reply-to-message-id or --thread-id) |
-| `--reply-to` | `string` |  | Reply-To header address |
-| `--reply-to-message-id`<br>`--in-reply-to` | `string` |  | Reply to Gmail message ID (sets In-Reply-To/References and thread) |
+| `--remove` | `[]string` |  | Remove recipients from all fields (repeatable) |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
 | `--signature` | `bool` |  | Append the Gmail signature from the active send-as address |
 | `--signature-file` | `string` |  | Append a local signature file (plain text or HTML) |
 | `--signature-from` | `string` |  | Append the Gmail signature from this send-as email address |
-| `--subject` | `string` |  | Subject (required unless replying; inherited with Re: for replies) |
-| `--thread-id` | `string` |  | Reply within a Gmail thread (uses latest message for headers) |
-| `--to` | `string` |  | Recipients (comma-separated; required unless --reply-all is used) |
-| `--track` | `bool` |  | Enable open tracking (requires tracking setup) |
-| `--track-split` | `bool` |  | Send tracked messages separately per recipient |
+| `--subject` | `string` |  | Override reply subject (a changed subject starts a new Gmail thread) |
+| `--to` | `[]string` |  | Add or move recipients to To (repeatable) |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |
 | `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |

--- a/docs/commands/gog-gmail-reply.md
+++ b/docs/commands/gog-gmail-reply.md
@@ -1,13 +1,13 @@
-# `gog gmail send`
+# `gog gmail reply`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Send an email
+Reply to a message
 
 ## Usage
 
 ```bash
-gog gmail (mail,email) send [flags]
+gog gmail (mail,email) reply <messageId> [flags]
 ```
 
 ## Parent
@@ -21,12 +21,12 @@ gog gmail (mail,email) send [flags]
 | `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email, alias, or auto for authenticated Google API commands |
 | `--attach` | `[]string` |  | Attachment file path (repeatable) |
-| `--bcc` | `string` |  | BCC recipients (comma-separated) |
+| `--bcc` | `[]string` |  | Add or move recipients to Bcc (repeatable) |
 | `--body` | `string` |  | Body (plain text; required unless --body-html is set) |
 | `--body-file` | `string` |  | Body file path (plain text; '-' for stdin) |
 | `--body-html` | `string` |  | Body (HTML; optional) |
 | `--body-html-file` | `string` |  | HTML body file path ('-' for stdin) |
-| `--cc` | `string` |  | CC recipients (comma-separated) |
+| `--cc` | `[]string` |  | Add or move recipients to Cc (repeatable) |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
@@ -40,21 +40,16 @@ gog gmail (mail,email) send [flags]
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `--no-quote` | `bool` |  | Do not include the original message below the reply |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
-| `--quote` | `bool` |  | Include quoted original message in reply (requires --reply-to-message-id or --thread-id) |
-| `--reply-all` | `bool` |  | Auto-populate recipients from original message (requires --reply-to-message-id or --thread-id) |
-| `--reply-to` | `string` |  | Reply-To header address |
-| `--reply-to-message-id`<br>`--in-reply-to` | `string` |  | Reply to Gmail message ID (sets In-Reply-To/References and thread) |
+| `--remove` | `[]string` |  | Remove recipients from all fields (repeatable) |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
 | `--signature` | `bool` |  | Append the Gmail signature from the active send-as address |
 | `--signature-file` | `string` |  | Append a local signature file (plain text or HTML) |
 | `--signature-from` | `string` |  | Append the Gmail signature from this send-as email address |
-| `--subject` | `string` |  | Subject (required unless replying; inherited with Re: for replies) |
-| `--thread-id` | `string` |  | Reply within a Gmail thread (uses latest message for headers) |
-| `--to` | `string` |  | Recipients (comma-separated; required unless --reply-all is used) |
-| `--track` | `bool` |  | Enable open tracking (requires tracking setup) |
-| `--track-split` | `bool` |  | Send tracked messages separately per recipient |
+| `--subject` | `string` |  | Override reply subject (a changed subject starts a new Gmail thread) |
+| `--to` | `[]string` |  | Add or move recipients to To (repeatable) |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |
 | `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |

--- a/docs/commands/gog-gmail.md
+++ b/docs/commands/gog-gmail.md
@@ -28,6 +28,8 @@ gog gmail (mail,email) <command> [flags]
 - [gog gmail mark-read](gog-gmail-mark-read.md) - Mark messages as read
 - [gog gmail messages](gog-gmail-messages.md) - Message operations
 - [gog gmail raw](gog-gmail-raw.md) - Dump raw Gmail API response as JSON (Users.Messages.Get; lossless; for scripting and LLM consumption)
+- [gog gmail reply](gog-gmail-reply.md) - Reply to a message
+- [gog gmail reply-all](gog-gmail-reply-all.md) - Reply to all message participants
 - [gog gmail search](gog-gmail-search.md) - Search threads using Gmail query syntax
 - [gog gmail send](gog-gmail-send.md) - Send an email
 - [gog gmail settings](gog-gmail-settings.md) - Settings and admin

--- a/docs/commands/gog-send.md
+++ b/docs/commands/gog-send.md
@@ -50,7 +50,7 @@ gog send [flags]
 | `--signature` | `bool` |  | Append the Gmail signature from the active send-as address |
 | `--signature-file` | `string` |  | Append a local signature file (plain text or HTML) |
 | `--signature-from` | `string` |  | Append the Gmail signature from this send-as email address |
-| `--subject` | `string` |  | Subject (required) |
+| `--subject` | `string` |  | Subject (required unless replying; inherited with Re: for replies) |
 | `--thread-id` | `string` |  | Reply within a Gmail thread (uses latest message for headers) |
 | `--to` | `string` |  | Recipients (comma-separated; required unless --reply-all is used) |
 | `--track` | `bool` |  | Enable open tracking (requires tracking setup) |

--- a/docs/gmail-workflows.md
+++ b/docs/gmail-workflows.md
@@ -66,6 +66,59 @@ For account-specific send blocking, use the no-send config commands:
 - [`gog config no-send list`](commands/gog-config-no-send-list.md)
 - [`gog config no-send remove`](commands/gog-config-no-send-remove.md)
 
+## Reply and Reply All
+
+The Gmail API has no reply method. Clients fetch the original message, build a
+complete RFC MIME message, and call `messages.send`. Use the first-class reply
+commands so gog owns that composition work:
+
+```bash
+gog gmail reply <messageId> --body-file reply.txt
+gog gmail reply-all <messageId> --body-file reply.txt \
+  --bcc '"Introducer" <introducer@example.com>'
+```
+
+Reply defaults match normal Gmail composition:
+
+- The original subject is inherited with one `Re:` prefix.
+- The original message is quoted; use `--no-quote` to omit it.
+- `reply` targets `Reply-To` when present, otherwise `From`.
+- `reply-all` also carries forward original To/Cc recipients while excluding
+  the active account and its send-as aliases.
+- Display names are preserved.
+- CID-backed inline images referenced by quoted HTML are fetched and rebuilt
+  as `multipart/related`. If a referenced MIME part is missing, the command
+  fails instead of sending broken images.
+
+Recipient flags modify the derived recipient set. `--to`, `--cc`, and `--bcc`
+are additive; naming an inherited recipient in a different field moves it
+there. Repeat `--remove` to subtract recipients from every field:
+
+```bash
+gog gmail reply-all <messageId> --body "Thanks all" \
+  --bcc introducer@example.com \
+  --remove former-participant@example.com
+```
+
+An explicit `--subject` override is supported. A changed subject cannot meet
+Gmail's thread-matching requirement, so gog keeps the RFC reply headers but
+does not force the original `threadId`; Gmail creates a new conversation.
+
+Remote HTTP images remain remote references. Only MIME parts referenced with
+`cid:` are copied into the outgoing message.
+
+`gmail send --reply-to-message-id` remains available as lower-level
+composition. It now inherits an omitted subject, but its explicit `--to` and
+`--cc` values retain replacement semantics and quoting remains opt-in. Prefer
+`gmail reply` or `gmail reply-all` for ordinary replies.
+
+Official behavior references:
+
+- [Gmail API: Manage threads](https://developers.google.com/workspace/gmail/api/guides/threads)
+- [Gmail API: Create and send messages](https://developers.google.com/workspace/gmail/api/guides/sending)
+- [RFC 2387: multipart/related](https://www.rfc-editor.org/rfc/rfc2387.html)
+- [RFC 2392: Content-ID URLs](https://www.rfc-editor.org/rfc/rfc2392)
+
 ## Attachment Confirmation
 
 `gmail send --json` and `gmail drafts create|update --json` include an

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -379,13 +379,15 @@ after the bounded retry window, the command exits with retryable code `8`.
 - `gog gmail get <messageId> [--format full|metadata|raw] [--headers ...]`
 - `gog gmail attachment <messageId> <attachmentId> [--out PATH] [--name NAME]`
 - `gog gmail url <threadIds...>`
+- `gog gmail reply <messageId> [--body B|--body-file PATH|--body-html HTML|--body-html-file PATH] [--to ...] [--cc ...] [--bcc ...] [--remove ...] [--subject S] [--no-quote] [--from addr] [--signature|--signature-from addr|--signature-file path] [--attach <file>...]`
+- `gog gmail reply-all <messageId> [--body B|--body-file PATH|--body-html HTML|--body-html-file PATH] [--to ...] [--cc ...] [--bcc ...] [--remove ...] [--subject S] [--no-quote] [--from addr] [--signature|--signature-from addr|--signature-file path] [--attach <file>...]`
 - `gog gmail forward <messageId> --to a@b.com [--cc ...] [--bcc ...] [--note TEXT|--note-file PATH] [--from addr] [--skip-attachments]`
 - `gog gmail labels list`
 - `gog gmail labels get <labelIdOrName>`
 - `gog gmail labels create <name>`
 - `gog gmail labels rename <labelIdOrName> <newName>`
 - `gog gmail labels modify <threadIds...> [--add ...] [--remove ...]`
-- `gog gmail send --to a@b.com --subject S [--body B|--body-file PATH] [--body-html H|--body-html-file PATH] [--cc ...] [--bcc ...] [--reply-to-message-id <messageId>] [--reply-to addr] [--from addr] [--signature|--signature-from addr|--signature-file path] [--attach <file>...]`
+- `gog gmail send --to a@b.com [--subject S] [--body B|--body-file PATH] [--body-html H|--body-html-file PATH] [--cc ...] [--bcc ...] [--reply-to-message-id <messageId>] [--reply-to addr] [--from addr] [--signature|--signature-from addr|--signature-file path] [--attach <file>...]`
 - `gog gmail drafts list [--max N] [--page TOKEN]`
 - `gog gmail drafts get <draftId> [--download]`
 - `gog gmail drafts create --subject S [--to a@b.com] [--body B] [--body-html H] [--cc ...] [--bcc ...] [--reply-to-message-id <messageId>] [--reply-to addr] [--attach <file>...]`

--- a/internal/cmd/execute_gmail_forward_test.go
+++ b/internal/cmd/execute_gmail_forward_test.go
@@ -129,14 +129,13 @@ func TestExecute_GmailForward_Basic(t *testing.T) {
 		t.Errorf("expected original body content in forwarded message")
 	}
 
-	// Verify thread ID was set (stays in original thread).
-	if sentThreadID != "thread-1" {
-		t.Errorf("expected threadId=thread-1, got %q", sentThreadID)
+	// A forward changes the subject, so it must not claim the original Gmail
+	// thread or stamp reply headers.
+	if sentThreadID != "" {
+		t.Errorf("expected no threadId for forward, got %q", sentThreadID)
 	}
-
-	// Verify In-Reply-To header references original Message-ID.
-	if !strings.Contains(sentRaw, "In-Reply-To: <orig-123@example.com>") {
-		t.Errorf("expected In-Reply-To header referencing original message")
+	if strings.Contains(sentRaw, "In-Reply-To:") || strings.Contains(sentRaw, "References:") {
+		t.Errorf("forward unexpectedly contains reply headers")
 	}
 }
 

--- a/internal/cmd/execute_gmail_send_reply_test.go
+++ b/internal/cmd/execute_gmail_send_reply_test.go
@@ -99,6 +99,9 @@ func TestExecute_GmailSend_ReplyToMessageID(t *testing.T) {
 			if !strings.Contains(s, "References: <ref0> <orig@id>\r\n") {
 				t.Fatalf("missing References in raw:\n%s", s)
 			}
+			if !strings.Contains(s, "Subject: Re: Original Subject\r\n") {
+				t.Fatalf("missing inherited reply subject in raw:\n%s", s)
+			}
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]any{"id": "s1", "threadId": "t0"})
 			return
@@ -115,7 +118,6 @@ func TestExecute_GmailSend_ReplyToMessageID(t *testing.T) {
 		"--account", "a@b.com",
 		"gmail", "send",
 		"--to", "x@y.com",
-		"--subject", "S",
 		"--body", "B",
 		"--reply-to-message-id", "m0",
 	}, svc)

--- a/internal/cmd/gmail.go
+++ b/internal/cmd/gmail.go
@@ -18,6 +18,8 @@ type GmailCmd struct {
 	Trash   GmailTrashMsgCmd `cmd:"" name:"trash" group:"Organize" help:"Move messages to trash"`
 
 	Send      GmailSendCmd      `cmd:"" name:"send" group:"Write" help:"Send an email"`
+	Reply     GmailReplyCmd     `cmd:"" name:"reply" group:"Write" help:"Reply to a message"`
+	ReplyAll  GmailReplyAllCmd  `cmd:"" name:"reply-all" aliases:"replyall" group:"Write" help:"Reply to all message participants"`
 	Forward   GmailForwardCmd   `cmd:"" name:"forward" aliases:"fwd" group:"Write" help:"Forward a message to new recipients"`
 	AutoReply GmailAutoReplyCmd `cmd:"" name:"autoreply" group:"Write" help:"Reply once to matching messages"`
 	Track     GmailTrackCmd     `cmd:"" name:"track" group:"Write" help:"Email open tracking"`

--- a/internal/cmd/gmail_drafts.go
+++ b/internal/cmd/gmail_drafts.go
@@ -308,6 +308,7 @@ func buildDraftMessage(ctx context.Context, svc *gmail.Service, account string, 
 	threadID := info.ThreadID
 	atts := attachmentsFromPaths(input.Attach)
 	atts = append(atts, input.PrebuiltAttachments...)
+	atts = append(atts, info.InlineResources...)
 	atts, attachmentMetadata, err := prepareMailAttachments(atts)
 	if err != nil {
 		return nil, "", nil, err

--- a/internal/cmd/gmail_forward.go
+++ b/internal/cmd/gmail_forward.go
@@ -87,26 +87,12 @@ func (c *GmailForwardCmd) Run(ctx context.Context, flags *RootFlags) error {
 		fwdHTML = formatForwardedMessageHTML(note, origFrom, origDate, origSubject, origTo, origCc, origHTML)
 	}
 
-	// Download and re-attach original attachments.
-	var attachments []mailAttachment
-	if !c.SkipAttachments {
-		origAtts := collectAttachments(origMsg.Payload)
-		for _, att := range origAtts {
-			data, dlErr := fetchAttachmentBytes(ctx, svc, messageID, att.AttachmentID)
-			if dlErr != nil {
-				return fmt.Errorf("download attachment %q: %w", att.Filename, dlErr)
-			}
-			attachments = append(attachments, mailAttachment{
-				Filename: att.Filename,
-				MIMEType: att.MimeType,
-				Data:     data,
-				DataSet:  true,
-			})
-		}
+	// Preserve CID-backed inline resources required by the forwarded HTML and,
+	// unless disabled, ordinary attachments.
+	attachments, err := preserveForwardMessageParts(ctx, svc, messageID, origMsg.Payload, origHTML, !c.SkipAttachments)
+	if err != nil {
+		return fmt.Errorf("preserve forwarded message parts: %w", err)
 	}
-
-	// Build threading info to keep the forward in the sender's thread.
-	info := replyInfoFromMessage(origMsg, false)
 
 	ccRecipients := splitCSV(c.Cc)
 	bccRecipients := splitCSV(c.Bcc)
@@ -116,7 +102,6 @@ func (c *GmailForwardCmd) Run(ctx context.Context, flags *RootFlags) error {
 		Subject:     fwdSubject,
 		Body:        fwdPlain,
 		BodyHTML:    fwdHTML,
-		ReplyInfo:   info,
 		Attachments: attachments,
 	}, sendBatch{
 		To:  toRecipients,

--- a/internal/cmd/gmail_inline.go
+++ b/internal/cmd/gmail_inline.go
@@ -15,8 +15,8 @@ import (
 )
 
 var (
-	cidReferencePattern    = regexp.MustCompile(`(?i)cid:([^"'[:space:]<>\),]+)`)
-	cidCSSReferencePattern = regexp.MustCompile(`(?i)url\(\s*['"]?cid:([^"'[:space:]<>\)]+)['"]?\s*\)`)
+	cidSrcsetReferencePattern = regexp.MustCompile(`(?i)(?:^|,)\s*cid:([^"'[:space:]<>\),]+)`)
+	cidCSSReferencePattern    = regexp.MustCompile(`(?i)url\(\s*['"]?cid:([^"'[:space:]<>\)]+)['"]?\s*\)`)
 )
 
 var cidURLAttributes = map[string]struct{}{
@@ -115,7 +115,7 @@ func referencedContentIDs(htmlBody string) []string {
 				case name == "style":
 					candidates = append(candidates, contentIDsFromMatches(cidCSSReferencePattern.FindAllStringSubmatch(attr.Val, -1))...)
 				case isCIDURLAttribute(attr):
-					candidates = append(candidates, contentIDsFromMatches(cidReferencePattern.FindAllStringSubmatch(attr.Val, -1))...)
+					candidates = append(candidates, contentIDsFromURLAttribute(attr)...)
 				}
 			}
 			if strings.EqualFold(node.Data, "style") {
@@ -163,13 +163,28 @@ func contentIDsFromMatches(matches [][]string) []string {
 	return out
 }
 
+func contentIDsFromURLAttribute(attr nethtml.Attribute) []string {
+	value := strings.TrimSpace(attr.Val)
+	if cidURLAttributeName(attr) == "srcset" {
+		return contentIDsFromMatches(cidSrcsetReferencePattern.FindAllStringSubmatch(value, -1))
+	}
+	if len(value) < len("cid:") || !strings.EqualFold(value[:len("cid:")], "cid:") {
+		return nil
+	}
+	return []string{strings.TrimSpace(value[len("cid:"):])}
+}
+
 func isCIDURLAttribute(attr nethtml.Attribute) bool {
+	_, ok := cidURLAttributes[cidURLAttributeName(attr)]
+	return ok
+}
+
+func cidURLAttributeName(attr nethtml.Attribute) string {
 	name := strings.ToLower(attr.Key)
 	if attr.Namespace != "" {
 		name = strings.ToLower(attr.Namespace) + ":" + name
 	}
-	_, ok := cidURLAttributes[name]
-	return ok
+	return name
 }
 
 func indexMessagePartsByContentID(payload *gmail.MessagePart) map[string]*gmail.MessagePart {

--- a/internal/cmd/gmail_inline.go
+++ b/internal/cmd/gmail_inline.go
@@ -1,0 +1,191 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"mime"
+	"net/url"
+	"regexp"
+	"strings"
+
+	"google.golang.org/api/gmail/v1"
+)
+
+var cidReferencePattern = regexp.MustCompile(`(?i)cid:([^"'[:space:]<>\)]+)`)
+
+func preserveReferencedInlineResources(ctx context.Context, svc *gmail.Service, messageID string, payload *gmail.MessagePart, htmlBody string) ([]mailAttachment, error) {
+	references := referencedContentIDs(htmlBody)
+	if len(references) == 0 {
+		return nil, nil
+	}
+
+	parts := indexMessagePartsByContentID(payload)
+	out := make([]mailAttachment, 0, len(references))
+	for _, contentID := range references {
+		part := parts[canonicalContentID(contentID)]
+		if part == nil {
+			return nil, fmt.Errorf("HTML references cid:%s but the message has no matching MIME part", contentID)
+		}
+		attachment, err := mailAttachmentFromMessagePart(ctx, svc, messageID, part)
+		if err != nil {
+			return nil, fmt.Errorf("load cid:%s: %w", contentID, err)
+		}
+		attachment.Inline = true
+		attachment.ContentID = normalizeContentID(headerValue(part, "Content-ID"))
+		attachment.ContentLocation = strings.TrimSpace(headerValue(part, "Content-Location"))
+		out = append(out, attachment)
+	}
+	return out, nil
+}
+
+func preserveForwardMessageParts(ctx context.Context, svc *gmail.Service, messageID string, payload *gmail.MessagePart, htmlBody string, includeAttachments bool) ([]mailAttachment, error) {
+	inline, err := preserveReferencedInlineResources(ctx, svc, messageID, payload, htmlBody)
+	if err != nil {
+		return nil, err
+	}
+	if !includeAttachments {
+		return inline, nil
+	}
+
+	inlineIDs := make(map[string]struct{}, len(inline))
+	for _, attachment := range inline {
+		inlineIDs[canonicalContentID(attachment.ContentID)] = struct{}{}
+	}
+
+	out := append([]mailAttachment{}, inline...)
+	var walk func(*gmail.MessagePart) error
+	walk = func(part *gmail.MessagePart) error {
+		if part == nil {
+			return nil
+		}
+		contentID := canonicalContentID(headerValue(part, "Content-ID"))
+		if _, ok := inlineIDs[contentID]; ok && contentID != "" {
+			return nil
+		}
+		if isOrdinaryAttachmentPart(part) {
+			attachment, loadErr := mailAttachmentFromMessagePart(ctx, svc, messageID, part)
+			if loadErr != nil {
+				return fmt.Errorf("load attachment %q: %w", part.Filename, loadErr)
+			}
+			out = append(out, attachment)
+			return nil
+		}
+		for _, child := range part.Parts {
+			if walkErr := walk(child); walkErr != nil {
+				return walkErr
+			}
+		}
+		return nil
+	}
+	if err := walk(payload); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func referencedContentIDs(htmlBody string) []string {
+	matches := cidReferencePattern.FindAllStringSubmatch(htmlBody, -1)
+	out := make([]string, 0, len(matches))
+	seen := make(map[string]struct{}, len(matches))
+	for _, match := range matches {
+		if len(match) < 2 {
+			continue
+		}
+		contentID := match[1]
+		if decoded, err := url.PathUnescape(contentID); err == nil {
+			contentID = decoded
+		}
+		contentID = normalizeContentID(contentID)
+		key := canonicalContentID(contentID)
+		if key == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, contentID)
+	}
+	return out
+}
+
+func indexMessagePartsByContentID(payload *gmail.MessagePart) map[string]*gmail.MessagePart {
+	out := make(map[string]*gmail.MessagePart)
+	var walk func(*gmail.MessagePart)
+	walk = func(part *gmail.MessagePart) {
+		if part == nil {
+			return
+		}
+		if contentID := canonicalContentID(headerValue(part, "Content-ID")); contentID != "" {
+			if _, exists := out[contentID]; !exists {
+				out[contentID] = part
+			}
+		}
+		for _, child := range part.Parts {
+			walk(child)
+		}
+	}
+	walk(payload)
+	return out
+}
+
+func mailAttachmentFromMessagePart(ctx context.Context, svc *gmail.Service, messageID string, part *gmail.MessagePart) (mailAttachment, error) {
+	if part == nil || part.Body == nil {
+		return mailAttachment{}, fmt.Errorf("empty MIME part")
+	}
+
+	var (
+		data []byte
+		err  error
+	)
+	switch {
+	case strings.TrimSpace(part.Body.AttachmentId) != "":
+		data, err = fetchAttachmentBytes(ctx, svc, messageID, part.Body.AttachmentId)
+	case part.Body.Data != "":
+		data, err = decodeBase64URLBytes(part.Body.Data)
+	case part.Body.Size == 0:
+		data = []byte{}
+	default:
+		err = fmt.Errorf("MIME part has no body data")
+	}
+	if err != nil {
+		return mailAttachment{}, err
+	}
+
+	fallbackFilename := defaultAttachmentFilename
+	if canonicalContentID(headerValue(part, "Content-ID")) != "" {
+		fallbackFilename = "inline"
+	}
+	filename := sanitizeAttachmentFilename(part.Filename, fallbackFilename)
+	return mailAttachment{
+		Filename: filename,
+		MIMEType: strings.TrimSpace(part.MimeType),
+		Data:     data,
+		DataSet:  true,
+	}, nil
+}
+
+func isOrdinaryAttachmentPart(part *gmail.MessagePart) bool {
+	if part == nil || part.Body == nil {
+		return false
+	}
+	if strings.TrimSpace(part.Body.AttachmentId) != "" {
+		return true
+	}
+	if part.Body.Data == "" && part.Body.Size != 0 {
+		return false
+	}
+	if strings.TrimSpace(part.Filename) != "" {
+		return true
+	}
+	disposition, _, err := mime.ParseMediaType(headerValue(part, "Content-Disposition"))
+	return err == nil && strings.EqualFold(disposition, "attachment")
+}
+
+func normalizeContentID(value string) string {
+	return strings.Trim(strings.TrimSpace(value), "<>")
+}
+
+func canonicalContentID(value string) string {
+	return strings.ToLower(normalizeContentID(value))
+}

--- a/internal/cmd/gmail_inline.go
+++ b/internal/cmd/gmail_inline.go
@@ -8,12 +8,26 @@ import (
 	"regexp"
 	"strings"
 
+	nethtml "golang.org/x/net/html"
 	"google.golang.org/api/gmail/v1"
 
 	"github.com/steipete/gogcli/internal/mailmime"
 )
 
-var cidReferencePattern = regexp.MustCompile(`(?i)cid:([^"'[:space:]<>\)]+)`)
+var (
+	cidReferencePattern    = regexp.MustCompile(`(?i)cid:([^"'[:space:]<>\),]+)`)
+	cidCSSReferencePattern = regexp.MustCompile(`(?i)url\(\s*['"]?cid:([^"'[:space:]<>\)]+)['"]?\s*\)`)
+)
+
+var cidURLAttributes = map[string]struct{}{
+	"background": {},
+	"data":       {},
+	"href":       {},
+	"poster":     {},
+	"src":        {},
+	"srcset":     {},
+	"xlink:href": {},
+}
 
 func preserveReferencedInlineResources(ctx context.Context, svc *gmail.Service, messageID string, payload *gmail.MessagePart, htmlBody string) ([]mailmime.Attachment, error) {
 	references := referencedContentIDs(htmlBody)
@@ -86,15 +100,42 @@ func preserveForwardMessageParts(ctx context.Context, svc *gmail.Service, messag
 }
 
 func referencedContentIDs(htmlBody string) []string {
-	matches := cidReferencePattern.FindAllStringSubmatch(htmlBody, -1)
-	out := make([]string, 0, len(matches))
-	seen := make(map[string]struct{}, len(matches))
-	for _, match := range matches {
-		if len(match) < 2 {
-			continue
+	doc, err := nethtml.Parse(strings.NewReader(htmlBody))
+	if err != nil {
+		return nil
+	}
+
+	var candidates []string
+	var walk func(*nethtml.Node)
+	walk = func(node *nethtml.Node) {
+		if node.Type == nethtml.ElementNode {
+			for _, attr := range node.Attr {
+				name := strings.ToLower(attr.Key)
+				switch {
+				case name == "style":
+					candidates = append(candidates, contentIDsFromMatches(cidCSSReferencePattern.FindAllStringSubmatch(attr.Val, -1))...)
+				case isCIDURLAttribute(attr):
+					candidates = append(candidates, contentIDsFromMatches(cidReferencePattern.FindAllStringSubmatch(attr.Val, -1))...)
+				}
+			}
+			if strings.EqualFold(node.Data, "style") {
+				for child := node.FirstChild; child != nil; child = child.NextSibling {
+					if child.Type == nethtml.TextNode {
+						candidates = append(candidates, contentIDsFromMatches(cidCSSReferencePattern.FindAllStringSubmatch(child.Data, -1))...)
+					}
+				}
+			}
 		}
-		contentID := match[1]
-		if decoded, err := url.PathUnescape(contentID); err == nil {
+		for child := node.FirstChild; child != nil; child = child.NextSibling {
+			walk(child)
+		}
+	}
+	walk(doc)
+
+	out := make([]string, 0, len(candidates))
+	seen := make(map[string]struct{}, len(candidates))
+	for _, contentID := range candidates {
+		if decoded, decodeErr := url.PathUnescape(contentID); decodeErr == nil {
 			contentID = decoded
 		}
 		contentID = normalizeContentID(contentID)
@@ -109,6 +150,26 @@ func referencedContentIDs(htmlBody string) []string {
 		out = append(out, contentID)
 	}
 	return out
+}
+
+func contentIDsFromMatches(matches [][]string) []string {
+	out := make([]string, 0, len(matches))
+	for _, match := range matches {
+		if len(match) < 2 {
+			continue
+		}
+		out = append(out, match[1])
+	}
+	return out
+}
+
+func isCIDURLAttribute(attr nethtml.Attribute) bool {
+	name := strings.ToLower(attr.Key)
+	if attr.Namespace != "" {
+		name = strings.ToLower(attr.Namespace) + ":" + name
+	}
+	_, ok := cidURLAttributes[name]
+	return ok
 }
 
 func indexMessagePartsByContentID(payload *gmail.MessagePart) map[string]*gmail.MessagePart {

--- a/internal/cmd/gmail_mime.go
+++ b/internal/cmd/gmail_mime.go
@@ -19,11 +19,14 @@ import (
 )
 
 type mailAttachment struct {
-	Path     string
-	Filename string
-	MIMEType string
-	Data     []byte
-	DataSet  bool
+	Path            string
+	Filename        string
+	MIMEType        string
+	Data            []byte
+	DataSet         bool
+	Inline          bool
+	ContentID       string
+	ContentLocation string
 }
 
 type mailAttachmentMetadata struct {
@@ -138,78 +141,139 @@ func buildRFC822(opts mailOptions, cfg *rfc822Config) ([]byte, error) {
 	if prepareErr != nil {
 		return nil, prepareErr
 	}
+	inlineAttachments, regularAttachments := splitInlineAttachments(attachments)
 
-	if len(opts.Attachments) == 0 {
-		switch {
-		case hasPlain && hasHTML:
-			altBoundary, err := randomBoundary()
-			if err != nil {
+	switch {
+	case len(inlineAttachments) == 0 && len(regularAttachments) == 0:
+		if err := writeBodyEntity(&b, plainBody, htmlBody, hasPlain, hasHTML); err != nil {
+			return nil, err
+		}
+	case len(regularAttachments) == 0:
+		if err := writeRelatedEntity(&b, plainBody, htmlBody, hasPlain, hasHTML, inlineAttachments); err != nil {
+			return nil, err
+		}
+	default:
+		mixedBoundary, err := randomBoundary()
+		if err != nil {
+			return nil, err
+		}
+		writeHeader(&b, "Content-Type", fmt.Sprintf("multipart/mixed; boundary=%q", mixedBoundary))
+		b.WriteString("\r\n")
+
+		fmt.Fprintf(&b, "--%s\r\n", mixedBoundary)
+		if len(inlineAttachments) > 0 {
+			if err := writeRelatedEntity(&b, plainBody, htmlBody, hasPlain, hasHTML, inlineAttachments); err != nil {
 				return nil, err
 			}
-			writeHeader(&b, "Content-Type", fmt.Sprintf("multipart/alternative; boundary=%q", altBoundary))
-			b.WriteString("\r\n")
+		} else if err := writeBodyEntity(&b, plainBody, htmlBody, hasPlain, hasHTML); err != nil {
+			return nil, err
+		}
 
-			writeTextPart(&b, altBoundary, "text/plain; charset=\"utf-8\"", plainBody)
-			writeTextPart(&b, altBoundary, "text/html; charset=\"utf-8\"", htmlBody)
-			fmt.Fprintf(&b, "--%s--\r\n", altBoundary)
-			return b.Bytes(), nil
-		case hasHTML && !hasPlain:
-			writeHeader(&b, "Content-Type", "text/html; charset=\"utf-8\"")
-			writeHeader(&b, "Content-Transfer-Encoding", textTransferEncoding(htmlBody))
-			b.WriteString("\r\n")
-			writeBodyWithTrailingCRLF(&b, htmlBody)
-			return b.Bytes(), nil
-		default:
-			writeHeader(&b, "Content-Type", "text/plain; charset=\"utf-8\"")
-			writeHeader(&b, "Content-Transfer-Encoding", "quoted-printable")
-			b.WriteString("\r\n")
-			writeQuotedPrintableBody(&b, plainBody)
-			return b.Bytes(), nil
+		for _, attachment := range regularAttachments {
+			fmt.Fprintf(&b, "\r\n--%s\r\n", mixedBoundary)
+			if err := writeAttachmentEntity(&b, attachment); err != nil {
+				return nil, err
+			}
+		}
+		fmt.Fprintf(&b, "--%s--\r\n", mixedBoundary)
+	}
+	return b.Bytes(), nil
+}
+
+func splitInlineAttachments(attachments []mailAttachment) (inline, regular []mailAttachment) {
+	for _, attachment := range attachments {
+		if attachment.Inline {
+			inline = append(inline, attachment)
+		} else {
+			regular = append(regular, attachment)
 		}
 	}
+	return inline, regular
+}
 
-	mixedBoundary, err := randomBoundary()
-	if err != nil {
-		return nil, err
-	}
-
-	writeHeader(&b, "Content-Type", fmt.Sprintf("multipart/mixed; boundary=%q", mixedBoundary))
-	b.WriteString("\r\n")
-
-	// Body part
-	fmt.Fprintf(&b, "--%s\r\n", mixedBoundary)
+func writeBodyEntity(b *bytes.Buffer, plainBody, htmlBody string, hasPlain, hasHTML bool) error {
 	switch {
 	case hasPlain && hasHTML:
 		altBoundary, err := randomBoundary()
 		if err != nil {
-			return nil, err
+			return err
 		}
-		fmt.Fprintf(&b, "Content-Type: multipart/alternative; boundary=%q\r\n\r\n", altBoundary)
-		writeTextPart(&b, altBoundary, "text/plain; charset=\"utf-8\"", plainBody)
-		writeTextPart(&b, altBoundary, "text/html; charset=\"utf-8\"", htmlBody)
-		fmt.Fprintf(&b, "--%s--\r\n", altBoundary)
-	case hasHTML && !hasPlain:
+		fmt.Fprintf(b, "Content-Type: multipart/alternative; boundary=%q\r\n\r\n", altBoundary)
+		writeTextPart(b, altBoundary, "text/plain; charset=\"utf-8\"", plainBody)
+		writeTextPart(b, altBoundary, "text/html; charset=\"utf-8\"", htmlBody)
+		fmt.Fprintf(b, "--%s--\r\n", altBoundary)
+	case hasHTML:
 		b.WriteString("Content-Type: text/html; charset=\"utf-8\"\r\n")
-		fmt.Fprintf(&b, "Content-Transfer-Encoding: %s\r\n\r\n", textTransferEncoding(htmlBody))
-		writeBodyWithTrailingCRLF(&b, htmlBody)
+		fmt.Fprintf(b, "Content-Transfer-Encoding: %s\r\n\r\n", textTransferEncoding(htmlBody))
+		writeBodyWithTrailingCRLF(b, htmlBody)
 	default:
 		b.WriteString("Content-Type: text/plain; charset=\"utf-8\"\r\n")
 		b.WriteString("Content-Transfer-Encoding: quoted-printable\r\n\r\n")
-		writeQuotedPrintableBody(&b, plainBody)
+		writeQuotedPrintableBody(b, plainBody)
 	}
+	return nil
+}
 
-	// Attachments
-	for _, a := range attachments {
-		fmt.Fprintf(&b, "\r\n--%s\r\n", mixedBoundary)
-		fmt.Fprintf(&b, "Content-Type: %s\r\n", a.MIMEType)
-		b.WriteString("Content-Transfer-Encoding: base64\r\n")
-		fmt.Fprintf(&b, "Content-Disposition: attachment; %s\r\n\r\n", contentDispositionFilename(a.Filename))
-		b.WriteString(wrapBase64(a.Data))
-		b.WriteString("\r\n")
+func writeRelatedEntity(b *bytes.Buffer, plainBody, htmlBody string, hasPlain, hasHTML bool, inline []mailAttachment) error {
+	relatedBoundary, err := randomBoundary()
+	if err != nil {
+		return err
 	}
+	fmt.Fprintf(
+		b,
+		"Content-Type: multipart/related; boundary=%q; type=%q\r\n\r\n",
+		relatedBoundary,
+		relatedRootMIMEType(hasPlain, hasHTML),
+	)
+	fmt.Fprintf(b, "--%s\r\n", relatedBoundary)
+	if err := writeBodyEntity(b, plainBody, htmlBody, hasPlain, hasHTML); err != nil {
+		return err
+	}
+	for _, attachment := range inline {
+		fmt.Fprintf(b, "\r\n--%s\r\n", relatedBoundary)
+		if err := writeAttachmentEntity(b, attachment); err != nil {
+			return err
+		}
+	}
+	fmt.Fprintf(b, "--%s--\r\n", relatedBoundary)
+	return nil
+}
 
-	fmt.Fprintf(&b, "--%s--\r\n", mixedBoundary)
-	return b.Bytes(), nil
+func relatedRootMIMEType(hasPlain, hasHTML bool) string {
+	if hasPlain && hasHTML {
+		return "multipart/alternative"
+	}
+	if hasHTML {
+		return "text/html"
+	}
+	return mimeTextPlain
+}
+
+func writeAttachmentEntity(b *bytes.Buffer, attachment mailAttachment) error {
+	fmt.Fprintf(b, "Content-Type: %s\r\n", attachment.MIMEType)
+	b.WriteString("Content-Transfer-Encoding: base64\r\n")
+	if attachment.Inline {
+		contentID := normalizeContentID(attachment.ContentID)
+		if contentID == "" {
+			return errors.New("inline attachment missing Content-ID")
+		}
+		if err := validateHeaderValue(contentID); err != nil {
+			return fmt.Errorf("invalid Content-ID: %w", err)
+		}
+		fmt.Fprintf(b, "Content-ID: <%s>\r\n", contentID)
+		if location := strings.TrimSpace(attachment.ContentLocation); location != "" {
+			if err := validateHeaderValue(location); err != nil {
+				return fmt.Errorf("invalid Content-Location: %w", err)
+			}
+			fmt.Fprintf(b, "Content-Location: %s\r\n", location)
+		}
+		fmt.Fprintf(b, "Content-Disposition: inline; %s\r\n\r\n", contentDispositionFilename(attachment.Filename))
+	} else {
+		fmt.Fprintf(b, "Content-Disposition: attachment; %s\r\n\r\n", contentDispositionFilename(attachment.Filename))
+	}
+	b.WriteString(wrapBase64(attachment.Data))
+	b.WriteString("\r\n")
+	return nil
 }
 
 func prepareMailAttachments(attachments []mailAttachment) ([]mailAttachment, []mailAttachmentMetadata, error) {

--- a/internal/cmd/gmail_mime_test.go
+++ b/internal/cmd/gmail_mime_test.go
@@ -128,6 +128,41 @@ func TestBuildRFC822AlternativeWithAttachment(t *testing.T) {
 	}
 }
 
+func TestBuildRFC822WithInlineResource(t *testing.T) {
+	raw, err := buildRFC822(mailOptions{
+		From:     "a@b.com",
+		To:       []string{"c@d.com"},
+		Subject:  "Hi",
+		Body:     "Plain",
+		BodyHTML: `<p>HTML<img src="cid:image@example.com"></p>`,
+		Attachments: []mailAttachment{
+			{
+				Filename:  "inline.png",
+				MIMEType:  "image/png",
+				Data:      []byte("png"),
+				DataSet:   true,
+				Inline:    true,
+				ContentID: "image@example.com",
+			},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("buildRFC822: %v", err)
+	}
+	s := string(raw)
+	for _, want := range []string{
+		"multipart/related",
+		"multipart/alternative",
+		"Content-ID: <image@example.com>",
+		`Content-Disposition: inline; filename="inline.png"`,
+		`cid:image@example.com`,
+	} {
+		if !strings.Contains(s, want) {
+			t.Fatalf("missing %q:\n%s", want, s)
+		}
+	}
+}
+
 func TestPrepareMailAttachments(t *testing.T) {
 	dir := t.TempDir()
 	payloadPath := filepath.Join(dir, "report.txt")

--- a/internal/cmd/gmail_no_send.go
+++ b/internal/cmd/gmail_no_send.go
@@ -12,6 +12,9 @@ import (
 var gmailSendCommandPaths = map[string]struct{}{
 	"send":              {},
 	"gmail.send":        {},
+	"gmail.reply":       {},
+	"gmail.reply-all":   {},
+	"gmail.replyall":    {},
 	"gmail.autoreply":   {},
 	"gmail.forward":     {},
 	"gmail.fwd":         {},

--- a/internal/cmd/gmail_recipients.go
+++ b/internal/cmd/gmail_recipients.go
@@ -35,7 +35,7 @@ func buildReplyRecipients(info *replyInfo, selfEmails []string, replyAll bool, e
 	if replyAll {
 		out.To = appendMailboxes(out.To, parseMailboxHeader(replyToHeader(info)), self)
 		out.Cc = appendMailboxes(out.Cc, parseMailboxHeader(replyCcHeader(info)), self)
-	} else if len(out.To) == 0 {
+	} else if len(out.To) == 0 && containsMailbox(parseMailboxHeader(info.FromAddr), self) {
 		// Replying to a message sent by the active account targets its original
 		// To recipients instead of producing an empty recipient list.
 		out.To = appendMailboxes(out.To, parseMailboxHeader(replyToHeader(info)), self)
@@ -80,6 +80,15 @@ func buildReplyRecipients(info *replyInfo, selfEmails []string, replyAll bool, e
 		return replyRecipients{}, usage("reply has no recipients after applying recipient changes")
 	}
 	return out, nil
+}
+
+func containsMailbox(addrs []mail.Address, candidates map[string]struct{}) bool {
+	for _, addr := range addrs {
+		if _, ok := candidates[canonicalEmail(addr.Address)]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 func parseExplicitRecipientFields(to, cc, bcc []string) (replyRecipients, error) {

--- a/internal/cmd/gmail_recipients.go
+++ b/internal/cmd/gmail_recipients.go
@@ -1,0 +1,287 @@
+package cmd
+
+import (
+	"net/mail"
+	"strings"
+
+	"google.golang.org/api/gmail/v1"
+)
+
+type replyRecipients struct {
+	To  []mail.Address
+	Cc  []mail.Address
+	Bcc []mail.Address
+}
+
+func buildReplyRecipients(info *replyInfo, selfEmails []string, replyAll bool, explicitTo, explicitCc, explicitBcc, remove []string) (replyRecipients, error) {
+	if info == nil {
+		return replyRecipients{}, usage("missing reply message")
+	}
+
+	self := make(map[string]struct{}, len(selfEmails))
+	for _, email := range selfEmails {
+		if key := canonicalEmail(email); key != "" {
+			self[key] = struct{}{}
+		}
+	}
+
+	replyTarget := parseMailboxHeader(info.ReplyToAddr)
+	if len(replyTarget) == 0 {
+		replyTarget = parseMailboxHeader(info.FromAddr)
+	}
+
+	var out replyRecipients
+	out.To = appendMailboxes(out.To, replyTarget, self)
+	if replyAll {
+		out.To = appendMailboxes(out.To, parseMailboxHeader(replyToHeader(info)), self)
+		out.Cc = appendMailboxes(out.Cc, parseMailboxHeader(replyCcHeader(info)), self)
+	} else if len(out.To) == 0 {
+		// Replying to a message sent by the active account targets its original
+		// To recipients instead of producing an empty recipient list.
+		out.To = appendMailboxes(out.To, parseMailboxHeader(replyToHeader(info)), self)
+	}
+	out = deduplicateRecipientFields(out)
+
+	explicit, err := parseExplicitRecipientFields(explicitTo, explicitCc, explicitBcc)
+	if err != nil {
+		return replyRecipients{}, err
+	}
+	for _, placement := range []struct {
+		field string
+		addrs []mail.Address
+	}{
+		{field: "to", addrs: explicit.To},
+		{field: "cc", addrs: explicit.Cc},
+		{field: "bcc", addrs: explicit.Bcc},
+	} {
+		for _, addr := range placement.addrs {
+			out.remove(addr.Address)
+			switch placement.field {
+			case "to":
+				out.To = appendMailbox(out.To, addr)
+			case "cc":
+				out.Cc = appendMailbox(out.Cc, addr)
+			case "bcc":
+				out.Bcc = appendMailbox(out.Bcc, addr)
+			}
+		}
+	}
+
+	removeAddrs, err := parseMailboxValues("--remove", remove)
+	if err != nil {
+		return replyRecipients{}, err
+	}
+	for _, addr := range removeAddrs {
+		out.remove(addr.Address)
+	}
+	out = deduplicateRecipientFields(out)
+
+	if len(out.To)+len(out.Cc)+len(out.Bcc) == 0 {
+		return replyRecipients{}, usage("reply has no recipients after applying recipient changes")
+	}
+	return out, nil
+}
+
+func parseExplicitRecipientFields(to, cc, bcc []string) (replyRecipients, error) {
+	var out replyRecipients
+	var err error
+	if out.To, err = parseMailboxValues("--to", to); err != nil {
+		return replyRecipients{}, err
+	}
+	if out.Cc, err = parseMailboxValues("--cc", cc); err != nil {
+		return replyRecipients{}, err
+	}
+	if out.Bcc, err = parseMailboxValues("--bcc", bcc); err != nil {
+		return replyRecipients{}, err
+	}
+
+	seen := make(map[string]string)
+	for _, field := range []struct {
+		name  string
+		addrs []mail.Address
+	}{
+		{name: "--to", addrs: out.To},
+		{name: "--cc", addrs: out.Cc},
+		{name: "--bcc", addrs: out.Bcc},
+	} {
+		for _, addr := range field.addrs {
+			key := canonicalEmail(addr.Address)
+			if previous, ok := seen[key]; ok && previous != field.name {
+				return replyRecipients{}, usagef("%s appears in both %s and %s", addr.Address, previous, field.name)
+			}
+			seen[key] = field.name
+		}
+	}
+	return out, nil
+}
+
+func parseMailboxValues(flag string, values []string) ([]mail.Address, error) {
+	var out []mail.Address
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		addrs, err := mail.ParseAddressList(value)
+		if err != nil {
+			return nil, usagef("invalid %s recipient list %q: %v", flag, value, err)
+		}
+		for _, addr := range addrs {
+			if addr == nil || strings.TrimSpace(addr.Address) == "" {
+				continue
+			}
+			out = appendMailbox(out, *addr)
+		}
+	}
+	return out, nil
+}
+
+func parseMailboxHeader(value string) []mail.Address {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+	addrs, err := mail.ParseAddressList(value)
+	if err == nil {
+		out := make([]mail.Address, 0, len(addrs))
+		for _, addr := range addrs {
+			if addr != nil && strings.TrimSpace(addr.Address) != "" {
+				out = appendMailbox(out, *addr)
+			}
+		}
+		return out
+	}
+
+	fallback := parseEmailAddressesFallback(value)
+	out := make([]mail.Address, 0, len(fallback))
+	for _, email := range fallback {
+		out = appendMailbox(out, mail.Address{Address: email})
+	}
+	return out
+}
+
+func appendMailboxes(dst []mail.Address, src []mail.Address, excluded map[string]struct{}) []mail.Address {
+	for _, addr := range src {
+		if _, skip := excluded[canonicalEmail(addr.Address)]; skip {
+			continue
+		}
+		dst = appendMailbox(dst, addr)
+	}
+	return dst
+}
+
+func appendMailbox(dst []mail.Address, addr mail.Address) []mail.Address {
+	key := canonicalEmail(addr.Address)
+	if key == "" {
+		return dst
+	}
+	addr.Address = strings.TrimSpace(addr.Address)
+	addr.Name = strings.TrimSpace(addr.Name)
+	for i := range dst {
+		if canonicalEmail(dst[i].Address) != key {
+			continue
+		}
+		if dst[i].Name == "" && addr.Name != "" {
+			dst[i] = addr
+		}
+		return dst
+	}
+	return append(dst, addr)
+}
+
+func deduplicateRecipientFields(in replyRecipients) replyRecipients {
+	var out replyRecipients
+	seen := make(map[string]struct{})
+	for _, field := range []struct {
+		src  []mail.Address
+		dest *[]mail.Address
+	}{
+		{src: in.To, dest: &out.To},
+		{src: in.Cc, dest: &out.Cc},
+		{src: in.Bcc, dest: &out.Bcc},
+	} {
+		for _, addr := range field.src {
+			key := canonicalEmail(addr.Address)
+			if key == "" {
+				continue
+			}
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			*field.dest = append(*field.dest, addr)
+		}
+	}
+	return out
+}
+
+func (r *replyRecipients) remove(email string) {
+	key := canonicalEmail(email)
+	r.To = removeMailbox(r.To, key)
+	r.Cc = removeMailbox(r.Cc, key)
+	r.Bcc = removeMailbox(r.Bcc, key)
+}
+
+func removeMailbox(addrs []mail.Address, key string) []mail.Address {
+	out := addrs[:0]
+	for _, addr := range addrs {
+		if canonicalEmail(addr.Address) != key {
+			out = append(out, addr)
+		}
+	}
+	return out
+}
+
+func canonicalEmail(value string) string {
+	value = strings.TrimSpace(value)
+	if addr, err := mail.ParseAddress(value); err == nil && addr != nil {
+		value = addr.Address
+	}
+	return strings.ToLower(strings.TrimSpace(value))
+}
+
+func formatMailboxes(addrs []mail.Address) []string {
+	out := make([]string, 0, len(addrs))
+	for _, addr := range addrs {
+		if strings.TrimSpace(addr.Address) == "" {
+			continue
+		}
+		if strings.TrimSpace(addr.Name) == "" {
+			out = append(out, addr.Address)
+		} else {
+			out = append(out, addr.String())
+		}
+	}
+	return out
+}
+
+func selfEmailsForReply(account, sendingEmail string, sendAs []*gmail.SendAs) []string {
+	out := []string{account, sendingEmail}
+	for _, alias := range sendAs {
+		if alias != nil {
+			out = append(out, alias.SendAsEmail)
+		}
+	}
+	return out
+}
+
+func replyModeName(replyAll bool) string {
+	if replyAll {
+		return "reply-all"
+	}
+	return "reply"
+}
+
+func replyToHeader(info *replyInfo) string {
+	if strings.TrimSpace(info.ToHeader) != "" {
+		return info.ToHeader
+	}
+	return strings.Join(info.ToAddrs, ", ")
+}
+
+func replyCcHeader(info *replyInfo) string {
+	if strings.TrimSpace(info.CcHeader) != "" {
+		return info.CcHeader
+	}
+	return strings.Join(info.CcAddrs, ", ")
+}

--- a/internal/cmd/gmail_reply.go
+++ b/internal/cmd/gmail_reply.go
@@ -13,50 +13,29 @@ import (
 // buildReplyAllRecipients constructs To and Cc lists for a reply-all.
 // Per RFC 5322: if Reply-To header is present, use it instead of From.
 func buildReplyAllRecipients(info *replyInfo, selfEmail string) (to, cc []string) {
-	toAddrs := make([]string, 0, 1+len(info.ToAddrs))
-
-	replyAddress := info.ReplyToAddr
-	if replyAddress == "" {
-		replyAddress = info.FromAddr
+	recipients, err := buildReplyRecipients(info, []string{selfEmail}, true, nil, nil, nil, nil)
+	if err != nil {
+		return []string{}, []string{}
 	}
-	if replyAddrs := parseEmailAddresses(replyAddress); len(replyAddrs) > 0 {
-		toAddrs = append(toAddrs, replyAddrs...)
-	}
-	toAddrs = append(toAddrs, info.ToAddrs...)
-
-	toAddrs = filterOutSelf(toAddrs, selfEmail)
-	toAddrs = deduplicateAddresses(toAddrs)
-
-	ccAddrs := filterOutSelf(info.CcAddrs, selfEmail)
-	ccAddrs = deduplicateAddresses(ccAddrs)
-
-	toSet := make(map[string]bool)
-	for _, addr := range toAddrs {
-		toSet[strings.ToLower(addr)] = true
-	}
-	filteredCc := make([]string, 0, len(ccAddrs))
-	for _, addr := range ccAddrs {
-		if !toSet[strings.ToLower(addr)] {
-			filteredCc = append(filteredCc, addr)
-		}
-	}
-
-	return toAddrs, filteredCc
+	return formatMailboxes(recipients.To), formatMailboxes(recipients.Cc)
 }
 
 // replyInfo contains all information extracted from the original message for replying.
 type replyInfo struct {
-	InReplyTo   string
-	References  string
-	ThreadID    string
-	FromAddr    string
-	ReplyToAddr string
-	ToAddrs     []string
-	CcAddrs     []string
-	Date        string
-	Subject     string
-	Body        string
-	BodyHTML    string
+	InReplyTo       string
+	References      string
+	ThreadID        string
+	FromAddr        string
+	ReplyToAddr     string
+	ToHeader        string
+	CcHeader        string
+	ToAddrs         []string
+	CcAddrs         []string
+	Date            string
+	Subject         string
+	Body            string
+	BodyHTML        string
+	InlineResources []mailAttachment
 }
 
 func replyHeaders(ctx context.Context, svc *gmail.Service, replyToMessageID string) (inReplyTo string, references string, threadID string, err error) {
@@ -80,6 +59,12 @@ func fetchReplyInfo(ctx context.Context, svc *gmail.Service, replyToMessageID st
 			return nil, err
 		}
 		info := replyInfoFromMessage(msg, includeQuoteBodies)
+		if includeQuoteBodies {
+			info.InlineResources, err = preserveReferencedInlineResources(ctx, svc, msg.Id, msg.Payload, info.BodyHTML)
+			if err != nil {
+				return nil, fmt.Errorf("preserve quoted inline images: %w", err)
+			}
+		}
 		if info.InReplyTo == "" {
 			return nil, fmt.Errorf("reply target message %s has no Message-ID header; cannot set In-Reply-To/References", replyToMessageID)
 		}
@@ -106,6 +91,12 @@ func fetchReplyInfo(ctx context.Context, svc *gmail.Service, replyToMessageID st
 	}
 
 	info := replyInfoFromMessage(msg, includeQuoteBodies)
+	if includeQuoteBodies {
+		info.InlineResources, err = preserveReferencedInlineResources(ctx, svc, msg.Id, msg.Payload, info.BodyHTML)
+		if err != nil {
+			return nil, fmt.Errorf("preserve quoted inline images: %w", err)
+		}
+	}
 	if info.ThreadID == "" {
 		info.ThreadID = thread.Id
 	}
@@ -138,11 +129,13 @@ func replyInfoFromMessage(msg *gmail.Message, includeQuoteBodies bool) *replyInf
 		ThreadID:    msg.ThreadId,
 		FromAddr:    headerValue(msg.Payload, "From"),
 		ReplyToAddr: headerValue(msg.Payload, "Reply-To"),
-		ToAddrs:     parseEmailAddresses(headerValue(msg.Payload, "To")),
-		CcAddrs:     parseEmailAddresses(headerValue(msg.Payload, "Cc")),
+		ToHeader:    headerValue(msg.Payload, "To"),
+		CcHeader:    headerValue(msg.Payload, "Cc"),
 		Date:        headerValue(msg.Payload, "Date"),
 		Subject:     headerValue(msg.Payload, "Subject"),
 	}
+	info.ToAddrs = parseEmailAddresses(info.ToHeader)
+	info.CcAddrs = parseEmailAddresses(info.CcHeader)
 
 	if includeQuoteBodies {
 		plain := findPartBody(msg.Payload, "text/plain")

--- a/internal/cmd/gmail_reply.go
+++ b/internal/cmd/gmail_reply.go
@@ -263,9 +263,19 @@ func applyQuoteToBodies(plainBody string, htmlBody string, quote bool, info *rep
 	}
 
 	userPlain := plainBody
-	outPlain := plainBody
-	if info.Body != "" {
-		outPlain += formatQuotedMessage(info.FromAddr, info.Date, info.Body)
+	hasHTMLReply := strings.TrimSpace(htmlBody) != ""
+	if strings.TrimSpace(userPlain) == "" && hasHTMLReply {
+		userPlain = htmlToPlainText(htmlBody)
+	}
+
+	quotedPlain := info.Body
+	if strings.TrimSpace(quotedPlain) == "" && strings.TrimSpace(info.BodyHTML) != "" {
+		quotedPlain = htmlToPlainText(info.BodyHTML)
+	}
+
+	outPlain := userPlain
+	if quotedPlain != "" && (!hasHTMLReply || strings.TrimSpace(userPlain) != "") {
+		outPlain += formatQuotedMessage(info.FromAddr, info.Date, quotedPlain)
 	}
 
 	quoteContent := info.BodyHTML

--- a/internal/cmd/gmail_reply_commands.go
+++ b/internal/cmd/gmail_reply_commands.go
@@ -1,0 +1,192 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+type GmailReplyCmd struct {
+	MessageID string            `arg:"" name:"messageId" help:"Gmail message ID to reply to"`
+	Options   GmailReplyOptions `embed:""`
+}
+
+type GmailReplyAllCmd struct {
+	MessageID string            `arg:"" name:"messageId" help:"Gmail message ID to reply to"`
+	Options   GmailReplyOptions `embed:""`
+}
+
+type GmailReplyOptions struct {
+	To            []string `name:"to" sep:"none" help:"Add or move recipients to To (repeatable)"`
+	Cc            []string `name:"cc" sep:"none" help:"Add or move recipients to Cc (repeatable)"`
+	Bcc           []string `name:"bcc" sep:"none" help:"Add or move recipients to Bcc (repeatable)"`
+	Remove        []string `name:"remove" sep:"none" help:"Remove recipients from all fields (repeatable)"`
+	Subject       string   `name:"subject" help:"Override reply subject (a changed subject starts a new Gmail thread)"`
+	Body          string   `name:"body" help:"Body (plain text; required unless --body-html is set)"`
+	BodyFile      string   `name:"body-file" help:"Body file path (plain text; '-' for stdin)"`
+	BodyHTML      string   `name:"body-html" help:"Body (HTML; optional)"`
+	BodyHTMLFile  string   `name:"body-html-file" help:"HTML body file path ('-' for stdin)"`
+	NoQuote       bool     `name:"no-quote" help:"Do not include the original message below the reply"`
+	Attach        []string `name:"attach" sep:"none" help:"Attachment file path (repeatable)"`
+	From          string   `name:"from" help:"Send from this email address (must be a verified send-as alias)"`
+	Signature     bool     `name:"signature" help:"Append the Gmail signature from the active send-as address"`
+	SignatureFrom string   `name:"signature-from" help:"Append the Gmail signature from this send-as email address"`
+	SignatureFile string   `name:"signature-file" help:"Append a local signature file (plain text or HTML)"`
+}
+
+func (c *GmailReplyCmd) Run(ctx context.Context, flags *RootFlags) error {
+	return c.Options.run(ctx, flags, c.MessageID, false)
+}
+
+func (c *GmailReplyAllCmd) Run(ctx context.Context, flags *RootFlags) error {
+	return c.Options.run(ctx, flags, c.MessageID, true)
+}
+
+func (c *GmailReplyOptions) run(ctx context.Context, flags *RootFlags, messageID string, replyAll bool) error {
+	u := ui.FromContext(ctx)
+	messageID = normalizeGmailMessageID(messageID)
+	if messageID == "" {
+		return usage("required: messageId")
+	}
+
+	body, htmlBody, err := resolveComposeBodyInputs(ctx, c.Body, c.BodyFile, c.BodyHTML, c.BodyHTMLFile)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(body) == "" && strings.TrimSpace(htmlBody) == "" {
+		return usage("required: --body, --body-file, --body-html, or --body-html-file")
+	}
+	if validationErr := validateHeaderValue(c.Subject); validationErr != nil {
+		return usagef("invalid --subject: %v", validationErr)
+	}
+	if validationErr := validateHeaderValue(c.From); validationErr != nil {
+		return usagef("invalid --from: %v", validationErr)
+	}
+	if _, parseErr := parseExplicitRecipientFields(c.To, c.Cc, c.Bcc); parseErr != nil {
+		return parseErr
+	}
+	if _, parseErr := parseMailboxValues("--remove", c.Remove); parseErr != nil {
+		return parseErr
+	}
+
+	signatureCmd := GmailSendCmd{
+		Signature:     c.Signature,
+		SignatureFrom: c.SignatureFrom,
+		SignatureFile: c.SignatureFile,
+	}
+	if signatureErr := signatureCmd.validateSignatureOptions(); signatureErr != nil {
+		return signatureErr
+	}
+
+	attachPaths, err := expandComposeAttachmentPaths(c.Attach)
+	if err != nil {
+		return err
+	}
+
+	if dryRunErr := dryRunExit(ctx, flags, "gmail."+replyModeName(replyAll), map[string]any{
+		"message_id":       messageID,
+		"to_add":           c.To,
+		"cc_add":           c.Cc,
+		"bcc_add":          c.Bcc,
+		"remove":           c.Remove,
+		"subject_override": strings.TrimSpace(c.Subject),
+		"quote":            !c.NoQuote,
+		"from":             strings.TrimSpace(c.From),
+		"body_len":         len(strings.TrimSpace(body)),
+		"body_html_len":    len(strings.TrimSpace(htmlBody)),
+		"attachments":      attachPaths,
+		"signature":        c.Signature,
+		"signature_from":   strings.TrimSpace(c.SignatureFrom),
+		"signature_file":   strings.TrimSpace(c.SignatureFile),
+	}); dryRunErr != nil {
+		return dryRunErr
+	}
+
+	account, svc, err := requireGmailSendService(ctx, flags)
+	if err != nil {
+		return err
+	}
+
+	sendAs, sendAsErr := listSendAs(ctx, svc)
+	from, err := resolveComposeFrom(ctx, svc, account, c.From, sendAs, sendAsErr)
+	if err != nil {
+		return err
+	}
+	if signatureCmd.signatureRequested() {
+		signature, source, sigErr := signatureCmd.resolveComposeSignature(ctx, svc, from.sendingEmail)
+		if sigErr != nil {
+			return sigErr
+		}
+		if signature.empty() {
+			u.Err().Linef("Warning: no signature configured for %s", source)
+		} else {
+			body, htmlBody = appendComposeSignature(body, htmlBody, signature)
+		}
+	}
+
+	info, body, htmlBody, err := prepareComposeReply(ctx, svc, messageID, "", !c.NoQuote, body, htmlBody)
+	if err != nil {
+		return err
+	}
+	recipients, err := buildReplyRecipients(
+		info,
+		selfEmailsForReply(account, from.sendingEmail, sendAs),
+		replyAll,
+		c.To,
+		c.Cc,
+		c.Bcc,
+		c.Remove,
+	)
+	if err != nil {
+		return err
+	}
+
+	defaultSubject := autoReplySubject("", info.Subject)
+	subject := strings.TrimSpace(c.Subject)
+	if subject == "" {
+		subject = defaultSubject
+	}
+	if strings.TrimSpace(c.Subject) != "" && subject != defaultSubject {
+		// Gmail requires matching subjects for an explicit threadId. Keep reply
+		// headers, but let Gmail create a new thread for an edited subject.
+		info.ThreadID = ""
+	}
+
+	userAttachments, attachmentMetadata, err := prepareMailAttachments(attachmentsFromPaths(attachPaths))
+	if err != nil {
+		return err
+	}
+	attachments := append([]mailAttachment{}, userAttachments...)
+	attachments = append(attachments, info.InlineResources...)
+
+	msg, err := buildGmailMessage(ctx, sendMessageOptions{
+		FromAddr:    from.header,
+		Subject:     subject,
+		Body:        body,
+		BodyHTML:    htmlBody,
+		ReplyInfo:   info,
+		Attachments: attachments,
+	}, sendBatch{
+		To:  formatMailboxes(recipients.To),
+		Cc:  formatMailboxes(recipients.Cc),
+		Bcc: formatMailboxes(recipients.Bcc),
+	}, &rfc822Config{allowMissingTo: true})
+	if err != nil {
+		return fmt.Errorf("build reply: %w", err)
+	}
+
+	sent, err := svc.Users.Messages.Send("me", msg).Context(ctx).Do()
+	if err != nil {
+		return fmt.Errorf("send reply: %w", err)
+	}
+
+	return writeGmailMessageResults(ctx, u, []gmailMessageResult{{
+		From:        from.header,
+		To:          strings.Join(formatMailboxes(recipients.To), ", "),
+		MessageID:   sent.Id,
+		ThreadID:    sent.ThreadId,
+		Attachments: attachmentMetadata,
+	}})
+}

--- a/internal/cmd/gmail_reply_commands_test.go
+++ b/internal/cmd/gmail_reply_commands_test.go
@@ -299,7 +299,8 @@ func TestPreserveReferencedInlineResourcesRejectsBrokenCID(t *testing.T) {
 
 func TestReferencedContentIDsOnlyScansResourceReferences(t *testing.T) {
 	htmlBody := `<p>Literal <code>cid:not-a-resource</code></p>
-<img src="cid:image-1%40example.com" srcset="cid:image-2@example.com 2x">
+<a href="https://example.test/?q=cid:not-a-resource">Link</a>
+<img src="cid:image-1%40example.com" srcset="https://example.test/?q=cid:not-a-resource 1x, cid:image-2@example.com 2x">
 <div style="background-image: url('cid:image-3@example.com')"></div>
 <style>.hero { background: url(cid:image-4@example.com) }</style>`
 

--- a/internal/cmd/gmail_reply_commands_test.go
+++ b/internal/cmd/gmail_reply_commands_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"slices"
 	"strings"
 	"testing"
 
@@ -293,6 +294,38 @@ func TestPreserveReferencedInlineResourcesRejectsBrokenCID(t *testing.T) {
 	)
 	if err == nil || !strings.Contains(err.Error(), "no matching MIME part") {
 		t.Fatalf("expected missing CID error, got %v", err)
+	}
+}
+
+func TestReferencedContentIDsOnlyScansResourceReferences(t *testing.T) {
+	htmlBody := `<p>Literal <code>cid:not-a-resource</code></p>
+<img src="cid:image-1%40example.com" srcset="cid:image-2@example.com 2x">
+<div style="background-image: url('cid:image-3@example.com')"></div>
+<style>.hero { background: url(cid:image-4@example.com) }</style>`
+
+	got := referencedContentIDs(htmlBody)
+	want := []string{
+		"image-1@example.com",
+		"image-2@example.com",
+		"image-3@example.com",
+		"image-4@example.com",
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("referencedContentIDs = %#v, want %#v", got, want)
+	}
+
+	resources, err := preserveReferencedInlineResources(
+		t.Context(),
+		nil,
+		"msg-literal-cid",
+		&gmail.MessagePart{},
+		`<p>Document <code>cid:example</code> syntax.</p>`,
+	)
+	if err != nil {
+		t.Fatalf("literal CID text returned error: %v", err)
+	}
+	if len(resources) != 0 {
+		t.Fatalf("literal CID text returned resources: %#v", resources)
 	}
 }
 

--- a/internal/cmd/gmail_reply_commands_test.go
+++ b/internal/cmd/gmail_reply_commands_test.go
@@ -1,0 +1,344 @@
+package cmd
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/gmail/v1"
+)
+
+func TestBuildReplyRecipientsPreservesNamesAndMovesRecipients(t *testing.T) {
+	info := &replyInfo{
+		FromAddr:    `"Alice Sender" <alice@example.com>`,
+		ToHeader:    `"Me Person" <me@example.com>, "Other Person" <other@example.com>`,
+		CcHeader:    `"Intro Person" <intro@example.com>, "CC Person" <cc@example.com>`,
+		ReplyToAddr: "",
+	}
+	recipients, err := buildReplyRecipients(
+		info,
+		[]string{"me@example.com", "alias@example.com"},
+		true,
+		nil,
+		nil,
+		[]string{`"Intro Person" <intro@example.com>`},
+		[]string{"cc@example.com"},
+	)
+	if err != nil {
+		t.Fatalf("buildReplyRecipients: %v", err)
+	}
+	if got := formatMailboxes(recipients.To); strings.Join(got, "|") != `"Alice Sender" <alice@example.com>|"Other Person" <other@example.com>` {
+		t.Fatalf("To = %#v", got)
+	}
+	if len(recipients.Cc) != 0 {
+		t.Fatalf("Cc = %#v", formatMailboxes(recipients.Cc))
+	}
+	if got := formatMailboxes(recipients.Bcc); len(got) != 1 || got[0] != `"Intro Person" <intro@example.com>` {
+		t.Fatalf("Bcc = %#v", got)
+	}
+}
+
+func TestParseMailboxValuesPreservesCommaInDisplayName(t *testing.T) {
+	addrs, err := parseMailboxValues("--to", []string{`"Bourgon, Malo" <malo@example.com>`})
+	if err != nil {
+		t.Fatalf("parseMailboxValues: %v", err)
+	}
+	if got := formatMailboxes(addrs); len(got) != 1 || got[0] != `"Bourgon, Malo" <malo@example.com>` {
+		t.Fatalf("addresses = %#v", got)
+	}
+}
+
+func TestGmailReplyDryRunPreservesCommaInDisplayNameFlag(t *testing.T) {
+	result := executeWithGmailTestService(t, []string{
+		"--dry-run",
+		"--account", "me@example.com",
+		"gmail", "reply", "msg-1",
+		"--body", "Hello",
+		"--to", `"Bourgon, Malo" <malo@example.com>`,
+	}, nil)
+	if result.err != nil {
+		t.Fatalf("Execute: %v", result.err)
+	}
+	if !strings.Contains(result.stdout, "Bourgon, Malo") {
+		t.Fatalf("dry-run output lost display name: %q", result.stdout)
+	}
+}
+
+func TestExecuteGmailReplyAllDefaultsAndInlineImages(t *testing.T) {
+	var sentRaw string
+	var sentThreadID string
+	htmlBody := `<p>Original HTML<img src="cid:image-1@example.com"></p>`
+
+	svc, cleanup := newGmailServiceForTest(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/gmail/v1/users/me/settings/sendAs":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"sendAs": []map[string]any{
+					{"sendAsEmail": "me@example.com", "displayName": "Me Person", "isPrimary": true, "verificationStatus": "accepted"},
+					{"sendAsEmail": "alias@example.com", "displayName": "Alias", "verificationStatus": "accepted"},
+				},
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/gmail/v1/users/me/messages/msg-1":
+			if got := r.URL.Query().Get("format"); got != "full" {
+				t.Fatalf("format = %q, want full", got)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":       "msg-1",
+				"threadId": "thread-1",
+				"payload": map[string]any{
+					"mimeType": "multipart/related",
+					"headers": []map[string]any{
+						{"name": "Message-ID", "value": "<original@example.com>"},
+						{"name": "References", "value": "<root@example.com>"},
+						{"name": "From", "value": `"Alice Sender" <alice@example.com>`},
+						{"name": "To", "value": `"Me Person" <me@example.com>, "Other Person" <other@example.com>`},
+						{"name": "Cc", "value": `"Intro Person" <intro@example.com>, "CC Person" <cc@example.com>`},
+						{"name": "Date", "value": "Fri, 12 Jun 2026 10:00:00 +0000"},
+						{"name": "Subject", "value": "Project update"},
+					},
+					"parts": []map[string]any{
+						{
+							"mimeType": "multipart/alternative",
+							"parts": []map[string]any{
+								{
+									"mimeType": "text/plain",
+									"body": map[string]any{
+										"data": base64.RawURLEncoding.EncodeToString([]byte("Original plain")),
+										"size": 14,
+									},
+								},
+								{
+									"mimeType": "text/html",
+									"body": map[string]any{
+										"data": base64.RawURLEncoding.EncodeToString([]byte(htmlBody)),
+										"size": len(htmlBody),
+									},
+								},
+							},
+						},
+						{
+							"mimeType": "image/png",
+							"filename": "inline.png",
+							"headers": []map[string]any{
+								{"name": "Content-ID", "value": "<image-1@example.com>"},
+								{"name": "Content-Disposition", "value": `inline; filename="inline.png"`},
+							},
+							"body": map[string]any{
+								"data": base64.RawURLEncoding.EncodeToString([]byte("png-data")),
+								"size": 8,
+							},
+						},
+					},
+				},
+			})
+		case r.Method == http.MethodPost && r.URL.Path == "/gmail/v1/users/me/messages/send":
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read send body: %v", err)
+			}
+			var msg gmail.Message
+			if unmarshalErr := json.Unmarshal(body, &msg); unmarshalErr != nil {
+				t.Fatalf("decode send body: %v", unmarshalErr)
+			}
+			raw, err := base64.RawURLEncoding.DecodeString(msg.Raw)
+			if err != nil {
+				t.Fatalf("decode raw: %v", err)
+			}
+			sentRaw = string(raw)
+			sentThreadID = msg.ThreadId
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": "sent-1", "threadId": "thread-1"})
+		default:
+			http.NotFound(w, r)
+		}
+	})
+	defer cleanup()
+
+	result := executeWithGmailTestService(t, []string{
+		"--json",
+		"--account", "me@example.com",
+		"gmail", "reply-all", "msg-1",
+		"--body", "Thanks",
+		"--bcc", `"Intro Person" <intro@example.com>`,
+		"--remove", "cc@example.com",
+	}, svc)
+	if result.err != nil {
+		t.Fatalf("Execute: %v", result.err)
+	}
+	for _, want := range []string{
+		`Subject: Re: Project update`,
+		`In-Reply-To: <original@example.com>`,
+		`References: <root@example.com> <original@example.com>`,
+		`Alice Sender`,
+		`Other Person`,
+		`Bcc: "Intro Person" <intro@example.com>`,
+		`Content-Type: multipart/related`,
+		`Content-ID: <image-1@example.com>`,
+		`Content-Disposition: inline; filename="inline.png"`,
+		`Original HTML`,
+		`cid:image-1@example.com`,
+	} {
+		if !strings.Contains(sentRaw, want) {
+			t.Fatalf("sent message missing %q:\n%s", want, sentRaw)
+		}
+	}
+	if strings.Contains(sentRaw, "CC Person") || strings.Contains(sentRaw, "\r\nCc:") {
+		t.Fatalf("removed Cc recipient still present:\n%s", sentRaw)
+	}
+	if sentThreadID != "thread-1" {
+		t.Fatalf("threadId = %q, want thread-1", sentThreadID)
+	}
+}
+
+func TestExecuteGmailReplyEditedSubjectStartsNewThread(t *testing.T) {
+	var sentThreadID string
+	svc, cleanup := newGmailServiceForTest(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/gmail/v1/users/me/settings/sendAs":
+			_ = json.NewEncoder(w).Encode(map[string]any{"sendAs": []map[string]any{
+				{"sendAsEmail": "me@example.com", "isPrimary": true, "verificationStatus": "accepted"},
+			}})
+		case r.Method == http.MethodGet && r.URL.Path == "/gmail/v1/users/me/messages/msg-2":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":       "msg-2",
+				"threadId": "thread-2",
+				"payload": map[string]any{
+					"headers": []map[string]any{
+						{"name": "Message-ID", "value": "<original-2@example.com>"},
+						{"name": "From", "value": "alice@example.com"},
+						{"name": "To", "value": "me@example.com"},
+						{"name": "Subject", "value": "Original"},
+					},
+				},
+			})
+		case r.Method == http.MethodPost && r.URL.Path == "/gmail/v1/users/me/messages/send":
+			var msg gmail.Message
+			_ = json.NewDecoder(r.Body).Decode(&msg)
+			sentThreadID = msg.ThreadId
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": "sent-2", "threadId": "new-thread"})
+		default:
+			http.NotFound(w, r)
+		}
+	})
+	defer cleanup()
+
+	result := executeWithGmailTestService(t, []string{
+		"--account", "me@example.com",
+		"gmail", "reply", "msg-2",
+		"--body", "New topic",
+		"--subject", "Different subject",
+		"--no-quote",
+	}, svc)
+	if result.err != nil {
+		t.Fatalf("Execute: %v", result.err)
+	}
+	if sentThreadID != "" {
+		t.Fatalf("edited subject unexpectedly retained threadId %q", sentThreadID)
+	}
+}
+
+func TestPreserveReferencedInlineResourcesFetchesAttachmentBody(t *testing.T) {
+	svc, cleanup := newGmailServiceForTest(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/gmail/v1/users/me/messages/msg-3/attachments/inline-att" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": base64.RawURLEncoding.EncodeToString([]byte("inline-bytes")),
+			"size": 12,
+		})
+	})
+	defer cleanup()
+
+	payload := &gmail.MessagePart{
+		MimeType: "multipart/related",
+		Parts: []*gmail.MessagePart{
+			{
+				MimeType: "image/png",
+				Filename: "image.png",
+				Headers: []*gmail.MessagePartHeader{
+					{Name: "Content-ID", Value: "<image-3@example.com>"},
+				},
+				Body: &gmail.MessagePartBody{AttachmentId: "inline-att", Size: 12},
+			},
+		},
+	}
+	resources, err := preserveReferencedInlineResources(
+		t.Context(),
+		svc,
+		"msg-3",
+		payload,
+		`<img src="cid:image-3%40example.com">`,
+	)
+	if err != nil {
+		t.Fatalf("preserveReferencedInlineResources: %v", err)
+	}
+	if len(resources) != 1 || !resources[0].Inline || string(resources[0].Data) != "inline-bytes" {
+		t.Fatalf("resources = %#v", resources)
+	}
+}
+
+func TestPreserveReferencedInlineResourcesRejectsBrokenCID(t *testing.T) {
+	_, err := preserveReferencedInlineResources(
+		t.Context(),
+		nil,
+		"msg-4",
+		&gmail.MessagePart{},
+		`<img src="cid:missing@example.com">`,
+	)
+	if err == nil || !strings.Contains(err.Error(), "no matching MIME part") {
+		t.Fatalf("expected missing CID error, got %v", err)
+	}
+}
+
+func TestPreserveForwardMessagePartsIncludesNamelessAttachmentID(t *testing.T) {
+	attachmentFetched := false
+	svc, cleanup := newGmailServiceForTest(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !strings.Contains(r.URL.Path, "/attachments/att-1") {
+			http.NotFound(w, r)
+			return
+		}
+		attachmentFetched = true
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": base64.RawURLEncoding.EncodeToString([]byte("attachment-data")),
+			"size": 15,
+		})
+	})
+	defer cleanup()
+
+	attachments, err := preserveForwardMessageParts(
+		t.Context(),
+		svc,
+		"msg-1",
+		&gmail.MessagePart{
+			MimeType: "multipart/mixed",
+			Parts: []*gmail.MessagePart{{
+				MimeType: "application/octet-stream",
+				Body: &gmail.MessagePartBody{
+					AttachmentId: "att-1",
+					Size:         15,
+				},
+			}},
+		},
+		"",
+		true,
+	)
+	if err != nil {
+		t.Fatalf("preserveForwardMessageParts: %v", err)
+	}
+	if !attachmentFetched {
+		t.Fatal("expected nameless attachment body to be fetched")
+	}
+	if len(attachments) != 1 {
+		t.Fatalf("attachments = %#v, want one", attachments)
+	}
+	if attachments[0].Filename != defaultAttachmentFilename {
+		t.Fatalf("filename = %q, want %q", attachments[0].Filename, defaultAttachmentFilename)
+	}
+}

--- a/internal/cmd/gmail_reply_commands_test.go
+++ b/internal/cmd/gmail_reply_commands_test.go
@@ -42,6 +42,46 @@ func TestBuildReplyRecipientsPreservesNamesAndMovesRecipients(t *testing.T) {
 	}
 }
 
+func TestBuildReplyRecipientsOnlyFallsBackForSelfSentMessages(t *testing.T) {
+	selfEmails := []string{"me@example.com", "alias@example.com"}
+
+	selfSent, err := buildReplyRecipients(
+		&replyInfo{
+			FromAddr: `"Me Person" <me@example.com>`,
+			ToHeader: `"Recipient" <recipient@example.com>`,
+		},
+		selfEmails,
+		false,
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("self-sent buildReplyRecipients: %v", err)
+	}
+	if got := formatMailboxes(selfSent.To); len(got) != 1 || got[0] != `"Recipient" <recipient@example.com>` {
+		t.Fatalf("self-sent To = %#v", got)
+	}
+
+	_, err = buildReplyRecipients(
+		&replyInfo{
+			FromAddr:    `"External Sender" <sender@example.com>`,
+			ReplyToAddr: `"Me Person" <me@example.com>`,
+			ToHeader:    `"Unrelated Recipient" <recipient@example.com>`,
+		},
+		selfEmails,
+		false,
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+	if err == nil || !strings.Contains(err.Error(), "reply has no recipients") {
+		t.Fatalf("external sender with self Reply-To error = %v", err)
+	}
+}
+
 func TestParseMailboxValuesPreservesCommaInDisplayName(t *testing.T) {
 	addrs, err := parseMailboxValues("--to", []string{`"Bourgon, Malo" <malo@example.com>`})
 	if err != nil {

--- a/internal/cmd/gmail_sanitize.go
+++ b/internal/cmd/gmail_sanitize.go
@@ -67,7 +67,7 @@ func extractSanitizedHTMLText(value string) string {
 		case html.StartTagToken, html.SelfClosingTagToken:
 			name, _ := tokenizer.TagName()
 			tag := strings.ToLower(string(name))
-			if tag == "script" || tag == "style" {
+			if tag == "script" || tag == literalStyle {
 				skipDepth++
 			}
 			if sanitizeBlockTags[tag] {
@@ -76,7 +76,7 @@ func extractSanitizedHTMLText(value string) string {
 		case html.EndTagToken:
 			name, _ := tokenizer.TagName()
 			tag := strings.ToLower(string(name))
-			if (tag == "script" || tag == "style") && skipDepth > 0 {
+			if (tag == "script" || tag == literalStyle) && skipDepth > 0 {
 				skipDepth--
 			}
 			if sanitizeBlockTags[tag] {

--- a/internal/cmd/gmail_send.go
+++ b/internal/cmd/gmail_send.go
@@ -15,7 +15,7 @@ type GmailSendCmd struct {
 	To               string   `name:"to" help:"Recipients (comma-separated; required unless --reply-all is used)"`
 	Cc               string   `name:"cc" help:"CC recipients (comma-separated)"`
 	Bcc              string   `name:"bcc" help:"BCC recipients (comma-separated)"`
-	Subject          string   `name:"subject" help:"Subject (required)"`
+	Subject          string   `name:"subject" help:"Subject (required unless replying; inherited with Re: for replies)"`
 	Body             string   `name:"body" help:"Body (plain text; required unless --body-html is set)"`
 	BodyFile         string   `name:"body-file" help:"Body file path (plain text; '-' for stdin)"`
 	BodyHTML         string   `name:"body-html" help:"Body (HTML; optional)"`
@@ -66,6 +66,7 @@ func (c *GmailSendCmd) Run(ctx context.Context, flags *RootFlags) error {
 
 	replyToMessageID := normalizeGmailMessageID(c.ReplyToMessageID)
 	threadID := normalizeGmailThreadID(c.ThreadID)
+	subject := strings.TrimSpace(c.Subject)
 
 	body, htmlBodyInput, err := resolveComposeBodyInputs(ctx, c.Body, c.BodyFile, c.BodyHTML, c.BodyHTMLFile)
 	if err != nil {
@@ -90,7 +91,7 @@ func (c *GmailSendCmd) Run(ctx context.Context, flags *RootFlags) error {
 	if strings.TrimSpace(c.To) == "" && !c.ReplyAll {
 		return usage("required: --to (or use --reply-all with --reply-to-message-id or --thread-id)")
 	}
-	if strings.TrimSpace(c.Subject) == "" {
+	if subject == "" && replyToMessageID == "" && threadID == "" {
 		return usage("required: --subject")
 	}
 	if strings.TrimSpace(body) == "" && strings.TrimSpace(htmlBodyInput) == "" {
@@ -118,7 +119,7 @@ func (c *GmailSendCmd) Run(ctx context.Context, flags *RootFlags) error {
 		"to":                  splitCSV(c.To),
 		"cc":                  splitCSV(c.Cc),
 		"bcc":                 splitCSV(c.Bcc),
-		"subject":             strings.TrimSpace(c.Subject),
+		"subject":             subject,
 		"reply_to_message_id": replyToMessageID,
 		"thread_id":           threadID,
 		"reply_all":           c.ReplyAll,
@@ -160,6 +161,9 @@ func (c *GmailSendCmd) Run(ctx context.Context, flags *RootFlags) error {
 	if err != nil {
 		return err
 	}
+	if subject == "" {
+		subject = autoReplySubject("", replyInfo.Subject)
+	}
 
 	// Determine recipients
 	var toRecipients, ccRecipients []string
@@ -187,6 +191,7 @@ func (c *GmailSendCmd) Run(ctx context.Context, flags *RootFlags) error {
 	if err != nil {
 		return err
 	}
+	atts = append(atts, replyInfo.InlineResources...)
 
 	var trackingCfg *tracking.Config
 	if c.Track {
@@ -200,7 +205,7 @@ func (c *GmailSendCmd) Run(ctx context.Context, flags *RootFlags) error {
 	results, err := sendGmailBatches(ctx, svc, sendMessageOptions{
 		FromAddr:    from.header,
 		ReplyTo:     c.ReplyTo,
-		Subject:     c.Subject,
+		Subject:     subject,
 		Body:        body,
 		BodyHTML:    htmlBody,
 		ReplyInfo:   replyInfo,

--- a/internal/cmd/gmail_send_quote_test.go
+++ b/internal/cmd/gmail_send_quote_test.go
@@ -70,3 +70,86 @@ func TestReplyInfoFromMessage_IncludeBody_DoesNotTreatHTMLAsPlain(t *testing.T) 
 		t.Fatalf("expected BodyHTML to be set")
 	}
 }
+
+func TestApplyQuoteToBodiesDerivesPlainReplyFromHTML(t *testing.T) {
+	plain, html := applyQuoteToBodies(
+		"",
+		"<p>HTML <strong>reply</strong></p>",
+		true,
+		&replyInfo{
+			FromAddr: "sender@example.com",
+			Date:     "Mon, 1 Jan 2024 00:00:00 +0000",
+			Body:     "Original plain",
+			BodyHTML: "<p>Original HTML</p>",
+		},
+	)
+
+	if !strings.Contains(plain, "HTML reply") {
+		t.Fatalf("plain body omitted derived reply text: %q", plain)
+	}
+	if !strings.Contains(plain, "> Original plain") {
+		t.Fatalf("plain body omitted quoted original: %q", plain)
+	}
+	if !strings.Contains(html, "<p>HTML <strong>reply</strong></p>") || !strings.Contains(html, "gmail_quote") {
+		t.Fatalf("HTML body missing reply or quote: %q", html)
+	}
+}
+
+func TestApplyQuoteToBodiesOmitsNonVisibleHTMLFromPlainReply(t *testing.T) {
+	plain, _ := applyQuoteToBodies(
+		"",
+		`<!doctype html><html><head><title>Hidden title</title><style>.secret { color: red; }</style><script>alert("hidden")</script></head><body><p>Visible reply</p></body></html>`,
+		true,
+		&replyInfo{
+			Body:     "Original plain",
+			BodyHTML: "<p>Original HTML</p>",
+		},
+	)
+
+	if !strings.Contains(plain, "Visible reply") || !strings.Contains(plain, "> Original plain") {
+		t.Fatalf("plain body missing visible reply or quote: %q", plain)
+	}
+	for _, hidden := range []string{"Hidden title", ".secret", `alert("hidden")`} {
+		if strings.Contains(plain, hidden) {
+			t.Fatalf("plain body included non-visible HTML %q: %q", hidden, plain)
+		}
+	}
+}
+
+func TestApplyQuoteToBodiesDerivesPlainQuoteFromHTMLOriginal(t *testing.T) {
+	plain, html := applyQuoteToBodies(
+		"",
+		"<p>HTML reply</p>",
+		true,
+		&replyInfo{
+			FromAddr: "sender@example.com",
+			BodyHTML: "<p>HTML-only original</p>",
+		},
+	)
+
+	if !strings.Contains(plain, "HTML reply") || !strings.Contains(plain, "> HTML-only original") {
+		t.Fatalf("plain body missing derived reply or quote: %q", plain)
+	}
+	if !strings.Contains(html, "<p>HTML reply</p>") || !strings.Contains(html, "HTML-only original") {
+		t.Fatalf("HTML body missing reply or quote: %q", html)
+	}
+}
+
+func TestApplyQuoteToBodiesKeepsImageOnlyReplyHTMLOnly(t *testing.T) {
+	plain, html := applyQuoteToBodies(
+		"",
+		`<img src="cid:reply-image">`,
+		true,
+		&replyInfo{
+			Body:     "Original plain",
+			BodyHTML: "<p>Original HTML</p>",
+		},
+	)
+
+	if strings.TrimSpace(plain) != "" {
+		t.Fatalf("image-only HTML reply produced quote-only plain alternative: %q", plain)
+	}
+	if !strings.Contains(html, `cid:reply-image`) || !strings.Contains(html, "gmail_quote") {
+		t.Fatalf("HTML body missing reply image or quote: %q", html)
+	}
+}

--- a/internal/cmd/gmail_send_signature.go
+++ b/internal/cmd/gmail_send_signature.go
@@ -133,7 +133,7 @@ func htmlToPlainText(value string) string {
 				return
 			}
 			switch strings.ToLower(n.Data) {
-			case "head", "style", "script", "template", "noscript", literalTitle:
+			case "head", literalStyle, "script", "template", "noscript", literalTitle:
 				return
 			case "br":
 				writeHTMLNewline(&out)
@@ -176,7 +176,7 @@ func hiddenHTMLElement(n *nethtml.Node) bool {
 			if strings.EqualFold(n.Data, "input") && strings.EqualFold(strings.TrimSpace(attr.Val), "hidden") {
 				return true
 			}
-		case "style":
+		case literalStyle:
 			if hiddenInlineStyle(attr.Val) {
 				return true
 			}

--- a/internal/cmd/gmail_send_signature.go
+++ b/internal/cmd/gmail_send_signature.go
@@ -55,7 +55,7 @@ func (c *GmailSendCmd) resolveComposeSignature(ctx context.Context, svc *gmail.S
 	}
 	htmlSignature := strings.TrimSpace(sendAs.Signature)
 	return composeSignature{
-		Plain: signatureHTMLToText(htmlSignature),
+		Plain: htmlToPlainText(htmlSignature),
 		HTML:  htmlSignature,
 	}, email, nil
 }
@@ -84,7 +84,7 @@ func readComposeSignatureFile(path string) (composeSignature, error) {
 	}
 	if looksLikeHTML(value) {
 		return composeSignature{
-			Plain: signatureHTMLToText(value),
+			Plain: htmlToPlainText(value),
 			HTML:  value,
 		}, nil
 	}
@@ -109,7 +109,7 @@ func appendBodyBlock(body, block string) string {
 	return body + "\n\n" + block
 }
 
-func signatureHTMLToText(value string) string {
+func htmlToPlainText(value string) string {
 	value = strings.TrimSpace(value)
 	if value == "" {
 		return ""
@@ -130,15 +130,17 @@ func signatureHTMLToText(value string) string {
 			out.WriteString(n.Data)
 		case nethtml.ElementNode:
 			switch strings.ToLower(n.Data) {
+			case "head", "style", "script", "template", "noscript", literalTitle:
+				return
 			case "br":
-				writeSignatureNewline(&out)
+				writeHTMLNewline(&out)
 				return
 			case "div", "p", "li":
-				writeSignatureNewline(&out)
+				writeHTMLNewline(&out)
 				for child := n.FirstChild; child != nil; child = child.NextSibling {
 					walk(child)
 				}
-				writeSignatureNewline(&out)
+				writeHTMLNewline(&out)
 				return
 			}
 		}
@@ -158,7 +160,7 @@ func signatureHTMLToText(value string) string {
 	return strings.Join(kept, "\n")
 }
 
-func writeSignatureNewline(out *strings.Builder) {
+func writeHTMLNewline(out *strings.Builder) {
 	if out.Len() == 0 {
 		return
 	}

--- a/internal/cmd/gmail_send_test.go
+++ b/internal/cmd/gmail_send_test.go
@@ -1091,7 +1091,7 @@ func TestBuildReplyAllRecipients(t *testing.T) {
 				CcAddrs:  nil,
 			},
 			selfEmail: "me@example.com",
-			expectTo:  []string{"sender@example.com"},
+			expectTo:  []string{`"Sender Name" <sender@example.com>`},
 			expectCc:  []string{},
 		},
 		{
@@ -1170,7 +1170,7 @@ func TestBuildReplyAllRecipients(t *testing.T) {
 				CcAddrs:     nil,
 			},
 			selfEmail: "me@example.com",
-			expectTo:  []string{"list@example.com", "alice@example.com"},
+			expectTo:  []string{`"Mailing List" <list@example.com>`, "alice@example.com"},
 			expectCc:  []string{},
 		},
 		{

--- a/internal/cmd/literals.go
+++ b/internal/cmd/literals.go
@@ -10,6 +10,7 @@ const (
 	literalAuto    = "auto"
 	literalDefault = "default"
 	literalError   = "error"
+	literalTitle   = "title"
 	literalWindows = "windows"
 
 	// literalMarkdownTripleDash is the three-dash token used for YAML

--- a/internal/cmd/literals.go
+++ b/internal/cmd/literals.go
@@ -10,6 +10,7 @@ const (
 	literalAuto    = "auto"
 	literalDefault = "default"
 	literalError   = "error"
+	literalStyle   = "style"
 	literalTitle   = "title"
 	literalWindows = "windows"
 

--- a/internal/cmd/root_more_test.go
+++ b/internal/cmd/root_more_test.go
@@ -352,6 +352,8 @@ func TestGmailNoSendBlocksBeforeAuth(t *testing.T) {
 	setTestConfigHome(t)
 	tests := [][]string{
 		{"--gmail-no-send", "gmail", "send", "--to", "a@example.com", "--subject", "S", "--body", "B"},
+		{"--gmail-no-send", "gmail", "reply", "msg-1", "--body", "B"},
+		{"--gmail-no-send", "gmail", "reply-all", "msg-1", "--body", "B"},
 		{"--gmail-no-send", "gmail", "autoreply", "from:a@example.com", "--subject", "S", "--body", "B"},
 		{"--gmail-no-send", "gmail", "forward", "msg-1", "--to", "a@example.com"},
 		{"--gmail-no-send", "gmail", "fwd", "msg-1", "--to", "a@example.com"},

--- a/internal/cmd/slides_layout.go
+++ b/internal/cmd/slides_layout.go
@@ -11,15 +11,13 @@ const (
 	LayoutKindThreeCols
 )
 
-const slideyLayoutTitle = "title"
-
 // MapSlideyLayout maps a slidey frontmatter layout name to a LayoutKind.
 // Unknown values fall back to LayoutKindDefault.
 func MapSlideyLayout(name string) LayoutKind {
 	switch name {
 	case "center":
 		return LayoutKindCenter
-	case slideyLayoutTitle, "hero", "statement":
+	case literalTitle, "hero", "statement":
 		return LayoutKindSectionHeader
 	case "two-cols":
 		return LayoutKindTwoCols

--- a/internal/cmd/slides_markdown.go
+++ b/internal/cmd/slides_markdown.go
@@ -109,7 +109,7 @@ func inlinesToText(inlines []Inline) string {
 
 func layoutSkipsTitleHoist(layout string) bool {
 	switch layout {
-	case slideyLayoutTitle, "hero", "statement":
+	case literalTitle, "hero", "statement":
 		return true
 	}
 	return false

--- a/internal/mailmime/mime.go
+++ b/internal/mailmime/mime.go
@@ -24,6 +24,7 @@ var (
 	errRandomSourceRequired     = errors.New("random source is required")
 	errAttachmentReaderRequired = errors.New("attachment file reader is required")
 	errHeaderValueNewline       = errors.New("header value contains newline")
+	errInlineContentIDRequired  = errors.New("inline attachment missing Content-ID")
 )
 
 // Attachment describes an RFC822 attachment from bytes or a file path.
@@ -203,6 +204,7 @@ func BuildRFC822(opts Options, cfg Config) ([]byte, error) {
 		b.WriteString("\r\n")
 
 		fmt.Fprintf(&b, "--%s\r\n", mixedBoundary)
+
 		if len(inlineAttachments) > 0 {
 			if err := writeRelatedEntity(&b, plainBody, htmlBody, hasPlain, hasHTML, inlineAttachments, cfg.Random); err != nil {
 				return nil, err
@@ -213,10 +215,12 @@ func BuildRFC822(opts Options, cfg Config) ([]byte, error) {
 
 		for _, attachment := range regularAttachments {
 			fmt.Fprintf(&b, "\r\n--%s\r\n", mixedBoundary)
+
 			if err := writeAttachmentEntity(&b, attachment); err != nil {
 				return nil, err
 			}
 		}
+
 		fmt.Fprintf(&b, "--%s--\r\n", mixedBoundary)
 	}
 
@@ -273,15 +277,19 @@ func writeRelatedEntity(b *bytes.Buffer, plainBody, htmlBody string, hasPlain, h
 		relatedRootMIMEType(hasPlain, hasHTML),
 	)
 	fmt.Fprintf(b, "--%s\r\n", relatedBoundary)
+
 	if err := writeBodyEntity(b, plainBody, htmlBody, hasPlain, hasHTML, random); err != nil {
 		return err
 	}
+
 	for _, attachment := range inline {
 		fmt.Fprintf(b, "\r\n--%s\r\n", relatedBoundary)
+
 		if err := writeAttachmentEntity(b, attachment); err != nil {
 			return err
 		}
 	}
+
 	fmt.Fprintf(b, "--%s--\r\n", relatedBoundary)
 
 	return nil
@@ -291,34 +299,44 @@ func relatedRootMIMEType(hasPlain, hasHTML bool) string {
 	if hasPlain && hasHTML {
 		return "multipart/alternative"
 	}
+
 	if hasHTML {
 		return "text/html"
 	}
+
 	return "text/plain"
 }
 
 func writeAttachmentEntity(b *bytes.Buffer, attachment Attachment) error {
 	fmt.Fprintf(b, "Content-Type: %s\r\n", attachment.MIMEType)
 	b.WriteString("Content-Transfer-Encoding: base64\r\n")
+
 	if attachment.Inline {
 		contentID := normalizeContentID(attachment.ContentID)
+
 		if contentID == "" {
-			return errors.New("inline attachment missing Content-ID")
+			return errInlineContentIDRequired
 		}
+
 		if err := ValidateHeaderValue(contentID); err != nil {
 			return fmt.Errorf("invalid Content-ID: %w", err)
 		}
+
 		fmt.Fprintf(b, "Content-ID: <%s>\r\n", contentID)
+
 		if location := strings.TrimSpace(attachment.ContentLocation); location != "" {
 			if err := ValidateHeaderValue(location); err != nil {
 				return fmt.Errorf("invalid Content-Location: %w", err)
 			}
+
 			fmt.Fprintf(b, "Content-Location: %s\r\n", location)
 		}
+
 		fmt.Fprintf(b, "Content-Disposition: inline; %s\r\n\r\n", contentDispositionFilename(attachment.Filename))
 	} else {
 		fmt.Fprintf(b, "Content-Disposition: attachment; %s\r\n\r\n", contentDispositionFilename(attachment.Filename))
 	}
+
 	b.WriteString(wrapBase64(attachment.Data))
 	b.WriteString("\r\n")
 

--- a/internal/mailmime/mime_test.go
+++ b/internal/mailmime/mime_test.go
@@ -164,6 +164,7 @@ func TestBuildRFC822WithInlineResource(t *testing.T) {
 	if err != nil {
 		t.Fatalf("buildRFC822: %v", err)
 	}
+
 	s := string(raw)
 	for _, want := range []string{
 		"multipart/related",


### PR DESCRIPTION
## Summary

- add first-class `gmail reply` and `gmail reply-all` commands
- inherit `Re:` subjects and quote the original message by default
- preserve display names and derive Reply-To/From plus reply-all To/Cc recipients
- make `--to`, `--cc`, and `--bcc` additive placement/move operations, with repeatable `--remove`
- preserve quoted CID resources as `multipart/related` instead of sending broken inline images
- keep edited-subject replies out of the original Gmail thread while retaining RFC reply headers
- preserve inline images when forwarding and stop forwards from claiming reply threading
- document the workflow in the command reference, Gmail workflow guide, specification, changelog, and `gog` agent skill

## Why

The Gmail API accepts complete RFC MIME messages through `messages.send`; it does not provide reply or reply-all methods. The previous lower-level send flags exposed MIME, subject, quote, recipient, display-name, and inline-resource details to callers. That made normal email behavior fragile for both humans and agents.

These commands move that behavior into a stable CLI primitive with Gmail-like defaults.

Official contracts used:

- https://developers.google.com/workspace/gmail/api/guides/threads
- https://developers.google.com/workspace/gmail/api/guides/sending
- https://www.rfc-editor.org/rfc/rfc2387.html
- https://www.rfc-editor.org/rfc/rfc2392

## Compatibility

- `gmail send --reply-to-message-id` remains available as the lower-level composition path and now inherits the original subject when `--subject` is omitted.
- Explicit recipient values on `gmail send` retain replacement semantics; first-class reply commands provide additive/move semantics.
- Forwards no longer set the original `threadId` or RFC reply headers because their changed `Fwd:` subject cannot satisfy Gmail's explicit thread-matching contract.

## Validation

- `make ci`
- structured autoreview: clean after fixing a nameless forwarded-attachment regression
- unit coverage for recipient derivation, display names containing commas, moves/removals, inherited and edited subjects, no-send guards, CID extraction/fetching, MIME nesting, broken CID failure, forwarding, and nameless attachments
- live Gmail smoke: sent a seed message, replied with `gmail reply`, and verified the stored raw message had the same thread, inherited `Re:` subject, correct To, matching `In-Reply-To` and `References`, reply body, and quoted original
- live reply-all smoke: moved the inherited recipient from To to Bcc, verified no duplicate remained, confirmed `--no-quote`, and confirmed Gmail retained the original thread
- disposable live-test messages moved to Trash after verification
