### PR TITLE
fix(gmail): enforce per-account no-send guard before dry-run exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.34.1 - Unreleased
 
+- Gmail: enforce per-account no-send guards before dry-run exits for first-class and Discovery send paths while preserving no-guard keyring avoidance. (#915, #916) — thanks @veteranbv.
 - MCP: add optional global and per-account capability ceilings in `config.json`, with narrow persistent write authorization, runtime-only restriction, and fail-closed selector validation. (#913) — thanks @mcaldas.
 
 ## 0.34.0 - 2026-07-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 ## 0.34.1 - Unreleased
 
 - MCP: add optional global and per-account capability ceilings in `config.json`, with narrow persistent write authorization, runtime-only restriction, and fail-closed selector validation. (#913) — thanks @mcaldas.
-- Gmail: enforce per-account `config no-send` guards before the dry-run exit so `--dry-run` reports the block instead of `would gmail.send`, matching the `--gmail-no-send` and `gmail_no_send` layers; the same pre-dry-run enforcement now covers Discovery `api call` Gmail send methods, and account resolution is skipped entirely when no per-account guards are configured. (#915)
 
 ## 0.34.0 - 2026-07-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.34.1 - Unreleased
 
 - MCP: add optional global and per-account capability ceilings in `config.json`, with narrow persistent write authorization, runtime-only restriction, and fail-closed selector validation. (#913) — thanks @mcaldas.
+- Gmail: enforce per-account `config no-send` guards before the dry-run exit so `--dry-run` reports the block instead of `would gmail.send`, matching the `--gmail-no-send` and `gmail_no_send` layers. (#915)
 
 ## 0.34.0 - 2026-07-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.34.1 - Unreleased
 
 - MCP: add optional global and per-account capability ceilings in `config.json`, with narrow persistent write authorization, runtime-only restriction, and fail-closed selector validation. (#913) — thanks @mcaldas.
-- Gmail: enforce per-account `config no-send` guards before the dry-run exit so `--dry-run` reports the block instead of `would gmail.send`, matching the `--gmail-no-send` and `gmail_no_send` layers. (#915)
+- Gmail: enforce per-account `config no-send` guards before the dry-run exit so `--dry-run` reports the block instead of `would gmail.send`, matching the `--gmail-no-send` and `gmail_no_send` layers; the same pre-dry-run enforcement now covers Discovery `api call` Gmail send methods, and account resolution is skipped entirely when no per-account guards are configured. (#915)
 
 ## 0.34.0 - 2026-07-11
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -181,7 +181,7 @@ Environment:
 - `config.json` can also set `places_api_key` (or use `GOG_PLACES_API_KEY` / `GOOGLE_PLACES_API_KEY`) for Calendar Places lookups.
 - `config.json` can also set `account_aliases` for `gog auth alias` (JSON5)
 - `config.json` can also set `account_clients` (email -> client) and `client_domains` (domain -> client)
-- `config.json` can also set `gmail_no_send` and `no_send_accounts` for send guards (both enforced before command execution, including under `--dry-run`)
+- `config.json` can also set `gmail_no_send` and `no_send_accounts` for send guards
 
 Flag aliases:
 - `--out` also accepts `--output`.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -181,7 +181,7 @@ Environment:
 - `config.json` can also set `places_api_key` (or use `GOG_PLACES_API_KEY` / `GOOGLE_PLACES_API_KEY`) for Calendar Places lookups.
 - `config.json` can also set `account_aliases` for `gog auth alias` (JSON5)
 - `config.json` can also set `account_clients` (email -> client) and `client_domains` (domain -> client)
-- `config.json` can also set `gmail_no_send` and `no_send_accounts` for send guards
+- `config.json` can also set `gmail_no_send` and `no_send_accounts` for send guards (both enforced before command execution, including under `--dry-run`)
 
 Flag aliases:
 - `--out` also accepts `--output`.

--- a/internal/cmd/api.go
+++ b/internal/cmd/api.go
@@ -285,7 +285,7 @@ func checkDiscoveryGmailNoSend(ctx context.Context, flags *RootFlags, methodID s
 	// Same rules as enforceGmailNoSend: only resolve an account when a
 	// per-account guard could match (default-account inference reads the
 	// keyring), and leave resolution failures to the command itself.
-	if len(cfg.NoSendAccounts) == 0 {
+	if !hasActiveNoSendAccount(cfg.NoSendAccounts) {
 		return nil
 	}
 	if account, accountErr := requireAccount(flags); accountErr == nil {

--- a/internal/cmd/api.go
+++ b/internal/cmd/api.go
@@ -118,6 +118,11 @@ func (c *APICallCmd) Run(ctx context.Context, flags *RootFlags) error {
 	if !read && !c.AllowWrite {
 		return usagef("method %s uses %s; pass --allow-write to opt in", method.ID, method.Spec.HttpMethod)
 	}
+	// Gmail send guards run before the dry-run exit so --dry-run reports
+	// the block, matching the first-class Gmail send commands.
+	if guardErr := checkDiscoveryGmailNoSend(ctx, flags, method.ID); guardErr != nil {
+		return guardErr
+	}
 	plan := map[string]any{"api": c.API, "version": c.Version, "method": method.ID, "http_method": method.Spec.HttpMethod, "url": requestURL, "has_body": len(body) > 0}
 	if dryRunErr := dryRunExit(ctx, flags, "api.call", plan); dryRunErr != nil {
 		return dryRunErr
@@ -138,8 +143,12 @@ func (c *APICallCmd) Run(ctx context.Context, flags *RootFlags) error {
 	if err != nil {
 		return err
 	}
-	if guardErr := checkDiscoveryGmailNoSend(ctx, flags, account, method.ID); guardErr != nil {
-		return guardErr
+	// Defense-in-depth for the auth-resolved account, mirroring the
+	// first-class send commands.
+	if isDiscoveryGmailSendMethod(method.ID) {
+		if guardErr := checkAccountNoSend(ctx, account); guardErr != nil {
+			return guardErr
+		}
 	}
 	scopes, err := discoveryScopes(method.Spec.Scopes, c.Scope)
 	if err != nil {
@@ -249,8 +258,12 @@ func discoveryScopeScore(scope string) int {
 	}
 }
 
-func checkDiscoveryGmailNoSend(ctx context.Context, flags *RootFlags, account, methodID string) error {
-	if methodID != "gmail.users.messages.send" && methodID != "gmail.users.drafts.send" {
+func isDiscoveryGmailSendMethod(methodID string) bool {
+	return methodID == "gmail.users.messages.send" || methodID == "gmail.users.drafts.send"
+}
+
+func checkDiscoveryGmailNoSend(ctx context.Context, flags *RootFlags, methodID string) error {
+	if !isDiscoveryGmailSendMethod(methodID) {
 		return nil
 	}
 	if flags != nil && flags.GmailNoSend {
@@ -269,7 +282,16 @@ func checkDiscoveryGmailNoSend(ctx context.Context, flags *RootFlags, account, m
 		return usage("Gmail sending is blocked by config gmail_no_send")
 	}
 
-	return checkAccountNoSend(ctx, account)
+	// Same rules as enforceGmailNoSend: only resolve an account when a
+	// per-account guard could match (default-account inference reads the
+	// keyring), and leave resolution failures to the command itself.
+	if len(cfg.NoSendAccounts) == 0 {
+		return nil
+	}
+	if account, accountErr := requireAccount(flags); accountErr == nil {
+		return checkAccountNoSend(ctx, account)
+	}
+	return nil
 }
 
 func readDiscoveryBody(value string) (json.RawMessage, error) {

--- a/internal/cmd/api_test.go
+++ b/internal/cmd/api_test.go
@@ -162,7 +162,7 @@ func TestDiscoveryGmailSendWithInactiveGuardsSkipsAccountResolution(t *testing.T
 	flags := &RootFlags{authOperations: app.AuthOperations{
 		OpenSecretsStore: func() (secrets.Store, error) {
 			t.Fatal("inactive no-send entries must not trigger account resolution")
-			return nil, nil
+			return nil, errors.New("unexpected account resolution")
 		},
 	}}
 

--- a/internal/cmd/api_test.go
+++ b/internal/cmd/api_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/steipete/gogcli/internal/app"
+	"github.com/steipete/gogcli/internal/config"
 	"github.com/steipete/gogcli/internal/googleapi"
 	"github.com/steipete/gogcli/internal/outfmt"
 )
@@ -116,9 +118,35 @@ func TestValidateDiscoveryRedirect(t *testing.T) {
 }
 
 func TestDiscoveryGmailSendHonorsNoSendFlag(t *testing.T) {
-	err := checkDiscoveryGmailNoSend(context.Background(), &RootFlags{GmailNoSend: true}, "user@example.com", "gmail.users.messages.send")
+	err := checkDiscoveryGmailNoSend(context.Background(), &RootFlags{GmailNoSend: true}, "gmail.users.messages.send")
 	if err == nil || !strings.Contains(err.Error(), "--gmail-no-send") {
 		t.Fatalf("error = %v, want no-send policy", err)
+	}
+}
+
+func TestDiscoveryGmailSendHonorsPerAccountNoSend(t *testing.T) {
+	t.Parallel()
+
+	store := config.NewConfigStore(config.Layout{ConfigDir: t.TempDir()})
+	if err := store.Write(config.File{NoSendAccounts: map[string]bool{"blocked@example.com": true}}); err != nil {
+		t.Fatalf("WriteConfig: %v", err)
+	}
+	ctx := app.WithRuntime(context.Background(), &app.Runtime{Config: store})
+	flags := &RootFlags{Account: "blocked@example.com"}
+
+	err := checkDiscoveryGmailNoSend(ctx, flags, "gmail.users.messages.send")
+	if err == nil || !strings.Contains(err.Error(), "no-send") {
+		t.Fatalf("error = %v, want per-account no-send", err)
+	}
+	if err := checkDiscoveryGmailNoSend(ctx, flags, "gmail.users.drafts.send"); err == nil {
+		t.Fatalf("drafts.send: expected per-account no-send error")
+	}
+	// Non-send methods and non-guarded accounts are unaffected.
+	if err := checkDiscoveryGmailNoSend(ctx, flags, "gmail.users.labels.list"); err != nil {
+		t.Fatalf("non-send method: %v", err)
+	}
+	if err := checkDiscoveryGmailNoSend(ctx, &RootFlags{Account: "other@example.com"}, "gmail.users.messages.send"); err != nil {
+		t.Fatalf("non-guarded account: %v", err)
 	}
 }
 

--- a/internal/cmd/api_test.go
+++ b/internal/cmd/api_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/steipete/gogcli/internal/config"
 	"github.com/steipete/gogcli/internal/googleapi"
 	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/secrets"
 )
 
 func TestAPICallRequiresWriteOptIn(t *testing.T) {
@@ -147,6 +148,26 @@ func TestDiscoveryGmailSendHonorsPerAccountNoSend(t *testing.T) {
 	}
 	if err := checkDiscoveryGmailNoSend(ctx, &RootFlags{Account: "other@example.com"}, "gmail.users.messages.send"); err != nil {
 		t.Fatalf("non-guarded account: %v", err)
+	}
+}
+
+func TestDiscoveryGmailSendWithInactiveGuardsSkipsAccountResolution(t *testing.T) {
+	t.Parallel()
+
+	store := config.NewConfigStore(config.Layout{ConfigDir: t.TempDir()})
+	if err := store.Write(config.File{NoSendAccounts: map[string]bool{"inactive@example.com": false}}); err != nil {
+		t.Fatalf("WriteConfig: %v", err)
+	}
+	ctx := app.WithRuntime(context.Background(), &app.Runtime{Config: store})
+	flags := &RootFlags{authOperations: app.AuthOperations{
+		OpenSecretsStore: func() (secrets.Store, error) {
+			t.Fatal("inactive no-send entries must not trigger account resolution")
+			return nil, nil
+		},
+	}}
+
+	if err := checkDiscoveryGmailNoSend(ctx, flags, "gmail.users.messages.send"); err != nil {
+		t.Fatalf("inactive no-send entry: %v", err)
 	}
 }
 

--- a/internal/cmd/gmail_no_send.go
+++ b/internal/cmd/gmail_no_send.go
@@ -40,6 +40,21 @@ func enforceGmailNoSend(kctx *kong.Context, flags *RootFlags, runtime *app.Runti
 	if cfg.GmailNoSend {
 		return usage("Gmail sending is blocked by config gmail_no_send")
 	}
+	// Per-account guard, enforced at the same layer as the flag and the
+	// global config key so it also holds under --dry-run, which exits the
+	// command before the post-auth checkAccountNoSend call is reached.
+	// Account resolution failures are not errors here: commands own that
+	// failure mode, and checkAccountNoSend still covers real sends after
+	// auth resolves the account.
+	if account, accountErr := requireAccount(flags); accountErr == nil {
+		blocked, blockedErr := runtime.Config.IsNoSendAccount(account)
+		if blockedErr != nil {
+			return blockedErr
+		}
+		if blocked {
+			return usagef("Gmail sending is blocked for %s (config no-send)", strings.TrimSpace(account))
+		}
+	}
 	return nil
 }
 

--- a/internal/cmd/gmail_no_send.go
+++ b/internal/cmd/gmail_no_send.go
@@ -43,9 +43,14 @@ func enforceGmailNoSend(kctx *kong.Context, flags *RootFlags, runtime *app.Runti
 	// Per-account guard, enforced at the same layer as the flag and the
 	// global config key so it also holds under --dry-run, which exits the
 	// command before the post-auth checkAccountNoSend call is reached.
-	// Account resolution failures are not errors here: commands own that
-	// failure mode, and checkAccountNoSend still covers real sends after
-	// auth resolves the account.
+	// Skip entirely when no per-account guards exist so a plain dry-run
+	// never resolves an account (default-account inference reads the
+	// keyring). Account resolution failures are not errors here: commands
+	// own that failure mode, and checkAccountNoSend still covers real
+	// sends after auth resolves the account.
+	if len(cfg.NoSendAccounts) == 0 {
+		return nil
+	}
 	if account, accountErr := requireAccount(flags); accountErr == nil {
 		blocked, blockedErr := runtime.Config.IsNoSendAccount(account)
 		if blockedErr != nil {

--- a/internal/cmd/gmail_no_send.go
+++ b/internal/cmd/gmail_no_send.go
@@ -48,7 +48,7 @@ func enforceGmailNoSend(kctx *kong.Context, flags *RootFlags, runtime *app.Runti
 	// keyring). Account resolution failures are not errors here: commands
 	// own that failure mode, and checkAccountNoSend still covers real
 	// sends after auth resolves the account.
-	if len(cfg.NoSendAccounts) == 0 {
+	if !hasActiveNoSendAccount(cfg.NoSendAccounts) {
 		return nil
 	}
 	if account, accountErr := requireAccount(flags); accountErr == nil {
@@ -61,6 +61,15 @@ func enforceGmailNoSend(kctx *kong.Context, flags *RootFlags, runtime *app.Runti
 		}
 	}
 	return nil
+}
+
+func hasActiveNoSendAccount(accounts map[string]bool) bool {
+	for _, blocked := range accounts {
+		if blocked {
+			return true
+		}
+	}
+	return false
 }
 
 func checkAccountNoSend(ctx context.Context, account string) error {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -167,6 +167,18 @@ func executeWithRuntime(args []string, runtime *app.Runtime) (err error) {
 	cli.authMode = googleapi.ParseAuthMode(os.Getenv("GOG_AUTH_MODE"))
 	applyExplicitOutputModePrecedence(kctx, &cli.RootFlags)
 
+	// Make config-backed account and alias resolution available to the
+	// pre-Run enforcement hooks below (enforceGmailNoSend resolves the
+	// target account). The context-backed resolver installed later
+	// replaces this with an equivalent one; both reduce to
+	// configureRuntimeConfig + runtime.Config.
+	cli.configStoreResolver = func() (*config.ConfigStore, error) {
+		if cfgErr := configureRuntimeConfig(runtime); cfgErr != nil {
+			return nil, cfgErr
+		}
+		return runtime.Config, nil
+	}
+
 	if err = enforceBakedSafetyProfile(kctx); err != nil {
 		return reportEarlyError(runtimeIO.Err, err)
 	}

--- a/internal/cmd/root_more_test.go
+++ b/internal/cmd/root_more_test.go
@@ -475,7 +475,7 @@ func TestGmailSendDryRunWithInactiveGuardsSkipsAccountResolution(t *testing.T) {
 	runtime := &app.Runtime{Config: store}
 	runtime.Auth.OpenSecretsStore = func() (secrets.Store, error) {
 		t.Fatal("inactive no-send entries must not trigger account resolution")
-		return nil, nil
+		return nil, errors.New("unexpected account resolution")
 	}
 	args := []string{"gmail", "send", "--to", "a@example.com", "--subject", "S", "--body", "B", "--dry-run"}
 	result := executeWithTestRuntime(t, args, runtime)

--- a/internal/cmd/root_more_test.go
+++ b/internal/cmd/root_more_test.go
@@ -396,6 +396,54 @@ func TestConfigGmailNoSendBlocksBeforeAuth(t *testing.T) {
 	}
 }
 
+func TestConfigNoSendAccountBlocksBeforeDryRun(t *testing.T) {
+	t.Parallel()
+
+	store := config.NewConfigStore(config.Layout{ConfigDir: t.TempDir()})
+	if err := store.Write(config.File{NoSendAccounts: map[string]bool{"blocked@example.com": true}}); err != nil {
+		t.Fatalf("WriteConfig: %v", err)
+	}
+	runtime := &app.Runtime{Config: store}
+	tests := [][]string{
+		{"gmail", "send", "--account", "blocked@example.com", "--to", "a@example.com", "--subject", "S", "--body", "B", "--dry-run"},
+		{"gmail", "autoreply", "from:a@example.com", "--account", "blocked@example.com", "--subject", "S", "--body", "B", "--dry-run"},
+		{"gmail", "forward", "msg-1", "--account", "blocked@example.com", "--to", "a@example.com", "--dry-run"},
+		{"gmail", "drafts", "send", "draft-1", "--account", "blocked@example.com", "--dry-run"},
+	}
+	for _, args := range tests {
+		result := executeWithTestRuntime(t, args, runtime)
+		err := result.err
+		if err == nil {
+			t.Fatalf("expected error for %v", args)
+		}
+		if !strings.Contains(err.Error(), "no-send") {
+			t.Fatalf("unexpected error for %v: %v", args, err)
+		}
+	}
+}
+
+func TestConfigNoSendAccountDoesNotOverblockDryRun(t *testing.T) {
+	t.Parallel()
+
+	store := config.NewConfigStore(config.Layout{ConfigDir: t.TempDir()})
+	if err := store.Write(config.File{NoSendAccounts: map[string]bool{"blocked@example.com": true}}); err != nil {
+		t.Fatalf("WriteConfig: %v", err)
+	}
+	runtime := &app.Runtime{Config: store}
+	tests := [][]string{
+		// Send from a different account is not blocked.
+		{"gmail", "send", "--account", "other@example.com", "--to", "a@example.com", "--subject", "S", "--body", "B", "--dry-run"},
+		// Non-send commands for the guarded account are not blocked.
+		{"gmail", "drafts", "create", "--account", "blocked@example.com", "--to", "a@example.com", "--subject", "S", "--body", "B", "--dry-run"},
+	}
+	for _, args := range tests {
+		result := executeWithTestRuntime(t, args, runtime)
+		if result.err != nil {
+			t.Fatalf("expected success for %v, got %v\nstderr=%q", args, result.err, result.stderr)
+		}
+	}
+}
+
 func TestConfigIndependentCommandsDoNotRequireHome(t *testing.T) {
 	t.Setenv("HOME", "")
 	t.Setenv("USERPROFILE", "")

--- a/internal/cmd/root_more_test.go
+++ b/internal/cmd/root_more_test.go
@@ -400,7 +400,10 @@ func TestConfigNoSendAccountBlocksBeforeDryRun(t *testing.T) {
 	t.Parallel()
 
 	store := config.NewConfigStore(config.Layout{ConfigDir: t.TempDir()})
-	if err := store.Write(config.File{NoSendAccounts: map[string]bool{"blocked@example.com": true}}); err != nil {
+	if err := store.Write(config.File{
+		AccountAliases: map[string]string{"work": "blocked@example.com"},
+		NoSendAccounts: map[string]bool{"blocked@example.com": true},
+	}); err != nil {
 		t.Fatalf("WriteConfig: %v", err)
 	}
 	runtime := &app.Runtime{Config: store}
@@ -409,6 +412,8 @@ func TestConfigNoSendAccountBlocksBeforeDryRun(t *testing.T) {
 		{"gmail", "autoreply", "from:a@example.com", "--account", "blocked@example.com", "--subject", "S", "--body", "B", "--dry-run"},
 		{"gmail", "forward", "msg-1", "--account", "blocked@example.com", "--to", "a@example.com", "--dry-run"},
 		{"gmail", "drafts", "send", "draft-1", "--account", "blocked@example.com", "--dry-run"},
+		// Alias resolving to a guarded account is blocked too.
+		{"gmail", "send", "--account", "work", "--to", "a@example.com", "--subject", "S", "--body", "B", "--dry-run"},
 	}
 	for _, args := range tests {
 		result := executeWithTestRuntime(t, args, runtime)

--- a/internal/cmd/root_more_test.go
+++ b/internal/cmd/root_more_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/steipete/gogcli/internal/app"
 	"github.com/steipete/gogcli/internal/config"
+	"github.com/steipete/gogcli/internal/secrets"
 )
 
 func setTestConfigHome(t *testing.T) {
@@ -457,6 +458,25 @@ func TestGmailSendDryRunWithoutGuardsSkipsAccountResolution(t *testing.T) {
 	// keyring before the dry-run exit).
 	store := config.NewConfigStore(config.Layout{ConfigDir: t.TempDir()})
 	runtime := &app.Runtime{Config: store}
+	args := []string{"gmail", "send", "--to", "a@example.com", "--subject", "S", "--body", "B", "--dry-run"}
+	result := executeWithTestRuntime(t, args, runtime)
+	if result.err != nil {
+		t.Fatalf("expected success for %v, got %v\nstderr=%q", args, result.err, result.stderr)
+	}
+}
+
+func TestGmailSendDryRunWithInactiveGuardsSkipsAccountResolution(t *testing.T) {
+	t.Parallel()
+
+	store := config.NewConfigStore(config.Layout{ConfigDir: t.TempDir()})
+	if err := store.Write(config.File{NoSendAccounts: map[string]bool{"inactive@example.com": false}}); err != nil {
+		t.Fatalf("WriteConfig: %v", err)
+	}
+	runtime := &app.Runtime{Config: store}
+	runtime.Auth.OpenSecretsStore = func() (secrets.Store, error) {
+		t.Fatal("inactive no-send entries must not trigger account resolution")
+		return nil, nil
+	}
 	args := []string{"gmail", "send", "--to", "a@example.com", "--subject", "S", "--body", "B", "--dry-run"}
 	result := executeWithTestRuntime(t, args, runtime)
 	if result.err != nil {

--- a/internal/cmd/root_more_test.go
+++ b/internal/cmd/root_more_test.go
@@ -449,6 +449,21 @@ func TestConfigNoSendAccountDoesNotOverblockDryRun(t *testing.T) {
 	}
 }
 
+func TestGmailSendDryRunWithoutGuardsSkipsAccountResolution(t *testing.T) {
+	t.Parallel()
+
+	// No per-account guards configured: dry-run must succeed without any
+	// account being resolvable (resolution would otherwise read the
+	// keyring before the dry-run exit).
+	store := config.NewConfigStore(config.Layout{ConfigDir: t.TempDir()})
+	runtime := &app.Runtime{Config: store}
+	args := []string{"gmail", "send", "--to", "a@example.com", "--subject", "S", "--body", "B", "--dry-run"}
+	result := executeWithTestRuntime(t, args, runtime)
+	if result.err != nil {
+		t.Fatalf("expected success for %v, got %v\nstderr=%q", args, result.err, result.stderr)
+	}
+}
+
 func TestConfigIndependentCommandsDoNotRequireHome(t *testing.T) {
 	t.Setenv("HOME", "")
 	t.Setenv("USERPROFILE", "")


### PR DESCRIPTION
Fixes #915.

## What Problem This Solves

The per-account no-send guard (`gog config no-send set <email>`) is enforced only inside each send command's `Run()`, after auth resolution — and every send path calls `dryRunExit` before that point. `--dry-run`, the safe way to probe a guard, reported `would gmail.send` for an account whose sends are blocked. The `--gmail-no-send` flag and global `gmail_no_send` config layers block under `--dry-run`; the per-account layer silently did not.

## Why This Change Was Made

An operator or agent verifying its guardrails with `--dry-run` is told the guard is absent when it isn't — the exact wrong answer for a safety feature. Real (non-dry-run) sends were never at risk: `checkAccountNoSend` blocks before any API call on the real path. The failure is the safety signal.

The fix enforces the per-account guard in `enforceGmailNoSend`, at the same pre-`Run()` layer as its two siblings, and applies the same pre-dry-run enforcement to the Discovery path (`gog api call gmail v1 gmail.users.messages.send` / `...drafts.send`). Per Codex review follow-ups: aliases resolve correctly (a config-backed store resolver is installed before the enforcement hooks), and account resolution is skipped entirely when no per-account guards exist, so a plain dry-run never reads the keyring. Post-auth `checkAccountNoSend` remains as defense-in-depth everywhere.

## User Impact

- `--dry-run` on any Gmail send path (first-class or Discovery) now reports the per-account block instead of `would gmail.send` / `would api.call`.
- No new flags; no behavior change for accounts without guards, non-send commands, or the existing flag/global layers.
- A plain dry-run with no guards configured no longer resolves an account at all (no keyring inference).

## Evidence

Baseline `gog-main` built from upstream `main` @ `5800e0ef`; `gog-pr` built from this PR @ `0fe4595bdf16508e8eae99295757b706af996f06`. All runs fully isolated: `env -i` with throwaway `HOME`, `mktemp` config dirs, synthetic accounts only, no credentials. Guard config:

```json
{"account_aliases":{"work":"blocked@example.com"},"no_send_accounts":{"blocked@example.com":true}}
```

![before/after: guarded dry-run leaks on main, blocks on PR](https://raw.githubusercontent.com/veteranbv/gogcli/pr-916-assets/no-send-dry-run.gif)

**Claims proved live (24/24 checks):**

- All five first-class send paths (`send`, `drafts send`, `forward`, `reply`, `autoreply`) and the Discovery `gmail.users.messages.send` call report `would ...` on main for a guarded account under `--dry-run`, and `Gmail sending is blocked for blocked@example.com (config no-send)` on this PR.
- Alias form (`--account work` → `blocked@example.com`) blocked on this PR.
- No over-blocking: non-guarded account dry-runs normally; `drafts create` for the guarded account dry-runs normally; empty-guards config with no `--account` dry-runs normally — all identical on both binaries.
- Existing layers unchanged: `--gmail-no-send` and global `gmail_no_send` block identically on both binaries.

<details>
<summary>Full result matrix (24 cases, JSON)</summary>

```json
{"case":"guarded-email send --dry-run","binary":"gog-main","expect_contains":"Dry run:","first_line":"Dry run: would gmail.send","pass":true}
{"case":"guarded-alias send --dry-run","binary":"gog-main","expect_contains":"Dry run:","first_line":"Dry run: would gmail.send","pass":true}
{"case":"guarded drafts send --dry-run","binary":"gog-main","expect_contains":"Dry run:","first_line":"Dry run: would gmail.drafts.send","pass":true}
{"case":"guarded forward --dry-run","binary":"gog-main","expect_contains":"Dry run:","first_line":"Dry run: would gmail.forward","pass":true}
{"case":"guarded reply --dry-run","binary":"gog-main","expect_contains":"Dry run:","first_line":"Dry run: would gmail.reply","pass":true}
{"case":"guarded autoreply --dry-run","binary":"gog-main","expect_contains":"Dry run:","first_line":"Dry run: would gmail.autoreply","pass":true}
{"case":"guarded discovery messages.send --dry-run","binary":"gog-main","expect_contains":"Dry run:","first_line":"Dry run: would api.call","pass":true}
{"case":"other-account send --dry-run (allowed)","binary":"gog-main","expect_contains":"Dry run: would gmail.send","first_line":"Dry run: would gmail.send","pass":true}
{"case":"guarded drafts create --dry-run (allowed)","binary":"gog-main","expect_contains":"Dry run: would gmail.drafts.create","first_line":"Dry run: would gmail.drafts.create","pass":true}
{"case":"no-guards no-account send --dry-run (allowed)","binary":"gog-main","expect_contains":"Dry run: would gmail.send","first_line":"Dry run: would gmail.send","pass":true}
{"case":"flag --gmail-no-send --dry-run (blocked)","binary":"gog-main","expect_contains":"blocked by --gmail-no-send","first_line":"Gmail sending is blocked by --gmail-no-send","pass":true}
{"case":"global gmail_no_send --dry-run (blocked)","binary":"gog-main","expect_contains":"blocked by config gmail_no_send","first_line":"Gmail sending is blocked by config gmail_no_send","pass":true}
{"case":"guarded-email send --dry-run","binary":"gog-pr","expect_contains":"Gmail sending is blocked for blocked@example.com (config no-send)","first_line":"Gmail sending is blocked for blocked@example.com (config no-send)","pass":true}
{"case":"guarded-alias send --dry-run","binary":"gog-pr","expect_contains":"Gmail sending is blocked for blocked@example.com (config no-send)","first_line":"Gmail sending is blocked for blocked@example.com (config no-send)","pass":true}
{"case":"guarded drafts send --dry-run","binary":"gog-pr","expect_contains":"Gmail sending is blocked for blocked@example.com (config no-send)","first_line":"Gmail sending is blocked for blocked@example.com (config no-send)","pass":true}
{"case":"guarded forward --dry-run","binary":"gog-pr","expect_contains":"Gmail sending is blocked for blocked@example.com (config no-send)","first_line":"Gmail sending is blocked for blocked@example.com (config no-send)","pass":true}
{"case":"guarded reply --dry-run","binary":"gog-pr","expect_contains":"Gmail sending is blocked for blocked@example.com (config no-send)","first_line":"Gmail sending is blocked for blocked@example.com (config no-send)","pass":true}
{"case":"guarded autoreply --dry-run","binary":"gog-pr","expect_contains":"Gmail sending is blocked for blocked@example.com (config no-send)","first_line":"Gmail sending is blocked for blocked@example.com (config no-send)","pass":true}
{"case":"guarded discovery messages.send --dry-run","binary":"gog-pr","expect_contains":"Gmail sending is blocked for blocked@example.com (config no-send)","first_line":"Gmail sending is blocked for blocked@example.com (config no-send)","pass":true}
{"case":"other-account send --dry-run (allowed)","binary":"gog-pr","expect_contains":"Dry run: would gmail.send","first_line":"Dry run: would gmail.send","pass":true}
{"case":"guarded drafts create --dry-run (allowed)","binary":"gog-pr","expect_contains":"Dry run: would gmail.drafts.create","first_line":"Dry run: would gmail.drafts.create","pass":true}
{"case":"no-guards no-account send --dry-run (allowed)","binary":"gog-pr","expect_contains":"Dry run: would gmail.send","first_line":"Dry run: would gmail.send","pass":true}
{"case":"flag --gmail-no-send --dry-run (blocked)","binary":"gog-pr","expect_contains":"blocked by --gmail-no-send","first_line":"Gmail sending is blocked by --gmail-no-send","pass":true}
{"case":"global gmail_no_send --dry-run (blocked)","binary":"gog-pr","expect_contains":"blocked by config gmail_no_send","first_line":"Gmail sending is blocked by config gmail_no_send","pass":true}
```

</details>

Scope note: the live matrix intentionally exercises only dry-run and pre-auth paths (no credentialed runs, nothing sent). The real-send guard behavior is unchanged and covered by the existing and new unit tests.

**Hygiene, pinned to `0fe4595b`:**

- `git diff --check origin/main...HEAD` — clean
- `make fmt` — zero files changed
- `make lint` — pass
- Focused regression: `go test ./internal/cmd/ -run 'NoSend|DiscoveryGmailSend|GmailSendDryRun' -v` — 10 passed, 0 failed
- Full package: `go test ./internal/cmd/` — pass; upstream CI green across all seven checks

## Test plan

- [x] `TestConfigNoSendAccountBlocksBeforeDryRun` — guarded send paths + alias blocked under `--dry-run` (fails on unpatched main, passes with fix)
- [x] `TestConfigNoSendAccountDoesNotOverblockDryRun` — other accounts and non-send commands unaffected
- [x] `TestGmailSendDryRunWithoutGuardsSkipsAccountResolution` — no guards → no account resolution on dry-run
- [x] `TestDiscoveryGmailSendHonorsPerAccountNoSend` — Discovery messages.send/drafts.send blocked per-account; non-send methods and other accounts unaffected
- [x] `TestDiscoveryGmailSendHonorsNoSendFlag` — updated for the parameter-less guard signature
- [x] `make fmt` / `make lint` / `make test` — clean

User-facing change: `--dry-run` on a send command now reports the per-account block instead of `Dry run: would gmail.send`. No new flags. CHANGELOG and docs/spec.md updated.
