### PR TITLE
fix(secrets): trust developer-id signed binary in macOS keychain ACLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.32.1 - Unreleased
 
+- Auth: trust Developer-ID-signed release binaries when creating macOS Keychain items so upgrades read tokens without repeated permission prompts, while leaving ad-hoc/source builds unchanged and allowing `GOG_KEYCHAIN_TRUST_APPLICATION` overrides.
+
 ## 0.32.0 - 2026-07-03
 
 - Docs: add `docs suggestions list` for read-only pending text insertions and deletions, including exact UTF-16 ranges, segment context, and tab selection. (#876)

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -168,6 +168,7 @@ Environment:
 - `GOG_CLIENT=work` (select OAuth client bucket; see `--client`)
 - `GOG_KEYRING_PASSWORD=...` (used when keyring falls back to encrypted file backend in non-interactive environments)
 - `GOG_KEYRING_BACKEND={auto|keychain|file}` (force backend; use `file` to avoid Keychain prompts and pair with `GOG_KEYRING_PASSWORD` for non-interactive)
+- `GOG_KEYCHAIN_TRUST_APPLICATION={auto|true|false}` (control macOS Keychain application trust; auto enables it only for a stably signed binary)
 - `GOG_KEYRING_SERVICE_NAME=...` (override keyring namespace/service name; default `gogcli`)
 - `GOG_KEYRING_OPEN_TIMEOUT=30s` (max time to wait for a keyring open/operation — e.g. a macOS Keychain permission prompt — before failing; Go duration, default `30s` on macOS and `10s` elsewhere)
 - `GOG_TIMEZONE=America/New_York` (default output timezone; IANA name or `UTC`; `local` forces local timezone)

--- a/internal/cmd/auth_cmd_test.go
+++ b/internal/cmd/auth_cmd_test.go
@@ -454,6 +454,41 @@ func TestAuthDoctor_JSON_ClassifiesFileKeyringIntegrity(t *testing.T) {
 	}
 }
 
+func TestAuthDoctor_JSON_ReportsForcedKeychainTrust(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	runtime := runtimeWithAuthStore(newMemSecretsStore())
+	runtime.KeyringOptions.Backend = "keychain"
+	runtime.KeyringOptions.GOOS = "darwin"
+	runtime.KeyringOptions.KeychainTrustApplication = "true"
+
+	result := executeWithTestRuntime(t, []string{"--json", "auth", "doctor"}, runtime)
+	if result.err != nil {
+		t.Fatalf("Execute: %v", result.err)
+	}
+
+	var payload struct {
+		Checks []struct {
+			Name   string `json:"name"`
+			Status string `json:"status"`
+			Detail string `json:"detail"`
+		} `json:"checks"`
+	}
+	if err := json.Unmarshal([]byte(result.stdout), &payload); err != nil {
+		t.Fatalf("json parse: %v\nout=%q", err, result.stdout)
+	}
+	for _, check := range payload.Checks {
+		if check.Name == "keychain.trust" {
+			if check.Status != "ok" || check.Detail != "forced on via GOG_KEYCHAIN_TRUST_APPLICATION" {
+				t.Fatalf("keychain trust check = %#v", check)
+			}
+			return
+		}
+	}
+	t.Fatalf("missing keychain.trust check: %#v", payload.Checks)
+}
+
 func TestAuthList_JSON_ReportsUnreadableToken(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())

--- a/internal/cmd/auth_doctor.go
+++ b/internal/cmd/auth_doctor.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/steipete/gogcli/internal/app"
 	"github.com/steipete/gogcli/internal/config"
 	"github.com/steipete/gogcli/internal/outfmt"
 	"github.com/steipete/gogcli/internal/secrets"
@@ -67,6 +68,7 @@ func (c *AuthDoctorCmd) Run(ctx context.Context, _ *RootFlags) error {
 		add("keyring.backend", doctorError, backendErr.Error(), "")
 	} else {
 		add("keyring.backend", doctorOK, backendInfo.Value+" (source: "+backendInfo.Source+")", "")
+		addKeychainTrustCheck(ctx, add, backendInfo)
 		addKeyringEnvChecks(ctx, add, backendInfo)
 	}
 
@@ -127,6 +129,30 @@ func (c *AuthDoctorCmd) Run(ctx context.Context, _ *RootFlags) error {
 	}
 
 	return writeAuthDoctorResult(ctx, u, checks)
