### PR TITLE
feat(slides): add structured introspection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Slides: allow `insert-image` and `replace-slide` to use public HTTPS image URLs without temporary Drive sharing. (#825) — thanks @sebsnyk.
+- Slides: add structured element geometry, styled text runs, table-cell content, image source URLs, native presentation metadata, and read-only text location with exact UTF-16 ranges. (#822) — thanks @sebsnyk.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -381,11 +381,15 @@ gog sheets banding set <spreadsheetId> 'Sheet1!A1:D100'
 
 Docs: [Slides from Markdown](docs/slides-markdown.md),
 [template replacement](docs/slides-template-replacement.md),
+[introspection](docs/slides-introspection.md),
 [`gog slides`](docs/commands/gog-slides.md),
 [`gog forms`](docs/commands/gog-forms.md).
 
 ```bash
 gog slides create-from-markdown "Weekly update" --content-file slides.md
+gog slides info <presentationId> --json
+gog slides read-slide <presentationId> <slideId> --detail --json
+gog slides locate <presentationId> "Quarterly revenue" --all --json
 gog slides insert-image <presentationId> <slideId> chart.png --x 24 --y 24 --width 240
 gog slides insert-text <presentationId> <objectId> "New text"
 gog forms update <formId> --quiz=true

--- a/docs/commands.generated.md
+++ b/docs/commands.generated.md
@@ -596,8 +596,9 @@ Generated from `gog schema --json`.
     - [`gog slides (slide) insert-image --width=FLOAT-64 <presentationId> <slideId> [<image>] [flags]`](commands/gog-slides-insert-image.md) - Insert a local or public image at a position and size
     - [`gog slides (slide) insert-text <presentationId> <objectId> <text> [flags]`](commands/gog-slides-insert-text.md) - Insert text into an existing page element (shape or table) by objectId
     - [`gog slides (slide) list-slides <presentationId>`](commands/gog-slides-list-slides.md) - List all slides with their object IDs
+    - [`gog slides (slide) locate (find-element) <presentationId> <text> [flags]`](commands/gog-slides-locate.md) - Locate text in shapes and table cells with object IDs and UTF-16 ranges
     - [`gog slides (slide) raw <presentationId> [flags]`](commands/gog-slides-raw.md) - Dump raw Google Slides API response as JSON (Presentations.Get; lossless; for scripting and LLM consumption)
-    - [`gog slides (slide) read-slide <presentationId> <slideId>`](commands/gog-slides-read-slide.md) - Read slide content: speaker notes, text elements, and images
+    - [`gog slides (slide) read-slide <presentationId> <slideId> [flags]`](commands/gog-slides-read-slide.md) - Read slide content: speaker notes, text elements, and images
     - [`gog slides (slide) replace-slide <presentationId> <slideId> [<image>] [flags]`](commands/gog-slides-replace-slide.md) - Replace an existing slide image from a local file or public URL
     - [`gog slides (slide) replace-text <presentationId> <find> <replacement> [flags]`](commands/gog-slides-replace-text.md) - Find-and-replace text across a presentation
     - [`gog slides (slide) thumbnail (thumb) <presentationId> <slideId> [flags]`](commands/gog-slides-thumbnail.md) - Get or download a rendered thumbnail for a slide

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -2,7 +2,7 @@
 
 Every `gog` command has a generated docs page. The source of truth is the live CLI schema; run `make docs-commands` after changing command names, flags, help text, aliases, or arguments.
 
-Generated pages: 646.
+Generated pages: 647.
 
 ## Top-level Commands
 
@@ -647,6 +647,7 @@ Generated pages: 646.
     - [gog slides insert-image](gog-slides-insert-image.md) - Insert a local or public image at a position and size
     - [gog slides insert-text](gog-slides-insert-text.md) - Insert text into an existing page element (shape or table) by objectId
     - [gog slides list-slides](gog-slides-list-slides.md) - List all slides with their object IDs
+    - [gog slides locate](gog-slides-locate.md) - Locate text in shapes and table cells with object IDs and UTF-16 ranges
     - [gog slides raw](gog-slides-raw.md) - Dump raw Google Slides API response as JSON (Presentations.Get; lossless; for scripting and LLM consumption)
     - [gog slides read-slide](gog-slides-read-slide.md) - Read slide content: speaker notes, text elements, and images
     - [gog slides replace-slide](gog-slides-replace-slide.md) - Replace an existing slide image from a local file or public URL

--- a/docs/commands/gog-slides-locate.md
+++ b/docs/commands/gog-slides-locate.md
@@ -1,13 +1,13 @@
-# `gog slides read-slide`
+# `gog slides locate`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Read slide content: speaker notes, text elements, and images
+Locate text in shapes and table cells with object IDs and UTF-16 ranges
 
 ## Usage
 
 ```bash
-gog slides (slide) read-slide <presentationId> <slideId> [flags]
+gog slides (slide) locate (find-element) <presentationId> <text> [flags]
 ```
 
 ## Parent
@@ -20,19 +20,23 @@ gog slides (slide) read-slide <presentationId> <slideId> [flags]
 | --- | --- | --- | --- |
 | `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email, alias, or auto for authenticated Google API commands |
+| `--all` | `bool` |  | Return all matches |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
-| `--detail` | `bool` |  | Include normalized element geometry, text runs/styles, paragraphs, and table cells |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
 | `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
 | `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
 | `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
+| `--fail-empty`<br>`--non-empty`<br>`--require-results` | `bool` |  | Exit with code 3 if no matches |
 | `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
 | `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
 | `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--match-case` | `bool` |  | Use case-sensitive matching |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `--occurrence` | `*int` |  | Return the Nth occurrence (1-based; default first) |
+| `--page` | `string` |  | Limit matches to one slide object ID |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |

--- a/docs/commands/gog-slides.md
+++ b/docs/commands/gog-slides.md
@@ -27,6 +27,7 @@ gog slides (slide) <command> [flags]
 - [gog slides insert-image](gog-slides-insert-image.md) - Insert a local or public image at a position and size
 - [gog slides insert-text](gog-slides-insert-text.md) - Insert text into an existing page element (shape or table) by objectId
 - [gog slides list-slides](gog-slides-list-slides.md) - List all slides with their object IDs
+- [gog slides locate](gog-slides-locate.md) - Locate text in shapes and table cells with object IDs and UTF-16 ranges
 - [gog slides raw](gog-slides-raw.md) - Dump raw Google Slides API response as JSON (Presentations.Get; lossless; for scripting and LLM consumption)
 - [gog slides read-slide](gog-slides-read-slide.md) - Read slide content: speaker notes, text elements, and images
 - [gog slides replace-slide](gog-slides-replace-slide.md) - Replace an existing slide image from a local file or public URL

--- a/docs/slides-introspection.md
+++ b/docs/slides-introspection.md
@@ -1,0 +1,50 @@
+# Slides introspection
+
+Use the structured Slides commands when an edit needs stable object IDs or exact
+text ranges. `gog slides raw` remains the lossless API escape hatch.
+
+## Presentation metadata
+
+`slides info` combines Drive file metadata with Slides-native metadata:
+
+```bash
+gog slides info <presentationId> --json
+```
+
+The `presentation` object includes slide count, page size in points, locale,
+masters and their theme colors, and layouts.
+
+## Slide structure
+
+The default `read-slide` output includes shape text, table-cell text, image
+content/source URLs, and speaker notes. Add `--detail --json` for normalized
+elements:
+
+```bash
+gog slides read-slide <presentationId> <slideId> --detail --json
+```
+
+Detailed elements are flattened in visual hierarchy order. Group children carry
+`parentObjectId`. `geometry` is the element's axis-aligned bounding box in
+points after its group and element transforms are applied. Text runs retain the
+Slides API's UTF-16 `startIndex`/`endIndex`, style, links, paragraph style, and
+bullet metadata. Foreground/background colors are also normalized as `#RRGGBB`
+or `theme:NAME`; API-omitted inherited style fields remain omitted.
+
+Rendered image `contentUrl` values are short-lived and requester-scoped.
+`sourceUrl` is included when the presentation retains the original insertion
+URL.
+
+## Locate editable text
+
+`slides locate` searches shapes and table cells without changing the deck:
+
+```bash
+gog slides locate <presentationId> "Quarterly revenue" --all --json
+gog slides locate <presentationId> "Approved" --page <slideId> --match-case
+```
+
+Each match includes the slide and element object IDs plus exact UTF-16 range.
+Table matches also include zero-based row and column indexes. By default only
+the first match is returned; use `--all` or `--occurrence N` to select results,
+and `--fail-empty` for automation that requires a match.

--- a/internal/cmd/execute_docs_slides_sheets_more_test.go
+++ b/internal/cmd/execute_docs_slides_sheets_more_test.go
@@ -14,6 +14,7 @@ import (
 	"google.golang.org/api/docs/v1"
 	"google.golang.org/api/drive/v3"
 	"google.golang.org/api/option"
+	"google.golang.org/api/slides/v1"
 
 	"github.com/steipete/gogcli/internal/app"
 )
@@ -48,6 +49,14 @@ func TestExecute_DocsSlidesSheets_CopyCreateInfoCat_JSON(t *testing.T) {
 						},
 					},
 				},
