### PR TITLE
fix(calendar): expose --remove-meet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.34.1 - Unreleased
 
+- Calendar: add `calendar update --remove-meet` to clear only an event's Google Meet conference data before attaching another conferencing provider.
 - Docs: preserve external and internal text-run link targets in `docs cat --chips`, JSON, tab, table, and numbered output while keeping default text unchanged. (#917, #921) — thanks @neo-wanderer.
 - Gmail: enforce per-account no-send guards before dry-run exits for first-class and Discovery send paths while preserving no-guard keyring avoidance. (#915, #916) — thanks @veteranbv.
 - Gmail: accept padded Gmail API base64url payloads in `gmail get --format raw` while retaining unpadded compatibility. (#922, #923) — thanks @goutamadwant.

--- a/docs/commands/gog-calendar-update.md
+++ b/docs/commands/gog-calendar-update.md
@@ -62,6 +62,7 @@ gog calendar (cal) update (edit,set) <calendarId> <eventId> [flags]
 | `--regenerate-meet` | `bool` |  | Replace the event's Google Meet video conference |
 | `--regenerate-zoom` | `bool` |  | Replace the event's Zoom video conference |
 | `--reminder` | `[]string` |  | Custom reminders as method:duration (e.g., popup:30m, email:1d). Can be repeated (max 5). Set empty to clear. |
+| `--remove-meet` | `bool` |  | Remove the event's Google Meet video conference |
 | `--remove-zoom` | `bool` |  | Remove the event's Zoom video conference |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
 | `--rrule` | `[]string` |  | Recurrence rules (e.g., 'RRULE:FREQ=MONTHLY;BYMONTHDAY=11'). Can be repeated. Set empty to clear. |

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -279,7 +279,7 @@ Drive hierarchy semantics:
 - `gog calendar event|get <calendarId> <eventId>`
 - `GOG_CALENDAR_WEEKDAY=1` defaults `--weekday` for `gog calendar events`
 - `gog calendar create <calendarId> --summary S --from DT --to DT [--timezone TZ] [--start-timezone TZ] [--end-timezone TZ] [--description D] [--location L|--location-search Q|--place-id ID] [--place-language LANG] [--place-region REGION] [--attendees a@b.com,c@d.com] [--all-day] [--event-type TYPE]`
-- `gog calendar update <calendarId> <eventId> [--summary S] [--from DT] [--to DT] [--start-timezone TZ] [--end-timezone TZ] [--description D] [--location L|--location-search Q|--place-id ID] [--place-language LANG] [--place-region REGION] [--attendees ...] [--add-attendee ...] [--attachment URL ...] [--all-day] [--with-meet|--regenerate-meet] [--event-type TYPE]`
+- `gog calendar update <calendarId> <eventId> [--summary S] [--from DT] [--to DT] [--start-timezone TZ] [--end-timezone TZ] [--description D] [--location L|--location-search Q|--place-id ID] [--place-language LANG] [--place-region REGION] [--attendees ...] [--add-attendee ...] [--attachment URL ...] [--all-day] [--with-meet|--regenerate-meet|--remove-meet] [--event-type TYPE]`
 - `gog calendar delete <calendarId> <eventId>`
 - `gog calendar freebusy [calendarIds] [--cal ID_OR_NAME] [--calendars CSV] [--all] --from RFC3339 --to RFC3339`
 - `gog calendar conflicts [--cal ID_OR_NAME] [--calendars CSV] [--all] [--from RFC3339|date|relative] [--to RFC3339|date|relative] [--today|--week|--days N]`

--- a/internal/cmd/calendar_conference_plan.go
+++ b/internal/cmd/calendar_conference_plan.go
@@ -49,6 +49,8 @@ func validateZoomConferenceFlagMutex(fields calendarUpdateFields) error {
 		{{name: "with-zoom", selected: fields.WithZoom}, {name: "regenerate-meet", selected: fields.RegenerateMeet}},
 		{{name: "regenerate-zoom", selected: fields.RegenerateZoom}, {name: "with-meet", selected: fields.WithMeet}},
 		{{name: "regenerate-zoom", selected: fields.RegenerateZoom}, {name: "regenerate-meet", selected: fields.RegenerateMeet}},
+		{{name: "with-zoom", selected: fields.WithZoom}, {name: "remove-meet", selected: fields.RemoveMeet}},
+		{{name: "regenerate-zoom", selected: fields.RegenerateZoom}, {name: "remove-meet", selected: fields.RemoveMeet}},
 	}
 	for _, pair := range pairs {
 		if pair[0].selected && pair[1].selected {

--- a/internal/cmd/calendar_create_update_test.go
+++ b/internal/cmd/calendar_create_update_test.go
@@ -656,6 +656,49 @@ func TestCalendarUpdateCmd_RegenerateMeetReplacesConference(t *testing.T) {
 	}
 }
 
+func TestCalendarUpdateCmd_RemoveMeetClearsConferenceDataOnly(t *testing.T) {
+	var sawPatch bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimPrefix(r.URL.Path, "/calendar/v3")
+		if r.Method == http.MethodPatch && path == "/calendars/cal@example.com/events/ev" {
+			sawPatch = true
+			if r.URL.Query().Get("conferenceDataVersion") != "1" {
+				t.Fatalf("expected conferenceDataVersion=1")
+			}
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode patch: %v", err)
+			}
+			conferenceData, ok := body["conferenceData"]
+			if !ok || conferenceData != nil {
+				t.Fatalf("expected conferenceData: null, got %#v", body)
+			}
+			if len(body) != 1 {
+				t.Fatalf("expected conferenceData-only patch, got %#v", body)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": "ev", "summary": "Planning"})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	svc := newCalendarServiceFromServer(t, srv)
+	ctx := withCalendarTestService(newCmdRuntimeJSONOutputContext(t, io.Discard, io.Discard), svc)
+
+	if err := runKong(t, &CalendarUpdateCmd{}, []string{
+		"cal@example.com",
+		"ev",
+		"--remove-meet",
+	}, ctx, &RootFlags{Account: "a@b.com"}); err != nil {
+		t.Fatalf("runKong: %v", err)
+	}
+	if !sawPatch {
+		t.Fatal("expected patch")
+	}
+}
+
 func TestCalendarUpdateCmd_WithMeetScopeFutureExistingConferenceIsIdempotent(t *testing.T) {
 	var patchCalled bool
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/cmd/calendar_edit.go
+++ b/internal/cmd/calendar_edit.go
@@ -202,6 +202,7 @@ type CalendarUpdateCmd struct {
 	GuestsCanSeeOthers    *bool    `name:"guests-can-see-others" help:"Allow guests to see other guests"`
 	WithMeet              bool     `name:"with-meet" help:"Create a Google Meet video conference for this event"`
 	RegenerateMeet        bool     `name:"regenerate-meet" help:"Replace the event's Google Meet video conference"`
+	RemoveMeet            bool     `name:"remove-meet" help:"Remove the event's Google Meet video conference"`
 	WithZoom              bool     `name:"with-zoom" help:"Create a Zoom video conference for this event"`
 	RegenerateZoom        bool     `name:"regenerate-zoom" help:"Replace the event's Zoom video conference"`
 	RemoveZoom            bool     `name:"remove-zoom" help:"Remove the event's Zoom video conference"`
@@ -252,6 +253,7 @@ func calendarUpdateFieldsFromKong(kctx *kong.Context) calendarUpdateFields {
 		GuestsCanSeeOthers:    flagProvided(kctx, "guests-can-see-others"),
 		WithMeet:              flagProvided(kctx, "with-meet"),
 		RegenerateMeet:        flagProvided(kctx, "regenerate-meet"),
+		RemoveMeet:            flagProvided(kctx, "remove-meet"),
 		WithZoom:              flagProvided(kctx, "with-zoom"),
 		RegenerateZoom:        flagProvided(kctx, "regenerate-zoom"),
 		RemoveZoom:            flagProvided(kctx, "remove-zoom"),

--- a/internal/cmd/calendar_event_plan.go
+++ b/internal/cmd/calendar_event_plan.go
@@ -108,6 +108,7 @@ type calendarUpdateFields struct {
 	GuestsCanSeeOthers    bool
 	WithMeet              bool
 	RegenerateMeet        bool
+	RemoveMeet            bool
 	WithZoom              bool
 	RegenerateZoom        bool
 	RemoveZoom            bool
@@ -230,6 +231,9 @@ func buildCalendarUpdatePlan(store *config.ConfigStore, input calendarUpdateInpu
 	}
 	if fields.WithMeet && fields.RegenerateMeet {
 		return nil, usage("use only one of --with-meet or --regenerate-meet")
+	}
+	if fields.RemoveMeet && (fields.WithMeet || fields.RegenerateMeet) {
+		return nil, usage("use only one of --with-meet, --regenerate-meet, or --remove-meet")
 	}
 	if mutexErr := validateZoomConferenceFlagMutex(fields); mutexErr != nil {
 		return nil, mutexErr

--- a/internal/cmd/calendar_event_plan_test.go
+++ b/internal/cmd/calendar_event_plan_test.go
@@ -63,6 +63,12 @@ func TestBuildCalendarUpdatePlanValidatesSelectedFields(t *testing.T) {
 			want:   "cannot use both --attendees and --add-attendee",
 		},
 		{
+			name:   "meet removal conflicts with creation",
+			input:  calendarUpdateInput{CalendarID: "primary", EventID: "event-1"},
+			fields: calendarUpdateFields{WithMeet: true, RemoveMeet: true},
+			want:   "use only one of --with-meet, --regenerate-meet, or --remove-meet",
+		},
+		{
 			name:   "empty add attendee",
 			input:  calendarUpdateInput{CalendarID: "primary", EventID: "event-1"},
 			fields: calendarUpdateFields{AddAttendee: true},

--- a/internal/cmd/calendar_update_patch_plan.go
+++ b/internal/cmd/calendar_update_patch_plan.go
@@ -328,7 +328,7 @@ func applyUpdateGuestOptions(input calendarUpdateInput, fields calendarUpdateFie
 }
 
 func applyUpdateConferenceData(fields calendarUpdateFields, patch *calendar.Event) bool {
-	if fields.RemoveZoom {
+	if fields.RemoveMeet || fields.RemoveZoom {
 		patch.NullFields = append(patch.NullFields, "ConferenceData")
 		return true
 	}

--- a/internal/cmd/calendar_zoom_test.go
+++ b/internal/cmd/calendar_zoom_test.go
@@ -592,12 +592,20 @@ func TestCalendarUpdateCmd_FlagMutex_WithZoomRegenerateMeet(t *testing.T) {
 	assertCalendarUpdateZoomMutex(t, "--with-zoom", "--regenerate-meet")
 }
 
+func TestCalendarUpdateCmd_FlagMutex_WithZoomRemoveMeet(t *testing.T) {
+	assertCalendarUpdateZoomMutex(t, "--with-zoom", "--remove-meet")
+}
+
 func TestCalendarUpdateCmd_FlagMutex_RegenerateZoomWithMeet(t *testing.T) {
 	assertCalendarUpdateZoomMutex(t, "--regenerate-zoom", "--with-meet")
 }
 
 func TestCalendarUpdateCmd_FlagMutex_RegenerateZoomRegenerateMeet(t *testing.T) {
 	assertCalendarUpdateZoomMutex(t, "--regenerate-zoom", "--regenerate-meet")
+}
+
+func TestCalendarUpdateCmd_FlagMutex_RegenerateZoomRemoveMeet(t *testing.T) {
+	assertCalendarUpdateZoomMutex(t, "--regenerate-zoom", "--remove-meet")
 }
 
 func assertCalendarUpdateZoomMutex(t *testing.T, flags ...string) {


### PR DESCRIPTION
`calendar update --with-zoom` currently tells users with an existing Meet conference to run `--remove-meet` first, but the update command does not expose that flag. Following the CLI guidance therefore fails during argument parsing and leaves no first-class path for replacing Meet with Zoom.

This adds `--remove-meet` as a conference-data-only patch. It sends `conferenceData: null` with Calendar conference-data support enabled, leaving the event description and other fields untouched. The flag follows the existing recurring-event scope behavior and rejects conflicting Meet or Zoom creation flags.

For example:

```console
gog calendar update primary EVENT_ID --remove-meet
gog calendar update primary EVENT_ID --with-zoom
```

The generated command reference, CLI specification, and changelog now include the flag.