+}
+
+func addKeychainTrustCheck(ctx context.Context, add func(string, string, string, string), backendInfo secrets.KeyringBackendInfo) {
+	appRuntime, ok := app.FromContext(ctx)
+	if !ok || appRuntime.KeyringOptions == nil {
+		return
+	}
+
+	info := secrets.ResolveKeychainTrustApplication(*appRuntime.KeyringOptions, backendInfo)
+	if !info.Applicable {
+		return
+	}
+
+	detail := "application trust disabled (ad-hoc or unsigned binary)"
+	if info.Forced {
+		if info.Enabled {
+			detail = "forced on via GOG_KEYCHAIN_TRUST_APPLICATION"
+		} else {
+			detail = "forced off via GOG_KEYCHAIN_TRUST_APPLICATION"
+		}
+	} else if info.Enabled {
+		detail = "application trust enabled (developer-id signed)"
+	}
+	add("keychain.trust", doctorOK, detail, "")
 }
 
 func authDoctorTokenCheckName(prefix string, client string, email string) string {

--- a/internal/secrets/backend.go
+++ b/internal/secrets/backend.go
@@ -13,10 +13,11 @@ import (
 )
 
 const (
-	keyringPasswordEnv    = "GOG_KEYRING_PASSWORD" //nolint:gosec // env var name, not a credential
-	keyringBackendEnv     = "GOG_KEYRING_BACKEND"  //nolint:gosec // env var name, not a credential
-	keyringServiceNameEnv = "GOG_KEYRING_SERVICE_NAME"
-	keyringOpenTimeoutEnv = "GOG_KEYRING_OPEN_TIMEOUT"
+	keyringPasswordEnv          = "GOG_KEYRING_PASSWORD" //nolint:gosec // env var name, not a credential
+	keyringBackendEnv           = "GOG_KEYRING_BACKEND"  //nolint:gosec // env var name, not a credential
+	keyringServiceNameEnv       = "GOG_KEYRING_SERVICE_NAME"
+	keyringOpenTimeoutEnv       = "GOG_KEYRING_OPEN_TIMEOUT"
+	keychainTrustApplicationEnv = "GOG_KEYCHAIN_TRUST_APPLICATION"
 )
 
 var (
@@ -32,18 +33,20 @@ type KeyringBackendInfo struct {
 }
 
 type OpenOptions struct {
-	Layout        config.Layout
-	Config        *config.ConfigStore
-	Backend       string
-	Password      string
-	PasswordSet   bool
-	ServiceName   string
-	GOOS          string
-	DBusAddress   string
-	IsTTY         bool
-	OpenTimeout   time.Duration
-	LockTimeout   time.Duration
-	openKeyringFn func(keyring.Config) (keyring.Keyring, error)
+	Layout                   config.Layout
+	Config                   *config.ConfigStore
+	Backend                  string
+	Password                 string
+	PasswordSet              bool
+	ServiceName              string
+	GOOS                     string
+	DBusAddress              string
+	IsTTY                    bool
+	OpenTimeout              time.Duration
+	LockTimeout              time.Duration
+	KeychainTrustApplication string
+	openKeyringFn            func(keyring.Config) (keyring.Keyring, error)
+	codesignRunner           func(string) ([]byte, error)
 }
 
 const (
@@ -71,19 +74,21 @@ func OpenOptionsFromLookup(
 	dbusAddress, _ := lookup("DBUS_SESSION_BUS_ADDRESS")
 	openTimeoutRaw, _ := lookup(keyringOpenTimeoutEnv)
 	lockTimeoutRaw, _ := lookup(keyringLockTimeoutEnv)
+	keychainTrustApplication, _ := lookup(keychainTrustApplicationEnv)
 
 	return OpenOptions{
-		Layout:      layout,
-		Config:      store,
-		Backend:     backend,
-		Password:    password,
-		PasswordSet: passwordSet,
-		ServiceName: strings.TrimSpace(serviceName),
-		GOOS:        goos,
-		DBusAddress: dbusAddress,
-		IsTTY:       isTTY,
-		OpenTimeout: parseKeyringOpenTimeout(openTimeoutRaw, goos),
-		LockTimeout: parseKeyringLockTimeout(lockTimeoutRaw),
+		Layout:                   layout,
+		Config:                   store,
+		Backend:                  backend,
+		Password:                 password,
+		PasswordSet:              passwordSet,
+		ServiceName:              strings.TrimSpace(serviceName),
+		GOOS:                     goos,
+		DBusAddress:              dbusAddress,
+		IsTTY:                    isTTY,
+		OpenTimeout:              parseKeyringOpenTimeout(openTimeoutRaw, goos),
+		LockTimeout:              parseKeyringLockTimeout(lockTimeoutRaw),
+		KeychainTrustApplication: keychainTrustApplication,
 	}
 }
 
@@ -261,13 +266,11 @@ func openKeyringWithOptions(options OpenOptions) (keyring.Keyring, error) {
 
 	cfg := keyring.Config{
 		ServiceName: serviceNameFor(options),
-		// KeychainTrustApplication is intentionally false to support Homebrew upgrades.
-		// When true, macOS Keychain ties access control to the specific binary hash.
-		// Homebrew upgrades install a new binary with a different hash, causing the
-		// new binary to lose access to existing keychain items. With false, users may
-		// see a one-time keychain prompt after upgrade (click "Always Allow"), but
-		// tokens survive across upgrades. See: https://github.com/steipete/gogcli/issues/86
-		KeychainTrustApplication: false,
+		// Trust application access only for binaries with a stable signing identity,
+		// so Developer-ID releases keep access across upgrades. Ad-hoc/source builds
+		// retain false because their designated requirement changes each build, the
+		// Homebrew upgrade failure mode documented in issue #86.
+		KeychainTrustApplication: ResolveKeychainTrustApplication(options, backendInfo).Enabled,
 		AllowedBackends:          backends,
 		FileDir:                  keyringDir,
 		FilePasswordFunc:         fileKeyringPasswordFuncFrom(options.Password, options.PasswordSet, options.IsTTY),

--- a/internal/secrets/keychain_trust.go
+++ b/internal/secrets/keychain_trust.go
@@ -1,0 +1,97 @@
+package secrets
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+// KeychainTrustApplicationInfo describes whether macOS Keychain should trust
+// the current application when creating an item.
+type KeychainTrustApplicationInfo struct {
+	Enabled    bool
+	Applicable bool
+	Forced     bool
+}
+
+const codesignTimeout = 5 * time.Second
+
+var cachedStableExecutableSignature = sync.OnceValue(func() bool {
+	return executableHasStableSignature(runCodesign)
+})
+
+// ResolveKeychainTrustApplication resolves GOG_KEYCHAIN_TRUST_APPLICATION for
+// a macOS Keychain backend. Invalid and empty values use automatic detection.
+func ResolveKeychainTrustApplication(options OpenOptions, backendInfo KeyringBackendInfo) KeychainTrustApplicationInfo {
+	if options.GOOS != goosDarwin || (backendInfo.Value != keyringBackendAuto && backendInfo.Value != keyringBackendKeychain) {
+		return KeychainTrustApplicationInfo{}
+	}
+
+	switch strings.ToLower(strings.TrimSpace(options.KeychainTrustApplication)) {
+	case "true", "1":
+		return KeychainTrustApplicationInfo{Enabled: true, Applicable: true, Forced: true}
+	case "false", "0":
+		return KeychainTrustApplicationInfo{Applicable: true, Forced: true}
+	}
+
+	runner := options.codesignRunner
+	if runner == nil {
+		return KeychainTrustApplicationInfo{Enabled: cachedStableExecutableSignature(), Applicable: true}
+	}
+
+	return KeychainTrustApplicationInfo{Enabled: executableHasStableSignature(runner), Applicable: true}
+}
+
+func executableHasStableSignature(runner func(string) ([]byte, error)) bool {
+	executable, err := os.Executable()
+	if err != nil {
+		return false
+	}
+
+	executable, err = filepath.EvalSymlinks(executable)
+	if err != nil {
+		return false
+	}
+
+	output, err := runner(executable)
+	if err != nil {
+		return false
+	}
+
+	return codesignOutputHasStableIdentity(output)
+}
+
+func runCodesign(path string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), codesignTimeout)
+	defer cancel()
+
+	// path comes from os.Executable after symlink resolution, not user input.
+	output, err := exec.CommandContext(ctx, "/usr/bin/codesign", "-dv", path).CombinedOutput() //nolint:gosec
+	if err != nil {
+		return output, fmt.Errorf("inspect executable signature: %w", err)
+	}
+
+	return output, nil
+}
+
+func codesignOutputHasStableIdentity(output []byte) bool {
+	teamIdentifier := ""
+
+	for line := range strings.SplitSeq(string(output), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.EqualFold(line, "Signature=adhoc") {
+			return false
+		}
+
+		if value, ok := strings.CutPrefix(line, "TeamIdentifier="); ok {
+			teamIdentifier = strings.TrimSpace(value)
+		}
+	}
+
+	return teamIdentifier != "" && !strings.EqualFold(teamIdentifier, "not set")
+}

--- a/internal/secrets/keychain_trust_test.go
+++ b/internal/secrets/keychain_trust_test.go
@@ -1,0 +1,78 @@
+package secrets
+
+import (
+	"errors"
+	"testing"
+)
+
+var errCodesignFailed = errors.New("codesign failed")
+
+func TestResolveKeychainTrustApplication(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		goos        string
+		backend     string
+		override    string
+		output      string
+		runnerErr   error
+		want        bool
+		wantForced  bool
+		wantRuns    int
+		wantApplies bool
+	}{
+		{name: "unsigned", goos: "darwin", backend: "keychain", output: "code object is not signed at all", runnerErr: errCodesignFailed, wantRuns: 1, wantApplies: true},
+		{name: "ad-hoc", goos: "darwin", backend: "keychain", output: "Executable=/tmp/gog\nSignature=adhoc\nTeamIdentifier=not set", wantRuns: 1, wantApplies: true},
+		{name: "developer id", goos: "darwin", backend: "keychain", output: "Executable=/tmp/gog\nIdentifier=org.openclaw.gog\nTeamIdentifier=Y5PE65HELJ", want: true, wantRuns: 1, wantApplies: true},
+		{name: "team identifier not set", goos: "darwin", backend: "auto", output: "Signature=adhoc\nTeamIdentifier=not set", wantRuns: 1, wantApplies: true},
+		{name: "runner error", goos: "darwin", backend: "auto", runnerErr: errCodesignFailed, wantRuns: 1, wantApplies: true},
+		{name: "non-darwin", goos: "linux", backend: "keychain", override: "true", wantRuns: 0},
+		{name: "file backend", goos: "darwin", backend: "file", override: "true", wantRuns: 0},
+		{name: "forced true", goos: "darwin", backend: "keychain", override: "TrUe", want: true, wantForced: true, wantRuns: 0, wantApplies: true},
+		{name: "forced one", goos: "darwin", backend: "keychain", override: "1", want: true, wantForced: true, wantRuns: 0, wantApplies: true},
+		{name: "forced false", goos: "darwin", backend: "keychain", override: "FALSE", wantForced: true, wantRuns: 0, wantApplies: true},
+		{name: "forced zero", goos: "darwin", backend: "keychain", override: "0", wantForced: true, wantRuns: 0, wantApplies: true},
+		{name: "invalid uses auto", goos: "darwin", backend: "keychain", override: "sometimes", output: "TeamIdentifier=Y5PE65HELJ", want: true, wantRuns: 1, wantApplies: true},
+		{name: "explicit auto", goos: "darwin", backend: "keychain", override: "AUTO", output: "TeamIdentifier=Y5PE65HELJ", want: true, wantRuns: 1, wantApplies: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			runs := 0
+			options := OpenOptions{
+				GOOS:                     tt.goos,
+				KeychainTrustApplication: tt.override,
+				codesignRunner: func(path string) ([]byte, error) {
+					runs++
+
+					if path == "" {
+						t.Fatal("codesign path is empty")
+					}
+
+					return []byte(tt.output), tt.runnerErr
+				},
+			}
+
+			info := ResolveKeychainTrustApplication(options, KeyringBackendInfo{Value: tt.backend})
+			if info.Enabled != tt.want || info.Forced != tt.wantForced || info.Applicable != tt.wantApplies {
+				t.Fatalf("info = %#v, want enabled=%t forced=%t applicable=%t", info, tt.want, tt.wantForced, tt.wantApplies)
+			}
+
+			if runs != tt.wantRuns {
+				t.Fatalf("codesign runs = %d, want %d", runs, tt.wantRuns)
+			}
+		})
+	}
+}
+
+func TestCodesignOutputHasStableIdentityRejectsAdhocBeforeTeamIdentifier(t *testing.T) {
+	t.Parallel()
+
+	output := []byte("Signature=adhoc\nTeamIdentifier=Y5PE65HELJ\n")
+	if codesignOutputHasStableIdentity(output) {
+		t.Fatal("ad-hoc signature must not be trusted")
+	}
+}

--- a/internal/secrets/store_test.go
+++ b/internal/secrets/store_test.go
@@ -42,11 +42,12 @@ func TestOpenOptionsFromLookupCapturesEnvironment(t *testing.T) {
 	t.Parallel()
 
 	values := map[string]string{
-		keyringBackendEnv:          " file ",
-		keyringPasswordEnv:         "",
-		keyringServiceNameEnv:      " custom-gog ",
-		"DBUS_SESSION_BUS_ADDRESS": "unix:path=/tmp/dbus",
-		keyringLockTimeoutEnv:      "125ms",
+		keyringBackendEnv:           " file ",
+		keyringPasswordEnv:          "",
+		keyringServiceNameEnv:       " custom-gog ",
+		keychainTrustApplicationEnv: " TRUE ",
+		"DBUS_SESSION_BUS_ADDRESS":  "unix:path=/tmp/dbus",
+		keyringLockTimeoutEnv:       "125ms",
 	}
 	options := OpenOptionsFromLookup(
 		config.Layout{ConfigDir: "/config", DataDir: "/data"},
@@ -61,6 +62,10 @@ func TestOpenOptionsFromLookupCapturesEnvironment(t *testing.T) {
 
 	if options.Backend != " file " || options.ServiceName != "custom-gog" {
 		t.Fatalf("options = %#v", options)
+	}
+
+	if options.KeychainTrustApplication != " TRUE " {
+		t.Fatalf("keychain trust application = %q", options.KeychainTrustApplication)
 	}
 
 	if options.Password != "" || !options.PasswordSet {
@@ -174,6 +179,34 @@ func TestOpenUsesInjectedOptions(t *testing.T) {
 
 	if store.lock.timeout != 250*time.Millisecond {
 		t.Fatalf("lock timeout = %v", store.lock.timeout)
+	}
+}
+
+func TestOpenTrustsStableSignedApplicationForKeychain(t *testing.T) {
+	t.Parallel()
+
+	layout := config.Layout{ConfigDir: t.TempDir(), DataDir: t.TempDir()}
+	var opened keyring.Config
+	options := OpenOptions{
+		Layout:  layout,
+		Config:  config.NewConfigStore(layout),
+		Backend: "keychain",
+		GOOS:    "darwin",
+		codesignRunner: func(string) ([]byte, error) {
+			return []byte("Signature=Developer ID Application: Example\nTeamIdentifier=Y5PE65HELJ\n"), nil
+		},
+		openKeyringFn: func(cfg keyring.Config) (keyring.Keyring, error) {
+			opened = cfg
+			return keyring.NewArrayKeyring(nil), nil
+		},
+	}
+
+	if _, err := openKeyringWithOptions(options); err != nil {
+		t.Fatalf("openKeyringWithOptions: %v", err)
+	}
+
+	if !opened.KeychainTrustApplication {
+		t.Fatal("KeychainTrustApplication = false, want true")
 	}
 }
 


### PR DESCRIPTION
## Problem

Every gog keychain item is created with `KeychainTrustApplication: false`, so each of the (three-per-account) token items triggers a macOS "Always Allow + password" prompt on first access — and again after some upgrades. That trade-off exists to protect ad-hoc builds (#86), whose designated requirement changes every rebuild, but the official Homebrew release is Developer-ID signed (stable identity, hardened runtime) and pays the prompt tax for no benefit.

## Fix

- Auto-detect at keyring-open time whether the running executable has a stable signing identity (`codesign -dv`: not unsigned, not `Signature=adhoc`, non-empty `TeamIdentifier`), cached per process; enable `KeychainTrustApplication` only then. Ad-hoc/source builds keep today's behavior.
- `GOG_KEYCHAIN_TRUST_APPLICATION={auto|true|false}` override, plumbed like the other `GOG_*` envs; documented in `docs/spec.md`.
- `gog auth doctor` reports the effective mode as a `keychain.trust` check (darwin + keychain backend only).
- Decision-table unit tests with an injected codesign runner (no real codesign in tests); doctor JSON coverage.

## Proof

- `go test ./internal/secrets/... ./internal/cmd/...` — ok
- `make lint` — 0 issues
- Live: source build reports `keychain.trust = application trust disabled (ad-hoc or unsigned binary)`; with `GOG_KEYCHAIN_TRUST_APPLICATION=true` reports `forced on via GOG_KEYCHAIN_TRUST_APPLICATION`.

Storage format, item names, and existing items' ACLs are untouched; existing items still need their one-time "Always Allow".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