+			})
+			return
+		case r.Method == http.MethodGet && strings.HasPrefix(path, "/v1/presentations/"):
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"presentationId": "p1",
+				"title":          "Slides 1",
+				"slides":         []any{map[string]any{"objectId": "slide1"}},
 			})
 			return
 		case r.Method == http.MethodGet && strings.Contains(drivePath, "/files/d1") && !strings.HasSuffix(drivePath, "/copy"):
@@ -140,6 +149,15 @@ func TestExecute_DocsSlidesSheets_CopyCreateInfoCat_JSON(t *testing.T) {
 		t.Fatalf("NewDocsService: %v", err)
 	}
 
+	slidesSvc, err := slides.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewSlidesService: %v", err)
+	}
+
 	export := func(_ context.Context, _ *drive.Service, fileID, mimeType string) (*http.Response, error) {
 		if fileID == "" || mimeType == "" {
 			return nil, fmt.Errorf("invalid export request: file=%q mime=%q", fileID, mimeType)
@@ -155,6 +173,9 @@ func TestExecute_DocsSlidesSheets_CopyCreateInfoCat_JSON(t *testing.T) {
 	runtime := &app.Runtime{Services: app.Services{
 		Docs: func(context.Context, string) (*docs.Service, error) {
 			return docSvc, nil
+		},
+		Slides: func(context.Context, string) (*slides.Service, error) {
+			return slidesSvc, nil
 		},
 		Drive:       stubDriveService(svc),
 		DriveExport: export,

--- a/internal/cmd/info_via_drive.go
+++ b/internal/cmd/info_via_drive.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"strings"
 
+	"google.golang.org/api/drive/v3"
+
 	"github.com/steipete/gogcli/internal/outfmt"
 	"github.com/steipete/gogcli/internal/ui"
 )
@@ -19,10 +21,17 @@ type infoViaDriveOptions struct {
 const infoViaDriveDefaultKindLabel = "expected type"
 
 func infoViaDrive(ctx context.Context, flags *RootFlags, opts infoViaDriveOptions, id string) error {
-	u := ui.FromContext(ctx)
-	account, err := requireAccount(flags)
+	f, err := loadInfoViaDrive(ctx, flags, opts, id)
 	if err != nil {
 		return err
+	}
+	return writeInfoViaDrive(ctx, f)
+}
+
+func loadInfoViaDrive(ctx context.Context, flags *RootFlags, opts infoViaDriveOptions, id string) (*drive.File, error) {
+	account, err := requireAccount(flags)
+	if err != nil {
+		return nil, err
 	}
 
 	argName := strings.TrimSpace(opts.ArgName)
@@ -31,12 +40,12 @@ func infoViaDrive(ctx context.Context, flags *RootFlags, opts infoViaDriveOption
 	}
 	id = normalizeGoogleID(strings.TrimSpace(id))
 	if id == "" {
-		return usage(fmt.Sprintf("empty %s", argName))
+		return nil, usage(fmt.Sprintf("empty %s", argName))
 	}
 
 	svc, err := driveService(ctx, account)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	f, err := svc.Files.Get(id).
@@ -45,23 +54,27 @@ func infoViaDrive(ctx context.Context, flags *RootFlags, opts infoViaDriveOption
 		Context(ctx).
 		Do()
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if f == nil {
-		return errors.New("file not found")
+		return nil, errors.New("file not found")
 	}
 	if opts.ExpectedMime != "" && f.MimeType != opts.ExpectedMime {
 		label := strings.TrimSpace(opts.KindLabel)
 		if label == "" {
 			label = infoViaDriveDefaultKindLabel
 		}
-		return fmt.Errorf("file is not a %s (mimeType=%q)", label, f.MimeType)
+		return nil, fmt.Errorf("file is not a %s (mimeType=%q)", label, f.MimeType)
 	}
+	return f, nil
+}
 
+func writeInfoViaDrive(ctx context.Context, f *drive.File) error {
 	if outfmt.IsJSON(ctx) {
 		return outfmt.WriteJSON(ctx, stdoutWriter(ctx), map[string]any{strFile: f})
 	}
 
+	u := ui.FromContext(ctx)
 	u.Out().Linef("id\t%s", f.Id)
 	u.Out().Linef("name\t%s", f.Name)
 	u.Out().Linef("mime\t%s", f.MimeType)

--- a/internal/cmd/slides.go
+++ b/internal/cmd/slides.go
@@ -25,6 +25,7 @@ type SlidesCmd struct {
 	ListSlides         SlidesListSlidesCmd         `cmd:"" name:"list-slides" help:"List all slides with their object IDs"`
 	DeleteSlide        SlidesDeleteSlideCmd        `cmd:"" name:"delete-slide" help:"Delete a slide by object ID"`
 	ReadSlide          SlidesReadSlideCmd          `cmd:"" name:"read-slide" help:"Read slide content: speaker notes, text elements, and images"`
+	Locate             SlidesLocateCmd             `cmd:"" name:"locate" aliases:"find-element" help:"Locate text in shapes and table cells with object IDs and UTF-16 ranges"`
 	Thumbnail          SlidesThumbnailCmd          `cmd:"" name:"thumbnail" aliases:"thumb" help:"Get or download a rendered thumbnail for a slide"`
 	UpdateNotes        SlidesUpdateNotesCmd        `cmd:"" name:"update-notes" help:"Update speaker notes on an existing slide"`
 	ReplaceSlide       SlidesReplaceSlideCmd       `cmd:"" name:"replace-slide" help:"Replace an existing slide image from a local file or public URL"`
@@ -91,14 +92,6 @@ func (c *SlidesExportCmd) Run(ctx context.Context, flags *RootFlags) error {
 
 type SlidesInfoCmd struct {
 	PresentationID string `arg:"" name:"presentationId" help:"Presentation ID"`
-}
-
-func (c *SlidesInfoCmd) Run(ctx context.Context, flags *RootFlags) error {
-	return infoViaDrive(ctx, flags, infoViaDriveOptions{
-		ArgName:      "presentationId",
-		ExpectedMime: "application/vnd.google-apps.presentation",
-		KindLabel:    "Google Slides presentation",
-	}, c.PresentationID)
 }
 
 type SlidesCreateCmd struct {

--- a/internal/cmd/slides_info.go
+++ b/internal/cmd/slides_info.go
@@ -1,0 +1,170 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"strings"
+
+	"google.golang.org/api/slides/v1"
+
+	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+type slidesPresentationInfo struct {
+	Title      string             `json:"title,omitempty"`
+	Locale     string             `json:"locale,omitempty"`
+	RevisionID string             `json:"revisionId,omitempty"`
+	SlideCount int                `json:"slideCount"`
+	PageSize   *slidesPageSize    `json:"pageSize,omitempty"`
+	Masters    []slidesMasterInfo `json:"masters"`
+	Layouts    []slidesLayoutInfo `json:"layouts"`
+}
+
+type slidesPageSize struct {
+	Width  float64 `json:"width"`
+	Height float64 `json:"height"`
+	Unit   string  `json:"unit"`
+}
+
+type slidesMasterInfo struct {
+	ObjectID    string                 `json:"objectId"`
+	DisplayName string                 `json:"displayName,omitempty"`
+	ThemeColors []slidesThemeColorInfo `json:"themeColors"`
+}
+
+type slidesThemeColorInfo struct {
+	Type string `json:"type"`
+	RGB  string `json:"rgb"`
+}
+
+type slidesLayoutInfo struct {
+	ObjectID       string `json:"objectId"`
+	Name           string `json:"name,omitempty"`
+	DisplayName    string `json:"displayName,omitempty"`
+	MasterObjectID string `json:"masterObjectId,omitempty"`
+}
+
+func (c *SlidesInfoCmd) Run(ctx context.Context, flags *RootFlags) error {
+	file, err := loadInfoViaDrive(ctx, flags, infoViaDriveOptions{
+		ArgName:      "presentationId",
+		ExpectedMime: "application/vnd.google-apps.presentation",
+		KindLabel:    "Google Slides presentation",
+	}, c.PresentationID)
+	if err != nil {
+		return err
+	}
+
+	account, err := requireAccount(flags)
+	if err != nil {
+		return err
+	}
+	svc, err := slidesService(ctx, account)
+	if err != nil {
+		return err
+	}
+	presentation, err := svc.Presentations.Get(file.Id).Context(ctx).Do()
+	if err != nil {
+		return fmt.Errorf("get presentation: %w", err)
+	}
+	info, err := buildSlidesPresentationInfo(presentation)
+	if err != nil {
+		return err
+	}
+
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(ctx, stdoutWriter(ctx), map[string]any{
+			strFile:        file,
+			"presentation": info,
+		})
+	}
+	if err := writeInfoViaDrive(ctx, file); err != nil {
+		return err
+	}
+	u := ui.FromContext(ctx)
+	if info.Title != "" && info.Title != file.Name {
+		u.Out().Linef("slidesTitle\t%s", info.Title)
+	}
+	if info.Locale != "" {
+		u.Out().Linef("locale\t%s", info.Locale)
+	}
+	u.Out().Linef("slides\t%d", info.SlideCount)
+	if info.PageSize != nil {
+		u.Out().Linef("pageSize\t%.2f x %.2f %s", info.PageSize.Width, info.PageSize.Height, info.PageSize.Unit)
+	}
+	u.Out().Linef("masters\t%d", len(info.Masters))
+	u.Out().Linef("layouts\t%d", len(info.Layouts))
+	for _, master := range info.Masters {
+		colors := make([]string, 0, len(master.ThemeColors))
+		for _, color := range master.ThemeColors {
+			colors = append(colors, color.Type+"="+color.RGB)
+		}
+		u.Out().Linef("master\t%s\t%s\t%s", master.ObjectID, master.DisplayName, strings.Join(colors, ","))
+	}
+	return nil
+}
+
+func buildSlidesPresentationInfo(presentation *slides.Presentation) (slidesPresentationInfo, error) {
+	info := slidesPresentationInfo{
+		Masters: []slidesMasterInfo{},
+		Layouts: []slidesLayoutInfo{},
+	}
+	if presentation == nil {
+		return info, fmt.Errorf("presentation not found")
+	}
+	info.Title = presentation.Title
+	info.Locale = presentation.Locale
+	info.RevisionID = presentation.RevisionId
+	info.SlideCount = len(presentation.Slides)
+	if bounds, ok, err := slidesPageBounds(presentation.PageSize); err != nil {
+		return info, err
+	} else if ok {
+		info.PageSize = &slidesPageSize{Width: bounds.Width, Height: bounds.Height, Unit: bounds.Unit}
+	}
+
+	for _, master := range presentation.Masters {
+		if master == nil {
+			continue
+		}
+		masterInfo := slidesMasterInfo{ObjectID: master.ObjectId, ThemeColors: []slidesThemeColorInfo{}}
+		if master.MasterProperties != nil {
+			masterInfo.DisplayName = master.MasterProperties.DisplayName
+		}
+		if master.PageProperties != nil && master.PageProperties.ColorScheme != nil {
+			for _, pair := range master.PageProperties.ColorScheme.Colors {
+				if pair == nil || pair.Color == nil {
+					continue
+				}
+				masterInfo.ThemeColors = append(masterInfo.ThemeColors, slidesThemeColorInfo{
+					Type: pair.Type,
+					RGB:  slidesRGBHex(pair.Color),
+				})
+			}
+		}
+		info.Masters = append(info.Masters, masterInfo)
+	}
+	for _, layout := range presentation.Layouts {
+		if layout == nil {
+			continue
+		}
+		layoutInfo := slidesLayoutInfo{ObjectID: layout.ObjectId}
+		if layout.LayoutProperties != nil {
+			layoutInfo.Name = layout.LayoutProperties.Name
+			layoutInfo.DisplayName = layout.LayoutProperties.DisplayName
+			layoutInfo.MasterObjectID = layout.LayoutProperties.MasterObjectId
+		}
+		info.Layouts = append(info.Layouts, layoutInfo)
+	}
+	return info, nil
+}
+
+func slidesRGBHex(color *slides.RgbColor) string {
+	if color == nil {
+		return ""
+	}
+	component := func(value float64) int {
+		return int(math.Round(math.Max(0, math.Min(1, value)) * 255))
+	}
+	return fmt.Sprintf("#%02X%02X%02X", component(color.Red), component(color.Green), component(color.Blue))
+}

--- a/internal/cmd/slides_info_test.go
+++ b/internal/cmd/slides_info_test.go
@@ -1,0 +1,88 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/drive/v3"
+	"google.golang.org/api/slides/v1"
+)
+
+func TestSlidesInfoCmd_IncludesNativeMetadata(t *testing.T) {
+	driveSvc, closeDrive := newGoogleTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/files/pres1") {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":       "pres1",
+				"name":     "Deck",
+				"mimeType": "application/vnd.google-apps.presentation",
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}), drive.NewService)
+	t.Cleanup(closeDrive)
+
+	slidesSvc, closeSlides := newGoogleTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/presentations/pres1") {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"presentationId": "pres1",
+				"title":          "Deck",
+				"locale":         "en-US",
+				"revisionId":     "rev1",
+				"pageSize": map[string]any{
+					"width":  map[string]any{"magnitude": 12192000, "unit": "EMU"},
+					"height": map[string]any{"magnitude": 6858000, "unit": "EMU"},
+				},
+				"slides": []any{map[string]any{"objectId": "slide1"}, map[string]any{"objectId": "slide2"}},
+				"masters": []any{map[string]any{
+					"objectId":         "master1",
+					"masterProperties": map[string]any{"displayName": "Simple Light"},
+					"pageProperties": map[string]any{"colorScheme": map[string]any{"colors": []any{
+						map[string]any{"type": "ACCENT1", "color": map[string]any{"red": 1.0, "green": 0.5, "blue": 0.0}},
+					}}},
+				}},
+				"layouts": []any{map[string]any{
+					"objectId": "layout1",
+					"layoutProperties": map[string]any{
+						"name": "TITLE_AND_BODY", "displayName": "Title and body", "masterObjectId": "master1",
+					},
+				}},
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}), slides.NewService)
+	t.Cleanup(closeSlides)
+
+	var out bytes.Buffer
+	ctx := newCmdRuntimeJSONOutputContext(t, &out, io.Discard)
+	ctx = withDriveTestService(ctx, driveSvc)
+	ctx = withSlidesTestService(ctx, slidesSvc)
+	require.NoError(t, (&SlidesInfoCmd{PresentationID: "pres1"}).Run(ctx, &RootFlags{Account: "a@b.com"}))
+
+	var result struct {
+		File struct {
+			ID string `json:"id"`
+		} `json:"file"`
+		Presentation slidesPresentationInfo `json:"presentation"`
+	}
+	require.NoError(t, json.Unmarshal(out.Bytes(), &result))
+	assert.Equal(t, "pres1", result.File.ID)
+	assert.Equal(t, 2, result.Presentation.SlideCount)
+	require.NotNil(t, result.Presentation.PageSize)
+	assert.InDelta(t, 960, result.Presentation.PageSize.Width, 0.001)
+	assert.InDelta(t, 540, result.Presentation.PageSize.Height, 0.001)
+	require.Len(t, result.Presentation.Masters, 1)
+	require.Len(t, result.Presentation.Masters[0].ThemeColors, 1)
+	assert.Equal(t, "#FF8000", result.Presentation.Masters[0].ThemeColors[0].RGB)
+	require.Len(t, result.Presentation.Layouts, 1)
+	assert.Equal(t, "TITLE_AND_BODY", result.Presentation.Layouts[0].Name)
+}

--- a/internal/cmd/slides_introspection.go
+++ b/internal/cmd/slides_introspection.go
@@ -1,0 +1,386 @@
+package cmd
+
+import (
+	"fmt"
+	"math"
+	"strings"
+
+	"google.golang.org/api/slides/v1"
+)
+
+const (
+	slidesEMUPerPoint    = 12700
+	slidesElementTable   = "table"
+	slidesElementUnknown = "unknown"
+)
+
+type slidesElementDetail struct {
+	ObjectID       string                 `json:"objectId"`
+	Type           string                 `json:"type"`
+	ParentObjectID string                 `json:"parentObjectId,omitempty"`
+	Title          string                 `json:"title,omitempty"`
+	Description    string                 `json:"description,omitempty"`
+	Geometry       *slidesElementGeometry `json:"geometry,omitempty"`
+	Shape          *slidesShapeDetail     `json:"shape,omitempty"`
+	Image          *slidesImageDetail     `json:"image,omitempty"`
+	Table          *slidesTableDetail     `json:"table,omitempty"`
+	WordArt        string                 `json:"wordArt,omitempty"`
+}
+
+type slidesElementGeometry struct {
+	X      float64 `json:"x"`
+	Y      float64 `json:"y"`
+	Width  float64 `json:"width"`
+	Height float64 `json:"height"`
+	Unit   string  `json:"unit"`
+}
+
+type slidesShapeDetail struct {
+	ShapeType       string            `json:"shapeType,omitempty"`
+	PlaceholderType string            `json:"placeholderType,omitempty"`
+	Text            *slidesTextDetail `json:"text,omitempty"`
+}
+
+type slidesImageDetail struct {
+	ContentURL string `json:"contentUrl,omitempty"`
+	SourceURL  string `json:"sourceUrl,omitempty"`
+}
+
+type slidesTableDetail struct {
+	Rows    int64                   `json:"rows"`
+	Columns int64                   `json:"columns"`
+	Cells   []slidesTableCellDetail `json:"cells"`
+}
+
+type slidesTableCellDetail struct {
+	RowIndex    int64             `json:"rowIndex"`
+	ColumnIndex int64             `json:"columnIndex"`
+	RowSpan     int64             `json:"rowSpan"`
+	ColumnSpan  int64             `json:"columnSpan"`
+	Text        *slidesTextDetail `json:"text,omitempty"`
+}
+
+type slidesTextDetail struct {
+	Content    string                  `json:"content"`
+	Runs       []slidesTextRunDetail   `json:"runs"`
+	Paragraphs []slidesParagraphDetail `json:"paragraphs"`
+}
+
+type slidesTextRunDetail struct {
+	StartIndex      int64             `json:"startIndex"`
+	EndIndex        int64             `json:"endIndex"`
+	Content         string            `json:"content"`
+	Style           *slides.TextStyle `json:"style,omitempty"`
+	ForegroundColor string            `json:"foregroundColor,omitempty"`
+	BackgroundColor string            `json:"backgroundColor,omitempty"`
+	AutoTextType    string            `json:"autoTextType,omitempty"`
+}
+
+type slidesParagraphDetail struct {
+	StartIndex int64                  `json:"startIndex"`
+	EndIndex   int64                  `json:"endIndex"`
+	Style      *slides.ParagraphStyle `json:"style,omitempty"`
+	Bullet     *slides.Bullet         `json:"bullet,omitempty"`
+}
+
+type slidesAffineMatrix struct {
+	a float64
+	b float64
+	c float64
+	d float64
+	e float64
+	f float64
+}
+
+func slidesElementDetails(elements []*slides.PageElement) []slidesElementDetail {
+	details := make([]slidesElementDetail, 0, len(elements))
+	identity := slidesAffineMatrix{a: 1, d: 1}
+	for _, element := range elements {
+		appendSlidesElementDetails(&details, element, "", identity)
+	}
+	return details
+}
+
+func appendSlidesElementDetails(details *[]slidesElementDetail, element *slides.PageElement, parentID string, parentTransform slidesAffineMatrix) {
+	if element == nil {
+		return
+	}
+
+	localTransform, ok := slidesTransformMatrix(element.Transform)
+	if !ok {
+		localTransform = slidesAffineMatrix{a: 1, d: 1}
+	}
+	absoluteTransform := slidesComposeTransforms(parentTransform, localTransform)
+	detail := slidesElementDetail{
+		ObjectID:       element.ObjectId,
+		Type:           slidesElementType(element),
+		ParentObjectID: parentID,
+		Title:          element.Title,
+		Description:    element.Description,
+		Geometry:       slidesElementBounds(element.Size, absoluteTransform),
+	}
+
+	if element.Shape != nil {
+		detail.Shape = &slidesShapeDetail{ShapeType: element.Shape.ShapeType}
+		if element.Shape.Placeholder != nil {
+			detail.Shape.PlaceholderType = element.Shape.Placeholder.Type
+		}
+		if element.Shape.Text != nil {
+			detail.Shape.Text = slidesTextContentDetail(element.Shape.Text)
+		}
+	}
+	if element.Image != nil {
+		detail.Image = &slidesImageDetail{
+			ContentURL: element.Image.ContentUrl,
+			SourceURL:  element.Image.SourceUrl,
+		}
+	}
+	if element.Table != nil {
+		detail.Table = slidesTableContentDetail(element.Table)
+	}
+	if element.WordArt != nil {
+		detail.WordArt = element.WordArt.RenderedText
+	}
+
+	*details = append(*details, detail)
+	if element.ElementGroup == nil {
+		return
+	}
+	for _, child := range element.ElementGroup.Children {
+		appendSlidesElementDetails(details, child, element.ObjectId, absoluteTransform)
+	}
+}
+
+func slidesElementType(element *slides.PageElement) string {
+	switch {
+	case element == nil:
+		return slidesElementUnknown
+	case element.ElementGroup != nil:
+		return "group"
+	case element.Shape != nil:
+		return "shape"
+	case element.Image != nil:
+		return "image"
+	case element.Video != nil:
+		return "video"
+	case element.Line != nil:
+		return "line"
+	case element.Table != nil:
+		return slidesElementTable
+	case element.WordArt != nil:
+		return "wordArt"
+	case element.SheetsChart != nil:
+		return "sheetsChart"
+	case element.SpeakerSpotlight != nil:
+		return "speakerSpotlight"
+	default:
+		return slidesElementUnknown
+	}
+}
+
+func slidesTextContentDetail(content *slides.TextContent) *slidesTextDetail {
+	detail := &slidesTextDetail{
+		Runs:       []slidesTextRunDetail{},
+		Paragraphs: []slidesParagraphDetail{},
+	}
+	if content == nil {
+		return detail
+	}
+
+	var text strings.Builder
+	for _, element := range content.TextElements {
+		if element == nil {
+			continue
+		}
+		if element.TextRun != nil {
+			text.WriteString(element.TextRun.Content)
+			run := slidesTextRunDetail{
+				StartIndex: element.StartIndex,
+				EndIndex:   element.EndIndex,
+				Content:    element.TextRun.Content,
+				Style:      element.TextRun.Style,
+			}
+			if element.TextRun.Style != nil {
+				run.ForegroundColor = slidesOptionalColorValue(element.TextRun.Style.ForegroundColor)
+				run.BackgroundColor = slidesOptionalColorValue(element.TextRun.Style.BackgroundColor)
+			}
+			detail.Runs = append(detail.Runs, run)
+		}
+		if element.AutoText != nil {
+			text.WriteString(element.AutoText.Content)
+			detail.Runs = append(detail.Runs, slidesTextRunDetail{
+				StartIndex:   element.StartIndex,
+				EndIndex:     element.EndIndex,
+				Content:      element.AutoText.Content,
+				Style:        element.AutoText.Style,
+				AutoTextType: element.AutoText.Type,
+			})
+		}
+		if element.ParagraphMarker != nil {
+			detail.Paragraphs = append(detail.Paragraphs, slidesParagraphDetail{
+				StartIndex: element.StartIndex,
+				EndIndex:   element.EndIndex,
+				Style:      element.ParagraphMarker.Style,
+				Bullet:     element.ParagraphMarker.Bullet,
+			})
+		}
+	}
+	detail.Content = strings.TrimRight(text.String(), "\n")
+	return detail
+}
+
+func slidesOptionalColorValue(color *slides.OptionalColor) string {
+	if color == nil || color.OpaqueColor == nil {
+		return ""
+	}
+	if color.OpaqueColor.RgbColor != nil {
+		return slidesRGBHex(color.OpaqueColor.RgbColor)
+	}
+	if color.OpaqueColor.ThemeColor != "" {
+		return "theme:" + color.OpaqueColor.ThemeColor
+	}
+	return ""
+}
+
+func slidesTableContentDetail(table *slides.Table) *slidesTableDetail {
+	detail := &slidesTableDetail{Cells: []slidesTableCellDetail{}}
+	if table == nil {
+		return detail
+	}
+	detail.Rows = table.Rows
+	detail.Columns = table.Columns
+	for rowIndex, row := range table.TableRows {
+		if row == nil {
+			continue
+		}
+		for columnIndex, cell := range row.TableCells {
+			if cell == nil {
+				continue
+			}
+			cellRow := int64(rowIndex)
+			cellColumn := int64(columnIndex)
+			if cell.Location != nil {
+				cellRow = cell.Location.RowIndex
+				cellColumn = cell.Location.ColumnIndex
+			}
+			rowSpan := cell.RowSpan
+			if rowSpan == 0 {
+				rowSpan = 1
+			}
+			columnSpan := cell.ColumnSpan
+			if columnSpan == 0 {
+				columnSpan = 1
+			}
+			detail.Cells = append(detail.Cells, slidesTableCellDetail{
+				RowIndex:    cellRow,
+				ColumnIndex: cellColumn,
+				RowSpan:     rowSpan,
+				ColumnSpan:  columnSpan,
+				Text:        slidesTextContentDetail(cell.Text),
+			})
+		}
+	}
+	return detail
+}
+
+func slidesTransformMatrix(transform *slides.AffineTransform) (slidesAffineMatrix, bool) {
+	if transform == nil {
+		return slidesAffineMatrix{a: 1, d: 1}, true
+	}
+	tx, ok := slidesMagnitudeInPoints(transform.TranslateX, transform.Unit)
+	if !ok && transform.TranslateX != 0 {
+		return slidesAffineMatrix{}, false
+	}
+	ty, ok := slidesMagnitudeInPoints(transform.TranslateY, transform.Unit)
+	if !ok && transform.TranslateY != 0 {
+		return slidesAffineMatrix{}, false
+	}
+	return slidesAffineMatrix{
+		a: transform.ScaleX,
+		b: transform.ShearY,
+		c: transform.ShearX,
+		d: transform.ScaleY,
+		e: tx,
+		f: ty,
+	}, true
+}
+
+func slidesComposeTransforms(parent, child slidesAffineMatrix) slidesAffineMatrix {
+	return slidesAffineMatrix{
+		a: parent.a*child.a + parent.c*child.b,
+		b: parent.b*child.a + parent.d*child.b,
+		c: parent.a*child.c + parent.c*child.d,
+		d: parent.b*child.c + parent.d*child.d,
+		e: parent.a*child.e + parent.c*child.f + parent.e,
+		f: parent.b*child.e + parent.d*child.f + parent.f,
+	}
+}
+
+func slidesElementBounds(size *slides.Size, transform slidesAffineMatrix) *slidesElementGeometry {
+	if size == nil || size.Width == nil || size.Height == nil {
+		return nil
+	}
+	width, ok := slidesMagnitudeInPoints(size.Width.Magnitude, size.Width.Unit)
+	if !ok {
+		return nil
+	}
+	height, ok := slidesMagnitudeInPoints(size.Height.Magnitude, size.Height.Unit)
+	if !ok {
+		return nil
+	}
+
+	points := [][2]float64{
+		slidesTransformPoint(transform, 0, 0),
+		slidesTransformPoint(transform, width, 0),
+		slidesTransformPoint(transform, 0, height),
+		slidesTransformPoint(transform, width, height),
+	}
+	minX, maxX := points[0][0], points[0][0]
+	minY, maxY := points[0][1], points[0][1]
+	for _, point := range points[1:] {
+		minX = math.Min(minX, point[0])
+		maxX = math.Max(maxX, point[0])
+		minY = math.Min(minY, point[1])
+		maxY = math.Max(maxY, point[1])
+	}
+	return &slidesElementGeometry{
+		X:      minX,
+		Y:      minY,
+		Width:  maxX - minX,
+		Height: maxY - minY,
+		Unit:   "PT",
+	}
+}
+
+func slidesTransformPoint(transform slidesAffineMatrix, x, y float64) [2]float64 {
+	return [2]float64{
+		transform.a*x + transform.c*y + transform.e,
+		transform.b*x + transform.d*y + transform.f,
+	}
+}
+
+func slidesMagnitudeInPoints(magnitude float64, unit string) (float64, bool) {
+	switch strings.ToUpper(strings.TrimSpace(unit)) {
+	case "PT":
+		return magnitude, true
+	case "EMU":
+		return magnitude / slidesEMUPerPoint, true
+	default:
+		return 0, false
+	}
+}
+
+func slidesPageBounds(size *slides.Size) (slidesElementGeometry, bool, error) {
+	if size == nil || size.Width == nil || size.Height == nil {
+		return slidesElementGeometry{}, false, nil
+	}
+	width, ok := slidesMagnitudeInPoints(size.Width.Magnitude, size.Width.Unit)
+	if !ok {
+		return slidesElementGeometry{}, false, fmt.Errorf("unsupported page width unit %q", size.Width.Unit)
+	}
+	height, ok := slidesMagnitudeInPoints(size.Height.Magnitude, size.Height.Unit)
+	if !ok {
+		return slidesElementGeometry{}, false, fmt.Errorf("unsupported page height unit %q", size.Height.Unit)
+	}
+	return slidesElementGeometry{Width: width, Height: height, Unit: "PT"}, true, nil
+}

--- a/internal/cmd/slides_introspection_test.go
+++ b/internal/cmd/slides_introspection_test.go
@@ -1,0 +1,144 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/slides/v1"
+)
+
+func TestSlidesElementDetails_GroupedGeometry(t *testing.T) {
+	elements := []*slides.PageElement{
+		{
+			ObjectId: "group1",
+			Transform: &slides.AffineTransform{
+				ScaleX: 2, ScaleY: 2, TranslateX: 10, TranslateY: 20, Unit: "PT",
+			},
+			ElementGroup: &slides.Group{Children: []*slides.PageElement{
+				{
+					ObjectId: "child1",
+					Size: &slides.Size{
+						Width:  &slides.Dimension{Magnitude: 20, Unit: "PT"},
+						Height: &slides.Dimension{Magnitude: 10, Unit: "PT"},
+					},
+					Transform: &slides.AffineTransform{
+						ScaleX: 1, ScaleY: 1, TranslateX: 5, TranslateY: 7, Unit: "PT",
+					},
+					Shape: &slides.Shape{ShapeType: "RECTANGLE"},
+				},
+			}},
+		},
+	}
+
+	details := slidesElementDetails(elements)
+	require.Len(t, details, 2)
+	assert.Equal(t, "group", details[0].Type)
+	assert.Equal(t, "group1", details[1].ParentObjectID)
+	require.NotNil(t, details[1].Geometry)
+	assert.InDelta(t, 20, details[1].Geometry.X, 0.001)
+	assert.InDelta(t, 34, details[1].Geometry.Y, 0.001)
+	assert.InDelta(t, 40, details[1].Geometry.Width, 0.001)
+	assert.InDelta(t, 20, details[1].Geometry.Height, 0.001)
+}
+
+func TestSlidesElementDetails_EMUAndTableCells(t *testing.T) {
+	elements := []*slides.PageElement{
+		{
+			ObjectId: "table1",
+			Size: &slides.Size{
+				Width:  &slides.Dimension{Magnitude: 1270000, Unit: "EMU"},
+				Height: &slides.Dimension{Magnitude: 635000, Unit: "EMU"},
+			},
+			Transform: &slides.AffineTransform{ScaleX: 1, ScaleY: 1, Unit: "EMU"},
+			Table: &slides.Table{
+				Rows: 1, Columns: 1,
+				TableRows: []*slides.TableRow{{TableCells: []*slides.TableCell{{
+					Location: &slides.TableCellLocation{RowIndex: 0, ColumnIndex: 0},
+					Text: &slides.TextContent{TextElements: []*slides.TextElement{{
+						StartIndex: 1,
+						EndIndex:   5,
+						TextRun:    &slides.TextRun{Content: "Cell", Style: &slides.TextStyle{Bold: true}},
+					}}},
+				}}}},
+			},
+		},
+	}
+
+	details := slidesElementDetails(elements)
+	require.Len(t, details, 1)
+	require.NotNil(t, details[0].Geometry)
+	assert.InDelta(t, 100, details[0].Geometry.Width, 0.001)
+	assert.InDelta(t, 50, details[0].Geometry.Height, 0.001)
+	require.NotNil(t, details[0].Table)
+	require.Len(t, details[0].Table.Cells, 1)
+	assert.Equal(t, int64(1), details[0].Table.Cells[0].RowSpan)
+	assert.Equal(t, "Cell", details[0].Table.Cells[0].Text.Content)
+}
+
+func TestLocateSlidesText_UTF16AndSplitRuns(t *testing.T) {
+	content := &slides.TextContent{TextElements: []*slides.TextElement{
+		{StartIndex: 1, EndIndex: 7, TextRun: &slides.TextRun{Content: "Hello "}},
+		{StartIndex: 7, EndIndex: 14, TextRun: &slides.TextRun{Content: "😀World"}},
+	}}
+
+	matches := locateSlidesText(content, "o 😀", true)
+	require.Len(t, matches, 1)
+	assert.Equal(t, int64(5), matches[0].StartIndex)
+	assert.Equal(t, int64(9), matches[0].EndIndex)
+
+	matches = locateSlidesText(content, "world", false)
+	require.Len(t, matches, 1)
+	assert.Equal(t, int64(9), matches[0].StartIndex)
+	assert.Equal(t, int64(14), matches[0].EndIndex)
+}
+
+func TestSlidesLocateCmd_ShapesAndTableCells(t *testing.T) {
+	response := map[string]any{
+		"presentationId": "pres1",
+		"slides": []any{
+			map[string]any{
+				"objectId": "slide_1",
+				"pageElements": []any{
+					map[string]any{
+						"objectId": "shape1",
+						"shape": map[string]any{"text": map[string]any{"textElements": []any{
+							map[string]any{"startIndex": 1, "endIndex": 8, "textRun": map[string]any{"content": "Needle\n"}},
+						}}},
+					},
+					map[string]any{
+						"objectId": "table1",
+						"table": map[string]any{"rows": 1, "columns": 1, "tableRows": []any{
+							map[string]any{"tableCells": []any{
+								map[string]any{
+									"location": map[string]any{"rowIndex": 0, "columnIndex": 0},
+									"text": map[string]any{"textElements": []any{
+										map[string]any{"startIndex": 1, "endIndex": 8, "textRun": map[string]any{"content": "needle\n"}},
+									}},
+								},
+							}},
+						}},
+					},
+				},
+			},
+		},
+	}
+	svc := newSlidesReadTestService(t, response)
+	var out bytes.Buffer
+	ctx := withSlidesTestService(newCmdRuntimeJSONOutputContext(t, &out, io.Discard), svc)
+	cmd := &SlidesLocateCmd{PresentationID: "pres1", Text: "needle", All: true}
+	require.NoError(t, cmd.Run(ctx, &RootFlags{Account: "a@b.com"}))
+
+	var result slidesLocateResult
+	require.NoError(t, json.Unmarshal(out.Bytes(), &result))
+	require.Len(t, result.Matches, 2)
+	assert.Equal(t, "shape", result.Matches[0].Kind)
+	assert.Equal(t, int64(1), result.Matches[0].StartIndex)
+	assert.Equal(t, int64(7), result.Matches[0].EndIndex)
+	assert.Equal(t, "tableCell", result.Matches[1].Kind)
+	require.NotNil(t, result.Matches[1].RowIndex)
+	assert.Equal(t, int64(0), *result.Matches[1].RowIndex)
+}

--- a/internal/cmd/slides_locate.go
+++ b/internal/cmd/slides_locate.go
@@ -1,0 +1,277 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"unicode/utf16"
+
+	"google.golang.org/api/slides/v1"
+
+	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+type SlidesLocateCmd struct {
+	PresentationID string `arg:"" name:"presentationId" help:"Presentation ID"`
+	Text           string `arg:"" name:"text" help:"Literal text to locate"`
+	Page           string `name:"page" help:"Limit matches to one slide object ID"`
+	MatchCase      bool   `name:"match-case" help:"Use case-sensitive matching"`
+	All            bool   `name:"all" help:"Return all matches"`
+	Occurrence     *int   `name:"occurrence" help:"Return the Nth occurrence (1-based; default first)"`
+	FailEmpty      bool   `name:"fail-empty" aliases:"non-empty,require-results" help:"Exit with code 3 if no matches"`
+}
+
+type slidesLocateResult struct {
+	Matches []slidesTextLocation `json:"matches"`
+}
+
+type slidesTextLocation struct {
+	SlideObjectID string `json:"slideObjectId"`
+	SlideNumber   int    `json:"slideNumber"`
+	ObjectID      string `json:"objectId"`
+	Kind          string `json:"kind"`
+	RowIndex      *int64 `json:"rowIndex,omitempty"`
+	ColumnIndex   *int64 `json:"columnIndex,omitempty"`
+	StartIndex    int64  `json:"startIndex"`
+	EndIndex      int64  `json:"endIndex"`
+	Text          string `json:"text"`
+}
+
+func (c *SlidesLocateCmd) Run(ctx context.Context, flags *RootFlags) error {
+	presentationID := strings.TrimSpace(c.PresentationID)
+	if presentationID == "" {
+		return usage("empty presentationId")
+	}
+	if c.Text == "" {
+		return usage("empty text")
+	}
+	if c.All && c.Occurrence != nil {
+		return usage("--all and --occurrence are mutually exclusive")
+	}
+	if c.Occurrence != nil && *c.Occurrence <= 0 {
+		return usage("--occurrence must be > 0")
+	}
+
+	account, err := requireAccount(flags)
+	if err != nil {
+		return err
+	}
+	svc, err := slidesService(ctx, account)
+	if err != nil {
+		return err
+	}
+	presentation, err := svc.Presentations.Get(presentationID).Context(ctx).Do()
+	if err != nil {
+		return fmt.Errorf("get presentation: %w", err)
+	}
+
+	pageID := strings.TrimSpace(c.Page)
+	locations := []slidesTextLocation{}
+	pageFound := pageID == ""
+	for slideIndex, slide := range presentation.Slides {
+		if slide == nil || (pageID != "" && slide.ObjectId != pageID) {
+			continue
+		}
+		pageFound = true
+		locations = append(locations, locateSlidesTextInElements(slide.PageElements, c.Text, c.MatchCase, slide.ObjectId, slideIndex+1)...)
+	}
+	if !pageFound {
+		return fmt.Errorf("slide %q not found in presentation", pageID)
+	}
+
+	locations = selectSlidesTextLocations(locations, c.All, c.Occurrence)
+	if outfmt.IsJSON(ctx) {
+		if err := outfmt.WriteJSON(ctx, stdoutWriter(ctx), slidesLocateResult{Matches: locations}); err != nil {
+			return err
+		}
+		return failEmptyIfNoSlidesLocations(c.FailEmpty, locations)
+	}
+
+	u := ui.FromContext(ctx)
+	for _, location := range locations {
+		cell := ""
+		if location.RowIndex != nil && location.ColumnIndex != nil {
+			cell = fmt.Sprintf("%d:%d", *location.RowIndex, *location.ColumnIndex)
+		}
+		u.Out().Linef("%s\t%s\t%s\t%d\t%d\t%s", location.SlideObjectID, location.ObjectID, cell, location.StartIndex, location.EndIndex, location.Text)
+	}
+	return failEmptyIfNoSlidesLocations(c.FailEmpty, locations)
+}
+
+func selectSlidesTextLocations(locations []slidesTextLocation, all bool, occurrence *int) []slidesTextLocation {
+	if all {
+		return locations
+	}
+	selected := 1
+	if occurrence != nil {
+		selected = *occurrence
+	}
+	if selected > len(locations) {
+		return []slidesTextLocation{}
+	}
+	return locations[selected-1 : selected]
+}
+
+func failEmptyIfNoSlidesLocations(failEmpty bool, locations []slidesTextLocation) error {
+	if len(locations) == 0 {
+		return failEmptyExit(failEmpty)
+	}
+	return nil
+}
+
+func locateSlidesTextInElements(elements []*slides.PageElement, needle string, matchCase bool, slideID string, slideNumber int) []slidesTextLocation {
+	locations := []slidesTextLocation{}
+	for _, element := range elements {
+		if element == nil {
+			continue
+		}
+		if element.Shape != nil && element.Shape.Text != nil {
+			for _, match := range locateSlidesText(element.Shape.Text, needle, matchCase) {
+				locations = append(locations, slidesTextLocation{
+					SlideObjectID: slideID,
+					SlideNumber:   slideNumber,
+					ObjectID:      element.ObjectId,
+					Kind:          "shape",
+					StartIndex:    match.StartIndex,
+					EndIndex:      match.EndIndex,
+					Text:          match.Text,
+				})
+			}
+		}
+		if element.Table != nil {
+			for rowIndex, row := range element.Table.TableRows {
+				if row == nil {
+					continue
+				}
+				for columnIndex, cell := range row.TableCells {
+					if cell == nil || cell.Text == nil {
+						continue
+					}
+					cellRow := int64(rowIndex)
+					cellColumn := int64(columnIndex)
+					if cell.Location != nil {
+						cellRow = cell.Location.RowIndex
+						cellColumn = cell.Location.ColumnIndex
+					}
+					for _, match := range locateSlidesText(cell.Text, needle, matchCase) {
+						locations = append(locations, slidesTextLocation{
+							SlideObjectID: slideID,
+							SlideNumber:   slideNumber,
+							ObjectID:      element.ObjectId,
+							Kind:          "tableCell",
+							RowIndex:      int64Ptr(cellRow),
+							ColumnIndex:   int64Ptr(cellColumn),
+							StartIndex:    match.StartIndex,
+							EndIndex:      match.EndIndex,
+							Text:          match.Text,
+						})
+					}
+				}
+			}
+		}
+		if element.ElementGroup != nil {
+			locations = append(locations, locateSlidesTextInElements(element.ElementGroup.Children, needle, matchCase, slideID, slideNumber)...)
+		}
+	}
+	return locations
+}
+
+type slidesTextMatch struct {
+	StartIndex int64
+	EndIndex   int64
+	Text       string
+}
+
+type slidesTextSegment struct {
+	Text       string
+	Boundaries map[int]int64
+}
+
+func locateSlidesText(content *slides.TextContent, needle string, matchCase bool) []slidesTextMatch {
+	pattern := regexp.QuoteMeta(needle)
+	if !matchCase {
+		pattern = "(?i:" + pattern + ")"
+	}
+	re := regexp.MustCompile(pattern)
+	matches := []slidesTextMatch{}
+	for _, segment := range slidesTextSegments(content) {
+		for _, indexes := range re.FindAllStringIndex(segment.Text, -1) {
+			startIndex, startOK := segment.Boundaries[indexes[0]]
+			endIndex, endOK := segment.Boundaries[indexes[1]]
+			if !startOK || !endOK {
+				continue
+			}
+			matches = append(matches, slidesTextMatch{
+				StartIndex: startIndex,
+				EndIndex:   endIndex,
+				Text:       segment.Text[indexes[0]:indexes[1]],
+			})
+		}
+	}
+	return matches
+}
+
+func slidesTextSegments(content *slides.TextContent) []slidesTextSegment {
+	segments := []slidesTextSegment{}
+	if content == nil {
+		return segments
+	}
+
+	var text strings.Builder
+	boundaries := map[int]int64{}
+	var lastEnd int64
+	hasText := false
+	flush := func() {
+		if !hasText {
+			return
+		}
+		segments = append(segments, slidesTextSegment{Text: text.String(), Boundaries: boundaries})
+		text.Reset()
+		boundaries = map[int]int64{}
+		hasText = false
+	}
+
+	for _, element := range content.TextElements {
+		if element == nil {
+			continue
+		}
+		var runContent string
+		switch {
+		case element.TextRun != nil:
+			runContent = element.TextRun.Content
+		case element.AutoText != nil:
+			runContent = element.AutoText.Content
+		default:
+			continue
+		}
+		if runContent == "" {
+			continue
+		}
+		if hasText && element.StartIndex != lastEnd {
+			flush()
+		}
+
+		byteOffset := text.Len()
+		apiIndex := element.StartIndex
+		boundaries[byteOffset] = apiIndex
+		for _, r := range runContent {
+			text.WriteRune(r)
+			if r > 0xffff {
+				apiIndex += int64(len(utf16.Encode([]rune{r})))
+			} else {
+				apiIndex++
+			}
+			boundaries[text.Len()] = apiIndex
+		}
+		lastEnd = element.EndIndex
+		if lastEnd <= element.StartIndex {
+			lastEnd = apiIndex
+		}
+		boundaries[text.Len()] = lastEnd
+		hasText = true
+	}
+	flush()
+	return segments
+}

--- a/internal/cmd/slides_read_slide.go
+++ b/internal/cmd/slides_read_slide.go
@@ -13,6 +13,7 @@ import (
 type SlidesReadSlideCmd struct {
 	PresentationID string `arg:"" name:"presentationId" help:"Presentation ID"`
 	SlideID        string `arg:"" name:"slideId" help:"Slide object ID (use 'slides list-slides' to find IDs)"`
+	Detail         bool   `name:"detail" help:"Include normalized element geometry, text runs/styles, paragraphs, and table cells"`
 }
 
 func (c *SlidesReadSlideCmd) Run(ctx context.Context, flags *RootFlags) error {
@@ -74,39 +75,8 @@ func (c *SlidesReadSlideCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 	notesText = strings.TrimRight(notesText, "\n")
 
-	// Extract text elements from the slide itself
-	textElements := []map[string]any{}
-	for _, el := range slide.PageElements {
-		if el.Shape != nil && el.Shape.Text != nil {
-			var text string
-			for _, te := range el.Shape.Text.TextElements {
-				if te.TextRun != nil {
-					text += te.TextRun.Content
-				}
-			}
-			text = strings.TrimRight(text, "\n")
-			if text != "" {
-				textElements = append(textElements, map[string]any{
-					"objectId": el.ObjectId,
-					"text":     text,
-				})
-			}
-		}
-	}
-
-	// Extract image references
-	images := []map[string]any{}
-	for _, el := range slide.PageElements {
-		if el.Image != nil {
-			img := map[string]any{
-				"objectId": el.ObjectId,
-			}
-			if el.Image.ContentUrl != "" {
-				img["contentUrl"] = el.Image.ContentUrl
-			}
-			images = append(images, img)
-		}
-	}
+	elements := slidesElementDetails(slide.PageElements)
+	textElements, images, tables := slidesReadSlideSummaries(elements)
 
 	if outfmt.IsJSON(ctx) {
 		result := map[string]any{
@@ -116,6 +86,10 @@ func (c *SlidesReadSlideCmd) Run(ctx context.Context, flags *RootFlags) error {
 			"notes":          notesText,
 			"textElements":   textElements,
 			"images":         images,
+			"tables":         tables,
+		}
+		if c.Detail {
+			result["elements"] = elements
 		}
 		return outfmt.WriteJSON(ctx, stdoutWriter(ctx), result)
 	}
@@ -146,16 +120,107 @@ func (c *SlidesReadSlideCmd) Run(ctx context.Context, flags *RootFlags) error {
 	if len(images) > 0 {
 		u.Out().Println("Images:")
 		tw := tabwriter.NewWriter(stdoutWriter(ctx), 0, 4, 2, ' ', 0)
-		fmt.Fprintln(tw, "OBJECT ID\tURL")
+		fmt.Fprintln(tw, "OBJECT ID\tSOURCE URL\tCONTENT URL")
 		for _, img := range images {
-			url := "(none)"
-			if u, ok := img["contentUrl"].(string); ok {
-				url = u
+			fmt.Fprintf(tw, "%s\t%s\t%s\n", img["objectId"], valueOrNone(img["sourceUrl"]), valueOrNone(img["contentUrl"]))
+		}
+		_ = tw.Flush()
+		u.Out().Println("")
+	}
+
+	if len(tables) > 0 {
+		u.Out().Println("Table Cells:")
+		tw := tabwriter.NewWriter(stdoutWriter(ctx), 0, 4, 2, ' ', 0)
+		fmt.Fprintln(tw, "OBJECT ID\tROW\tCOLUMN\tTEXT")
+		for _, table := range tables {
+			cells, _ := table["cells"].([]map[string]any)
+			for _, cell := range cells {
+				fmt.Fprintf(tw, "%s\t%d\t%d\t%s\n", table["objectId"], cell["rowIndex"], cell["columnIndex"], cell["text"])
 			}
-			fmt.Fprintf(tw, "%s\t%s\n", img["objectId"], url)
+		}
+		_ = tw.Flush()
+		u.Out().Println("")
+	}
+
+	if c.Detail && len(elements) > 0 {
+		u.Out().Println("Elements:")
+		tw := tabwriter.NewWriter(stdoutWriter(ctx), 0, 4, 2, ' ', 0)
+		fmt.Fprintln(tw, "OBJECT ID\tTYPE\tX\tY\tWIDTH\tHEIGHT")
+		for _, element := range elements {
+			if element.Geometry == nil {
+				fmt.Fprintf(tw, "%s\t%s\t-\t-\t-\t-\n", element.ObjectID, element.Type)
+				continue
+			}
+			fmt.Fprintf(tw, "%s\t%s\t%.2f\t%.2f\t%.2f\t%.2f\n", element.ObjectID, element.Type, element.Geometry.X, element.Geometry.Y, element.Geometry.Width, element.Geometry.Height)
 		}
 		_ = tw.Flush()
 	}
 
 	return nil
+}
+
+func slidesReadSlideSummaries(elements []slidesElementDetail) ([]map[string]any, []map[string]any, []map[string]any) {
+	textElements := []map[string]any{}
+	images := []map[string]any{}
+	tables := []map[string]any{}
+
+	for _, element := range elements {
+		if element.Shape != nil && element.Shape.Text != nil && element.Shape.Text.Content != "" {
+			textElements = append(textElements, map[string]any{
+				"objectId": element.ObjectID,
+				"text":     element.Shape.Text.Content,
+			})
+		}
+		if element.Image != nil {
+			image := map[string]any{"objectId": element.ObjectID}
+			if element.Image.ContentURL != "" {
+				image["contentUrl"] = element.Image.ContentURL
+			}
+			if element.Image.SourceURL != "" {
+				image["sourceUrl"] = element.Image.SourceURL
+			}
+			images = append(images, image)
+		}
+		if element.Table == nil {
+			continue
+		}
+		cells := []map[string]any{}
+		for _, cell := range element.Table.Cells {
+			text := ""
+			if cell.Text != nil {
+				text = cell.Text.Content
+			}
+			cellSummary := map[string]any{
+				"rowIndex":    cell.RowIndex,
+				"columnIndex": cell.ColumnIndex,
+				"rowSpan":     cell.RowSpan,
+				"columnSpan":  cell.ColumnSpan,
+				"text":        text,
+			}
+			cells = append(cells, cellSummary)
+			if text != "" {
+				textElements = append(textElements, map[string]any{
+					"objectId":    element.ObjectID,
+					"rowIndex":    cell.RowIndex,
+					"columnIndex": cell.ColumnIndex,
+					"text":        text,
+				})
+			}
+		}
+		tables = append(tables, map[string]any{
+			"objectId": element.ObjectID,
+			"rows":     element.Table.Rows,
+			"columns":  element.Table.Columns,
+			"cells":    cells,
+		})
+	}
+
+	return textElements, images, tables
+}
+
+func valueOrNone(value any) string {
+	if text, ok := value.(string); ok && text != "" {
+		return text
+	}
+	return "(none)"
 }

--- a/internal/cmd/slides_read_slide_test.go
+++ b/internal/cmd/slides_read_slide_test.go
@@ -44,12 +44,39 @@ func readSlidePresResponse() map[string]any {
 				"pageElements": []any{
 					map[string]any{
 						"objectId": "text_el_1",
+						"size": map[string]any{
+							"width":  map[string]any{"magnitude": 100, "unit": "PT"},
+							"height": map[string]any{"magnitude": 40, "unit": "PT"},
+						},
+						"transform": map[string]any{
+							"scaleX": 1, "scaleY": 1, "translateX": 20, "translateY": 30, "unit": "PT",
+						},
 						"shape": map[string]any{
+							"shapeType": "TEXT_BOX",
 							"text": map[string]any{
 								"textElements": []any{
 									map[string]any{
+										"startIndex": 0,
+										"endIndex":   11,
+										"paragraphMarker": map[string]any{
+											"style":  map[string]any{"alignment": "CENTER"},
+											"bullet": map[string]any{"glyph": "•", "listId": "list1"},
+										},
+									},
+									map[string]any{
+										"startIndex": 0,
+										"endIndex":   11,
 										"textRun": map[string]any{
 											"content": "Slide Title",
+											"style": map[string]any{
+												"bold":       true,
+												"fontFamily": "Inter",
+												"fontSize":   map[string]any{"magnitude": 24, "unit": "PT"},
+												"foregroundColor": map[string]any{
+													"opaqueColor": map[string]any{"rgbColor": map[string]any{"red": 0.2, "green": 0.4, "blue": 0.8}},
+												},
+												"link": map[string]any{"url": "https://example.com/title"},
+											},
 										},
 									},
 								},
@@ -60,6 +87,37 @@ func readSlidePresResponse() map[string]any {
 						"objectId": "img_el_1",
 						"image": map[string]any{
 							"contentUrl": "https://example.com/image.png",
+							"sourceUrl":  "https://cdn.example.com/source.png",
+						},
+					},
+					map[string]any{
+						"objectId": "table_el_1",
+						"table": map[string]any{
+							"rows":    1,
+							"columns": 2,
+							"tableRows": []any{
+								map[string]any{
+									"tableCells": []any{
+										map[string]any{
+											"location":   map[string]any{"rowIndex": 0, "columnIndex": 0},
+											"rowSpan":    1,
+											"columnSpan": 2,
+											"text": map[string]any{
+												"textElements": []any{
+													map[string]any{
+														"startIndex": 1,
+														"endIndex":   11,
+														"textRun": map[string]any{
+															"content": "Cell value\n",
+															"style":   map[string]any{"italic": true},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
 						},
 					},
 				},
@@ -109,6 +167,9 @@ func TestSlidesReadSlide(t *testing.T) {
 	if !strings.Contains(out.String(), "img_el_1") {
 		t.Errorf("expected image element, got: %q", out.String())
 	}
+	if !strings.Contains(out.String(), "Cell value") {
+		t.Errorf("expected table cell text, got: %q", out.String())
+	}
 }
 
 func TestSlidesReadSlide_JSON(t *testing.T) {
@@ -120,6 +181,7 @@ func TestSlidesReadSlide_JSON(t *testing.T) {
 	cmd := &SlidesReadSlideCmd{
 		PresentationID: "pres1",
 		SlideID:        "slide_1",
+		Detail:         true,
 	}
 	if err := cmd.Run(ctx, flags); err != nil {
 		t.Fatalf("Run: %v", err)
@@ -140,13 +202,40 @@ func TestSlidesReadSlide_JSON(t *testing.T) {
 	}
 
 	textEls, ok := result["textElements"].([]any)
-	if !ok || len(textEls) != 1 {
-		t.Errorf("expected 1 text element, got %v", result["textElements"])
+	if !ok || len(textEls) != 2 {
+		t.Errorf("expected shape and table-cell text elements, got %v", result["textElements"])
 	}
 
 	imgs, ok := result["images"].([]any)
 	if !ok || len(imgs) != 1 {
 		t.Errorf("expected 1 image, got %v", result["images"])
+	}
+	image := imgs[0].(map[string]any)
+	if image["sourceUrl"] != "https://cdn.example.com/source.png" {
+		t.Errorf("expected sourceUrl, got %v", image)
+	}
+	tables, ok := result["tables"].([]any)
+	if !ok || len(tables) != 1 {
+		t.Fatalf("expected 1 table, got %v", result["tables"])
+	}
+	elements, ok := result["elements"].([]any)
+	if !ok || len(elements) != 3 {
+		t.Fatalf("expected 3 detailed elements, got %v", result["elements"])
+	}
+	textElement := elements[0].(map[string]any)
+	geometry := textElement["geometry"].(map[string]any)
+	if geometry["x"] != float64(20) || geometry["width"] != float64(100) {
+		t.Errorf("unexpected normalized geometry: %v", geometry)
+	}
+	shape := textElement["shape"].(map[string]any)
+	text := shape["text"].(map[string]any)
+	runs := text["runs"].([]any)
+	style := runs[0].(map[string]any)["style"].(map[string]any)
+	if style["fontFamily"] != "Inter" {
+		t.Errorf("expected run style, got %v", style)
+	}
+	if runs[0].(map[string]any)["foregroundColor"] != "#3366CC" {
+		t.Errorf("expected normalized foreground color, got %v", runs[0])
 	}
 }
 
@@ -176,6 +265,7 @@ func TestSlidesReadSlide_JSONEmptyArrays(t *testing.T) {
 	var result struct {
 		TextElements []json.RawMessage `json:"textElements"`
 		Images       []json.RawMessage `json:"images"`
+		Tables       []json.RawMessage `json:"tables"`
 	}
 	if err := json.Unmarshal(out.Bytes(), &result); err != nil {
 		t.Fatalf("JSON parse: %v\noutput: %q", err, out.String())
@@ -191,6 +281,9 @@ func TestSlidesReadSlide_JSONEmptyArrays(t *testing.T) {
 	}
 	if len(result.Images) != 0 {
 		t.Fatalf("images len = %d, want 0", len(result.Images))
+	}
+	if result.Tables == nil {
+		t.Fatalf("tables must be an empty array, got nil: %s", out.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

- add `slides locate` / `find-element` for read-only shape and table-cell text lookup with exact UTF-16 ranges
- enrich `slides read-slide` with table-cell text and image source URLs; `--detail` adds flattened element types, parent links, normalized PT bounds, runs/styles/links/colors, paragraphs, bullets, and table structure
- extend `slides info` with slide count, PT page size, locale, masters/theme colors, and layouts while retaining Drive metadata
- document the structured output contract and retain `slides raw` as the lossless API escape hatch

Closes #822.

## Compatibility

Existing `read-slide` JSON fields remain. `textElements` and `images` are additive; table-cell entries, `sourceUrl`, and `tables` are new. Detailed high-volume structure is opt-in with `--detail`.

## Verification

- focused geometry, styled-run, table-cell, metadata, split-run, and UTF-16/emoji regression tests
- `make ci`
- local diff and full branch autoreview: no actionable findings
- live Google Slides proof on a disposable deck: native metadata and 720x405 PT page size; shape/image/table element bounds; image `sourceUrl`; bold/italic/font/size/color/link runs; table-cell content; literal locator ranges for ordinary text, table text, and an emoji surrogate pair
- disposable live deck moved to trash and verified trashed

## Docs

- add `docs/slides-introspection.md`
- update README examples and generated command reference

Thanks @sebsnyk for the report.
