### PR TITLE
fix(docs): preserve text-run link targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.34.1 - Unreleased
 
+- Docs: preserve external and internal text-run link targets in `docs cat --chips`, JSON, tab, table, and numbered output while keeping default text unchanged. (#917, #921) — thanks @neo-wanderer.
 - Gmail: enforce per-account no-send guards before dry-run exits for first-class and Discovery send paths while preserving no-guard keyring avoidance. (#915, #916) — thanks @veteranbv.
 - MCP: add optional global and per-account capability ceilings in `config.json`, with narrow persistent write authorization, runtime-only restriction, and fail-closed selector validation. (#913) — thanks @mcaldas.
 

--- a/docs/commands/gog-docs-cat.md
+++ b/docs/commands/gog-docs-cat.md
@@ -21,7 +21,7 @@ gog docs (doc) cat (text,read) <docId> [flags]
 | `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email, alias, or auto for authenticated Google API commands |
 | `--all-tabs` | `bool` |  | Show all tabs with headers |
-| `--chips` | `bool` |  | Render Google Docs smart chips inline in text output |
+| `--chips` | `bool` |  | Render Google Docs smart chips and text links inline in text output |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |

--- a/internal/cmd/docs_commands_test.go
+++ b/internal/cmd/docs_commands_test.go
@@ -384,7 +384,7 @@ func smartChipDocsContent() []any {
 	}}
 }
 
-func newSmartChipDocsTestServer(t *testing.T) (*docs.Service, func()) {
+func newDocsContentTestServer(t *testing.T, title, tabID, tabTitle string, content func() []any) (*docs.Service, func()) {
 	t.Helper()
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -395,17 +395,17 @@ func newSmartChipDocsTestServer(t *testing.T) (*docs.Service, func()) {
 
 		response := map[string]any{
 			"documentId": "doc1",
-			"title":      "Smart chip doc",
+			"title":      title,
 		}
 		if r.URL.Query().Get("includeTabsContent") == "true" {
 			response["tabs"] = []any{map[string]any{
-				"tabProperties": map[string]any{"tabId": "tab-1", "title": "Chips", "index": 0},
+				"tabProperties": map[string]any{"tabId": tabID, "title": tabTitle, "index": 0},
 				"documentTab": map[string]any{
-					"body": map[string]any{"content": smartChipDocsContent()},
+					"body": map[string]any{"content": content()},
 				},
 			}}
 		} else {
-			response["body"] = map[string]any{"content": smartChipDocsContent()}
+			response["body"] = map[string]any{"content": content()}
 		}
 
 		w.Header().Set("Content-Type", "application/json")
@@ -422,6 +422,72 @@ func newSmartChipDocsTestServer(t *testing.T) (*docs.Service, func()) {
 	}
 
 	return docSvc, srv.Close
+}
+
+func newSmartChipDocsTestServer(t *testing.T) (*docs.Service, func()) {
+	t.Helper()
+	return newDocsContentTestServer(t, "Smart chip doc", "tab-1", "Chips", smartChipDocsContent)
+}
+
+func linkedTextDocsContent() []any {
+	return []any{
+		map[string]any{
+			"startIndex": 1,
+			"endIndex":   68,
+			"paragraph": map[string]any{"elements": []any{
+				map[string]any{"startIndex": 1, "endIndex": 7, "textRun": map[string]any{"content": "Intro "}},
+				map[string]any{"startIndex": 7, "endIndex": 13, "textRun": map[string]any{
+					"content":   "Ticket",
+					"textStyle": map[string]any{"link": map[string]any{"url": "https://tracker.example.com/a_(draft)"}},
+				}},
+				map[string]any{"startIndex": 13, "endIndex": 18, "textRun": map[string]any{"content": " tab "}},
+				map[string]any{"startIndex": 18, "endIndex": 25, "textRun": map[string]any{
+					"content":   "Details",
+					"textStyle": map[string]any{"link": map[string]any{"tabId": "t.bbb"}},
+				}},
+				map[string]any{"startIndex": 25, "endIndex": 35, "textRun": map[string]any{"content": " bookmark "}},
+				map[string]any{"startIndex": 35, "endIndex": 43, "textRun": map[string]any{
+					"content":   "Bookmark",
+					"textStyle": map[string]any{"link": map[string]any{"bookmarkId": "bookmark-legacy"}},
+				}},
+				map[string]any{"startIndex": 43, "endIndex": 52, "textRun": map[string]any{"content": " heading "}},
+				map[string]any{"startIndex": 52, "endIndex": 59, "textRun": map[string]any{
+					"content": "Heading",
+					"textStyle": map[string]any{"link": map[string]any{
+						"heading": map[string]any{"id": "heading-modern", "tabId": "t.bbb"},
+					}},
+				}},
+				map[string]any{"startIndex": 59, "endIndex": 66, "textRun": map[string]any{"content": " owner "}},
+				map[string]any{"startIndex": 66, "endIndex": 67, "person": map[string]any{
+					"personProperties": map[string]any{"name": "Sample Person", "email": "sample@example.com"},
+				}},
+				map[string]any{"startIndex": 67, "endIndex": 68, "textRun": map[string]any{"content": "\n"}},
+			}},
+		},
+		map[string]any{
+			"startIndex": 68,
+			"endIndex":   86,
+			"table": map[string]any{"rows": 1, "columns": 2, "tableRows": []any{map[string]any{
+				"tableCells": []any{
+					map[string]any{"content": []any{map[string]any{"paragraph": map[string]any{"elements": []any{
+						map[string]any{"startIndex": 70, "endIndex": 80, "textRun": map[string]any{
+							"content":   "Table link",
+							"textStyle": map[string]any{"link": map[string]any{"url": "https://example.com/table"}},
+						}},
+						map[string]any{"startIndex": 80, "endIndex": 81, "textRun": map[string]any{"content": "\n"}},
+					}}}}},
+					map[string]any{"content": []any{map[string]any{"paragraph": map[string]any{"elements": []any{
+						map[string]any{"startIndex": 82, "endIndex": 87, "textRun": map[string]any{"content": "Plain\n"}},
+					}}}}},
+				},
+			}}},
+		},
+	}
+}
+
+func newLinkedTextDocsTestServer(t *testing.T) (*docs.Service, func()) {
+	t.Helper()
+	return newDocsContentTestServer(t, "Linked text doc", "t.aaa", "Links", linkedTextDocsContent)
 }
 
 func runDocsCatCommand(t *testing.T, svc *docs.Service, args []string, jsonMode bool) executeTestResult {
@@ -772,6 +838,109 @@ func TestDocsCat_JSONAddsSmartChipDataWithoutChangingText(t *testing.T) {
 	}
 	if out.Chips[2].Type != "richLink" || out.Chips[2].Title != "Plan Doc" || out.Chips[2].URI != "https://docs.google.com/document/d/plan" {
 		t.Fatalf("unexpected rich link chip: %#v", out.Chips[2])
+	}
+}
+
+func TestDocsCat_LinkedTextUsesRenderedPathAndJSONSidecar(t *testing.T) {
+	t.Parallel()
+
+	docSvc, cleanup := newLinkedTextDocsTestServer(t)
+	defer cleanup()
+
+	plain := "Intro Ticket tab Details bookmark Bookmark heading Heading owner \nTable link\n\tPlain\n"
+	rendered := "Intro [Ticket](https://tracker.example.com/a_\\(draft\\)) tab [Details](https://docs.google.com/document/d/doc1/edit?tab=t.bbb) bookmark [Bookmark](https://docs.google.com/document/d/doc1/edit#bookmark=bookmark-legacy) heading [Heading](https://docs.google.com/document/d/doc1/edit?tab=t.bbb#heading=heading-modern) owner @Sample Person <sample@example.com>\n[Table link](https://example.com/table)\n\tPlain\n"
+
+	result := runDocsCatCommand(t, docSvc, []string{"doc1"}, false)
+	if result.err != nil {
+		t.Fatalf("cat: %v", result.err)
+	}
+	if result.stdout != plain {
+		t.Fatalf("default text changed\n got: %q\nwant: %q", result.stdout, plain)
+	}
+
+	result = runDocsCatCommand(t, docSvc, []string{"doc1", "--chips"}, false)
+	if result.err != nil {
+		t.Fatalf("cat --chips: %v", result.err)
+	}
+	if result.stdout != rendered {
+		t.Fatalf("unexpected rendered linked text\n got: %q\nwant: %q", result.stdout, rendered)
+	}
+
+	result = runDocsCatCommand(t, docSvc, []string{"doc1", "--tab", "Links", "--chips"}, false)
+	if result.err != nil {
+		t.Fatalf("cat --tab Links --chips: %v", result.err)
+	}
+	if result.stdout != rendered {
+		t.Fatalf("unexpected tab linked text\n got: %q\nwant: %q", result.stdout, rendered)
+	}
+
+	result = runDocsCatCommand(t, docSvc, []string{"doc1"}, true)
+	if result.err != nil {
+		t.Fatalf("cat --json: %v", result.err)
+	}
+	var out struct {
+		Text         string          `json:"text"`
+		RenderedText string          `json:"renderedText"`
+		Chips        []docsSmartChip `json:"chips"`
+		Links        []docsTextLink  `json:"links"`
+	}
+	if err := json.Unmarshal([]byte(result.stdout), &out); err != nil {
+		t.Fatalf("JSON parse: %v\nraw: %q", err, result.stdout)
+	}
+	if out.Text != plain || out.RenderedText != rendered {
+		t.Fatalf("unexpected JSON text: %#v", out)
+	}
+	if len(out.Chips) != 1 || out.Chips[0].Type != "person" {
+		t.Fatalf("unexpected mixed smart chips: %#v", out.Chips)
+	}
+	if len(out.Links) != 5 {
+		t.Fatalf("links length = %d, want 5: %#v", len(out.Links), out.Links)
+	}
+	if out.Links[0].Text != "Ticket" || out.Links[0].URL != "https://tracker.example.com/a_(draft)" || out.Links[0].StartIndex != 7 || out.Links[0].EndIndex != 13 {
+		t.Fatalf("unexpected external link: %#v", out.Links[0])
+	}
+	if out.Links[1].Text != "Details" || out.Links[1].TabID != "t.bbb" {
+		t.Fatalf("unexpected tab link: %#v", out.Links[1])
+	}
+	if out.Links[2].BookmarkID != "bookmark-legacy" {
+		t.Fatalf("unexpected bookmark link: %#v", out.Links[2])
+	}
+	if out.Links[3].HeadingID != "heading-modern" || out.Links[3].TabID != "t.bbb" {
+		t.Fatalf("unexpected heading link: %#v", out.Links[3])
+	}
+	if out.Links[4].Text != "Table link" || out.Links[4].URL != "https://example.com/table" {
+		t.Fatalf("unexpected table-cell link: %#v", out.Links[4])
+	}
+}
+
+func TestDocsCat_LinkedTextWorksInNumberedOutput(t *testing.T) {
+	t.Parallel()
+
+	docSvc, cleanup := newLinkedTextDocsTestServer(t)
+	defer cleanup()
+
+	result := runDocsCatCommand(t, docSvc, []string{"doc1", "--numbered", "--chips"}, false)
+	if result.err != nil {
+		t.Fatalf("cat --numbered --chips: %v", result.err)
+	}
+	want := "[1] Intro [Ticket](https://tracker.example.com/a_\\(draft\\)) tab [Details](https://docs.google.com/document/d/doc1/edit?tab=t.bbb) bookmark [Bookmark](https://docs.google.com/document/d/doc1/edit#bookmark=bookmark-legacy) heading [Heading](https://docs.google.com/document/d/doc1/edit?tab=t.bbb#heading=heading-modern) owner @Sample Person <sample@example.com>\n[2] [table 1x2] [Table link](https://example.com/table) | Plain\n"
+	if result.stdout != want {
+		t.Fatalf("unexpected numbered linked text\n got: %q\nwant: %q", result.stdout, want)
+	}
+}
+
+func TestDocsCat_LinkedTextRespectsMaxBytesAtomically(t *testing.T) {
+	t.Parallel()
+
+	docSvc, cleanup := newLinkedTextDocsTestServer(t)
+	defer cleanup()
+
+	result := runDocsCatCommand(t, docSvc, []string{"doc1", "--chips", "--max-bytes", "12"}, false)
+	if result.err != nil {
+		t.Fatalf("cat --chips --max-bytes: %v", result.err)
+	}
+	if got, want := result.stdout, "Intro "; got != want {
+		t.Fatalf("link markdown should not be partially rendered\n got: %q\nwant: %q", got, want)
 	}
 }
 

--- a/internal/cmd/docs_paragraphs.go
+++ b/internal/cmd/docs_paragraphs.go
@@ -92,7 +92,7 @@ func buildParagraphMapWithOptions(doc *docs.Document, tabID string, renderChips 
 			num++
 			text := paragraphText(el.Paragraph)
 			if renderChips {
-				text = paragraphTextWithChips(el.Paragraph)
+				text = paragraphTextWithChips(doc.DocumentId, el.Paragraph)
 			}
 			dp := docParagraph{
 				Num:        num,
@@ -127,7 +127,7 @@ func buildParagraphMapWithOptions(doc *docs.Document, tabID string, renderChips 
 			}
 			text := tablePreviewText(el.Table)
 			if renderChips {
-				text = tablePreviewTextWithChips(el.Table)
+				text = tablePreviewTextWithChips(doc.DocumentId, el.Table)
 			}
 			dp := docParagraph{
 				Num:        num,
@@ -160,20 +160,26 @@ func buildParagraphMapWithOptions(doc *docs.Document, tabID string, renderChips 
 
 // paragraphText extracts the plain text from a Paragraph element.
 func paragraphText(p *docs.Paragraph) string {
-	return paragraphTextWithOptions(p, false)
+	return paragraphTextWithOptions("", p, false)
 }
 
-func paragraphTextWithChips(p *docs.Paragraph) string {
-	return paragraphTextWithOptions(p, true)
+func paragraphTextWithChips(docID string, p *docs.Paragraph) string {
+	return paragraphTextWithOptions(docID, p, true)
 }
 
-func paragraphTextWithOptions(p *docs.Paragraph, renderChips bool) string {
+func paragraphTextWithOptions(docID string, p *docs.Paragraph, renderChips bool) string {
 	if p == nil {
 		return ""
 	}
 	var sb strings.Builder
 	for _, elem := range p.Elements {
 		if elem.TextRun != nil {
+			if renderChips {
+				if rendered, _, ok := renderDocsTextRunLink(docID, elem); ok {
+					sb.WriteString(rendered)
+					continue
+				}
+			}
 			sb.WriteString(elem.TextRun.Content)
 			continue
 		}
@@ -217,14 +223,14 @@ func fetchAndBuildMap(ctx context.Context, svc *docs.Service, docID, tabID strin
 
 // tablePreviewText returns a short preview of the table content.
 func tablePreviewText(t *docs.Table) string {
-	return tablePreviewTextWithOptions(t, false)
+	return tablePreviewTextWithOptions("", t, false)
 }
 
-func tablePreviewTextWithChips(t *docs.Table) string {
-	return tablePreviewTextWithOptions(t, true)
+func tablePreviewTextWithChips(docID string, t *docs.Table) string {
+	return tablePreviewTextWithOptions(docID, t, true)
 }
 
-func tablePreviewTextWithOptions(t *docs.Table, renderChips bool) string {
+func tablePreviewTextWithOptions(docID string, t *docs.Table, renderChips bool) string {
 	if t == nil || len(t.TableRows) == 0 {
 		return "[empty table]"
 	}
@@ -235,7 +241,7 @@ func tablePreviewTextWithOptions(t *docs.Table, renderChips bool) string {
 		for _, el := range cell.Content {
 			if el.Paragraph != nil {
 				if renderChips {
-					text.WriteString(paragraphTextWithChips(el.Paragraph))
+					text.WriteString(paragraphTextWithChips(docID, el.Paragraph))
 				} else {
 					text.WriteString(paragraphText(el.Paragraph))
 				}

--- a/internal/cmd/docs_read.go
+++ b/internal/cmd/docs_read.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/url"
 	"strings"
 
 	"github.com/alecthomas/kong"
@@ -23,7 +24,7 @@ type DocsCatCmd struct {
 	AllTabs  bool   `name:"all-tabs" help:"Show all tabs with headers"`
 	Raw      bool   `name:"raw" help:"Output the raw Google Docs API JSON response without modifications"`
 	Numbered bool   `name:"numbered" short:"N" help:"Prefix each paragraph with its number"`
-	Chips    bool   `name:"chips" help:"Render Google Docs smart chips inline in text output"`
+	Chips    bool   `name:"chips" help:"Render Google Docs smart chips and text links inline in text output"`
 }
 
 func (c *DocsCatCmd) Run(ctx context.Context, kctx *kong.Context, flags *RootFlags) error {
@@ -126,10 +127,10 @@ func (c *DocsCatCmd) runWithTabs(ctx context.Context, svc *docs.Service, id stri
 		}
 		text := tabPlainText(tab, c.MaxBytes)
 		if outfmt.IsJSON(ctx) {
-			return outfmt.WriteJSON(ctx, stdoutWriter(ctx), map[string]any{"tab": tabJSON(tab, text, tabRenderedText(tab, c.MaxBytes, true))})
+			return outfmt.WriteJSON(ctx, stdoutWriter(ctx), map[string]any{"tab": tabJSON(tab, text, tabRenderedText(doc.DocumentId, tab, c.MaxBytes, true))})
 		}
 		if c.Chips {
-			_, err = io.WriteString(stdoutWriter(ctx), tabRenderedText(tab, c.MaxBytes, false).Text)
+			_, err = io.WriteString(stdoutWriter(ctx), tabRenderedText(doc.DocumentId, tab, c.MaxBytes, false).Text)
 			return err
 		}
 		_, err = io.WriteString(stdoutWriter(ctx), text)
@@ -140,7 +141,7 @@ func (c *DocsCatCmd) runWithTabs(ctx context.Context, svc *docs.Service, id stri
 		var out []map[string]any
 		for _, tab := range tabs {
 			text := tabPlainText(tab, c.MaxBytes)
-			out = append(out, tabJSON(tab, text, tabRenderedText(tab, c.MaxBytes, true)))
+			out = append(out, tabJSON(tab, text, tabRenderedText(doc.DocumentId, tab, c.MaxBytes, true)))
 		}
 		return outfmt.WriteJSON(ctx, stdoutWriter(ctx), map[string]any{"tabs": out})
 	}
@@ -158,7 +159,7 @@ func (c *DocsCatCmd) runWithTabs(ctx context.Context, svc *docs.Service, id stri
 		}
 		text := tabPlainText(tab, c.MaxBytes)
 		if c.Chips {
-			text = tabRenderedText(tab, c.MaxBytes, false).Text
+			text = tabRenderedText(doc.DocumentId, tab, c.MaxBytes, false).Text
 		}
 		if _, err := io.WriteString(out, text); err != nil {
 			return err
@@ -323,6 +324,7 @@ func docsPlainText(doc *docs.Document, maxBytes int64) string {
 type docsTextResult struct {
 	Text  string
 	Chips []docsSmartChip
+	Links []docsTextLink
 }
 
 type docsSmartChip struct {
@@ -340,7 +342,17 @@ type docsSmartChip struct {
 	MimeType   string `json:"mimeType,omitempty"`
 }
 
-func docsRenderedText(doc *docs.Document, maxBytes int64, collectChips bool) docsTextResult {
+type docsTextLink struct {
+	Text       string `json:"text"`
+	URL        string `json:"url,omitempty"`
+	BookmarkID string `json:"bookmarkId,omitempty"`
+	HeadingID  string `json:"headingId,omitempty"`
+	TabID      string `json:"tabId,omitempty"`
+	StartIndex int64  `json:"startIndex,omitempty"`
+	EndIndex   int64  `json:"endIndex,omitempty"`
+}
+
+func docsRenderedText(doc *docs.Document, maxBytes int64, collectMetadata bool) docsTextResult {
 	if doc == nil || doc.Body == nil {
 		return docsTextResult{}
 	}
@@ -348,7 +360,7 @@ func docsRenderedText(doc *docs.Document, maxBytes int64, collectChips bool) doc
 	var result docsTextResult
 	var buf bytes.Buffer
 	for _, el := range doc.Body.Content {
-		if !appendDocsElementRenderedText(&buf, maxBytes, el, collectChips, &result.Chips) {
+		if !appendDocsElementRenderedText(&buf, maxBytes, doc.DocumentId, el, collectMetadata, &result.Chips, &result.Links) {
 			break
 		}
 	}
@@ -356,7 +368,7 @@ func docsRenderedText(doc *docs.Document, maxBytes int64, collectChips bool) doc
 	return result
 }
 
-func tabRenderedText(tab *docs.Tab, maxBytes int64, collectChips bool) docsTextResult {
+func tabRenderedText(docID string, tab *docs.Tab, maxBytes int64, collectMetadata bool) docsTextResult {
 	if tab == nil || tab.DocumentTab == nil || tab.DocumentTab.Body == nil {
 		return docsTextResult{}
 	}
@@ -364,7 +376,7 @@ func tabRenderedText(tab *docs.Tab, maxBytes int64, collectChips bool) docsTextR
 	var result docsTextResult
 	var buf bytes.Buffer
 	for _, el := range tab.DocumentTab.Body.Content {
-		if !appendDocsElementRenderedText(&buf, maxBytes, el, collectChips, &result.Chips) {
+		if !appendDocsElementRenderedText(&buf, maxBytes, docID, el, collectMetadata, &result.Chips, &result.Links) {
 			break
 		}
 	}
@@ -414,7 +426,7 @@ func appendDocsElementText(buf *bytes.Buffer, maxBytes int64, el *docs.Structura
 	return true
 }
 
-func appendDocsElementRenderedText(buf *bytes.Buffer, maxBytes int64, el *docs.StructuralElement, collectChips bool, chips *[]docsSmartChip) bool {
+func appendDocsElementRenderedText(buf *bytes.Buffer, maxBytes int64, docID string, el *docs.StructuralElement, collectMetadata bool, chips *[]docsSmartChip, links *[]docsTextLink) bool {
 	if el == nil {
 		return true
 	}
@@ -423,6 +435,20 @@ func appendDocsElementRenderedText(buf *bytes.Buffer, maxBytes int64, el *docs.S
 	case el.Paragraph != nil:
 		for _, p := range el.Paragraph.Elements {
 			if p.TextRun != nil {
+				rendered, link, ok := renderDocsTextRunLink(docID, p)
+				if ok {
+					if rendered == p.TextRun.Content {
+						if !appendLimited(buf, maxBytes, rendered) {
+							return false
+						}
+					} else if !appendWholeLimited(buf, maxBytes, rendered) {
+						return false
+					}
+					if collectMetadata {
+						*links = append(*links, link)
+					}
+					continue
+				}
 				if !appendLimited(buf, maxBytes, p.TextRun.Content) {
 					return false
 				}
@@ -437,7 +463,7 @@ func appendDocsElementRenderedText(buf *bytes.Buffer, maxBytes int64, el *docs.S
 			if !appendWholeLimited(buf, maxBytes, chip.Text) {
 				return false
 			}
-			if collectChips {
+			if collectMetadata {
 				*chips = append(*chips, chip)
 			}
 		}
@@ -451,7 +477,7 @@ func appendDocsElementRenderedText(buf *bytes.Buffer, maxBytes int64, el *docs.S
 					return false
 				}
 				for _, content := range cell.Content {
-					if !appendDocsElementRenderedText(buf, maxBytes, content, collectChips, chips) {
+					if !appendDocsElementRenderedText(buf, maxBytes, docID, content, collectMetadata, chips, links) {
 						return false
 					}
 				}
@@ -459,13 +485,64 @@ func appendDocsElementRenderedText(buf *bytes.Buffer, maxBytes int64, el *docs.S
 		}
 	case el.TableOfContents != nil:
 		for _, content := range el.TableOfContents.Content {
-			if !appendDocsElementRenderedText(buf, maxBytes, content, collectChips, chips) {
+			if !appendDocsElementRenderedText(buf, maxBytes, docID, content, collectMetadata, chips, links) {
 				return false
 			}
 		}
 	}
 
 	return true
+}
+
+func renderDocsTextRunLink(docID string, p *docs.ParagraphElement) (string, docsTextLink, bool) {
+	if p == nil || p.TextRun == nil || p.TextRun.TextStyle == nil {
+		return "", docsTextLink{}, false
+	}
+	target := docsParagraphRunLinkFrom(p.TextRun.TextStyle.Link)
+	text := p.TextRun.Content
+	if target == nil || text == "" {
+		return text, docsTextLink{}, false
+	}
+
+	link := docsTextLink{
+		Text:       text,
+		URL:        strings.TrimSpace(target.URL),
+		BookmarkID: strings.TrimSpace(target.BookmarkID),
+		HeadingID:  strings.TrimSpace(target.HeadingID),
+		TabID:      strings.TrimSpace(target.TabID),
+		StartIndex: p.StartIndex,
+		EndIndex:   p.EndIndex,
+	}
+	targetURL := docsTextLinkTargetURL(docID, link)
+
+	rendered := text
+	if targetURL != "" && strings.TrimSpace(text) != targetURL {
+		rendered = fmt.Sprintf("[%s](%s)", escapeMarkdownLinkLabel(text), escapeMarkdownLinkDestination(targetURL))
+	}
+	return rendered, link, true
+}
+
+func docsTextLinkTargetURL(docID string, link docsTextLink) string {
+	if link.URL != "" {
+		return link.URL
+	}
+	base := docsWebViewLink(docID)
+	if base == "" {
+		return ""
+	}
+	if link.TabID != "" {
+		base += "?tab=" + url.QueryEscape(link.TabID)
+	}
+	switch {
+	case link.BookmarkID != "":
+		return base + "#bookmark=" + url.QueryEscape(link.BookmarkID)
+	case link.HeadingID != "":
+		return base + "#heading=" + url.QueryEscape(link.HeadingID)
+	case link.TabID != "":
+		return base
+	default:
+		return ""
+	}
 }
 
 func renderDocsSmartChip(p *docs.ParagraphElement) (docsSmartChip, bool) {
@@ -598,6 +675,9 @@ func docsTextJSON(text string, rendered docsTextResult) map[string]any {
 	}
 	if len(rendered.Chips) > 0 {
 		m["chips"] = rendered.Chips
+	}
+	if len(rendered.Links) > 0 {
+		m["links"] = rendered.Links
 	}
 	return m
 }

--- a/internal/cmd/docs_sed_brace_structural.go
+++ b/internal/cmd/docs_sed_brace_structural.go
@@ -144,6 +144,8 @@ func buildPersonChipRequest(email string, index int64) []*docs.Request {
 // ChipType represents the type of smart chip to insert.
 type ChipType int
 
+const chipTypePersonName = "person"
+
 const (
 	ChipTypeUnknown ChipType = iota
 	ChipTypePerson
@@ -188,7 +190,7 @@ func parseChipURI(uri string) *ChipSpec {
 	spec := &ChipSpec{Value: value}
 
 	switch chipType {
-	case "person":
+	case chipTypePersonName:
 		spec.Type = ChipTypePerson
 	case strDate:
 		spec.Type = ChipTypeDate


### PR DESCRIPTION
## Summary

- preserve external URLs and internal tab, bookmark, and heading targets from Google Docs text runs
- render linked anchor text as Markdown under `docs cat --chips`, including tab, table, and numbered paths
- expose link metadata in JSON while leaving default plain text unchanged
- keep rendered links atomic when `--max-bytes` lands inside them

## Proof

- `make ci`
- AutoReview: clean after fixing its internal bookmark/heading rendering finding
- live Google Docs API validation with the exact built candidate: disposable secondary-tab document, external and heading links, plain/chips/JSON/numbered/max-bytes reads, then verified trash cleanup
- candidate SHA-256: `52f2ab0d931624b50f607f5b4e8204d70dad5331fea607ac32aea27589f3ffb7`

Closes #917
Closes #921
