### PR TITLE
fix(gmail): accept padded raw message encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.34.1 - Unreleased
 
 - Gmail: enforce per-account no-send guards before dry-run exits for first-class and Discovery send paths while preserving no-guard keyring avoidance. (#915, #916) — thanks @veteranbv.
+- Gmail: accept padded Gmail API base64url payloads in `gmail get --format raw` while retaining unpadded compatibility. (#922, #923) — thanks @goutamadwant.
 - MCP: add optional global and per-account capability ceilings in `config.json`, with narrow persistent write authorization, runtime-only restriction, and fail-closed selector validation. (#913) — thanks @mcaldas.
 
 ## 0.34.0 - 2026-07-11

--- a/internal/cmd/gmail_get.go
+++ b/internal/cmd/gmail_get.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"encoding/base64"
 	"strings"
 
 	"github.com/steipete/gogcli/internal/gmailcontent"
@@ -127,7 +126,7 @@ func (c *GmailGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 			u.Err().Println("Empty raw message")
 			return nil
 		}
-		decoded, err := base64.RawURLEncoding.DecodeString(msg.Raw)
+		decoded, err := decodeGmailRaw(msg.Raw)
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/gmail_get_cmd_test.go
+++ b/internal/cmd/gmail_get_cmd_test.go
@@ -322,6 +322,41 @@ func TestGmailGetCmd_Text_Metadata_WithAttachments(t *testing.T) {
 	}
 }
 
+func TestGmailGetCmd_RawAcceptsPaddedBase64URL(t *testing.T) {
+	rawMessage := "Subject: padded\r\nContent-Type: multipart/mixed\r\n\r\nbody!"
+	encoded := base64.URLEncoding.EncodeToString([]byte(rawMessage))
+	if !strings.HasSuffix(encoded, "=") {
+		t.Fatal("test fixture must include base64 padding")
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/gmail/v1/users/me/messages/") {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":       "m1",
+			"threadId": "t1",
+			"labelIds": []string{"INBOX"},
+			"raw":      encoded,
+		})
+	}))
+	defer srv.Close()
+
+	result := executeWithGmailTestService(
+		t,
+		[]string{"--plain", "--account", "a@b.com", "gmail", "get", "m1", "--format", "raw"},
+		newGmailServiceFromServer(t, srv),
+	)
+	if result.err != nil {
+		t.Fatalf("execute: %v\nstderr=%q", result.err, result.stderr)
+	}
+	if !strings.Contains(result.stdout, rawMessage) {
+		t.Fatalf("expected decoded raw message, got: %q", result.stdout)
+	}
+}
+
 func TestGmailGetCmd_RawEmpty(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !strings.Contains(r.URL.Path, "/gmail/v1/users/me/messages/") {


### PR DESCRIPTION
## Summary

- Accept padded and unpadded base64url payloads from Gmail when `gog gmail get --format raw` renders an RFC822 message.
- Reuse the existing Gmail raw decoder so interactive retrieval and backup export follow the same decoding rules.
- Add a command-level regression covering a padded multipart-style raw message response.

Closes #922

## Real behavior proof

- Behavior addressed: a valid padded Gmail `raw` response failed before rendering the message.
- Before fix: `TestGmailGetCmd_RawAcceptsPaddedBase64URL` failed with `illegal base64 data at input byte 74`.
- After fix: the same command-level test passes and its output contains the decoded RFC822 message.
- Exact focused command: `go test ./internal/cmd -run '^TestGmailGetCmd_Raw(AcceptsPaddedBase64URL|Empty)$' -count=1`
- Test environment: the command runs against a local HTTP server returning the same Gmail API message shape, including padded base64url data.
- Limitation: this was not tested against an authenticated Gmail account.

## Validation

- `go test ./internal/cmd -count=1`
- `go test ./... -count=1`
- `go vet ./...`
- `make fmt-check`
- `make build`
- `make deadcode`
- `make docker-version-check docs-check agent-skills-check`
- `node --test scripts/eval-gws.test.mjs scripts/eval-gws-agents.test.mjs`
- `.tools/golangci-lint run --enable-only=govet,staticcheck,errcheck,unused --new-from-rev=origin/main ./internal/cmd/...` (`0 issues`)

The complete 44-linter invocation did not terminate locally after package loading; the focused core linter set passed, and repository CI remains the authoritative full lint run.

Disclosure: AI was used to understand the codebase and review the fix.
