### PR TITLE
feat(drive): add recursive directory push

### DIFF
--- a/.agents/skills/gog-drive/SKILL.md
+++ b/.agents/skills/gog-drive/SKILL.md
@@ -51,6 +51,7 @@ gog --readonly --account user@example.com drive ls --max 20 --json --wrap-untrus
 | `search` | Full-text search across Drive |
 | `share` | Share a file or folder |
 | `shortcut` | Manage shortcuts to Drive files and folders |
+| `sync` | Reconcile local files with Drive |
 | `tree` | Print a read-only folder tree |
 | `unshare` | Remove a permission from a file |
 | `upload` | Upload a file |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.34.1 - Unreleased
 
+- Drive: add non-destructive `drive sync push` for recursive local-directory uploads with checksum skips, ID-preserving updates, full conflict preflight, deterministic dry-run plans, and shared-drive support. (#925) — thanks @Avg8888.
 - Gmail: add `gmail attachment --inline` for bounded base64 content output to remote callers while always fetching fresh bytes and retaining path-only fallback above 3 MiB. (#919) — thanks @chrischall.
 - Docs: preserve external and internal text-run link targets in `docs cat --chips`, JSON, tab, table, and numbered output while keeping default text unchanged. (#917, #921) — thanks @neo-wanderer.
 - Gmail: enforce per-account no-send guards before dry-run exits for first-class and Discovery send paths while preserving no-guard keyring avoidance. (#915, #916) — thanks @veteranbv.

--- a/README.md
+++ b/README.md
@@ -256,6 +256,10 @@ gog drive labels file list <fileId> --json
 gog drive labels file apply <fileId> <labelId> --text fieldId=value
 # Drive Labels requires a Google Workspace customer.
 
+# Recursively push local contents without deleting remote-only files.
+gog drive sync push ./backup --parent <folderId> --dry-run --json
+gog drive sync push ./backup --parent <folderId>
+
 # Ask Drive for non-default fields.
 gog drive get <fileId> --fields 'id,name,mimeType,size,owners,emailAddress' --json
 

--- a/docs/commands.generated.md
+++ b/docs/commands.generated.md
@@ -366,6 +366,8 @@ Generated from `gog schema --json`.
     - [`gog drive (drv) share <fileId> [flags]`](commands/gog-drive-share.md) - Share a file or folder
     - [`gog drive (drv) shortcut (shortcuts) <command>`](commands/gog-drive-shortcut.md) - Manage shortcuts to Drive files and folders
       - [`gog drive (drv) shortcut (shortcuts) create (add,new) <targetId> [flags]`](commands/gog-drive-shortcut-create.md) - Create a shortcut to a Drive file or folder
+    - [`gog drive (drv) sync <command>`](commands/gog-drive-sync.md) - Reconcile local files with Drive
+      - [`gog drive (drv) sync push --parent=STRING <localDirectory> [flags]`](commands/gog-drive-sync-push.md) - Push a local directory's contents into a Drive folder (no remote deletes)
     - [`gog drive (drv) tree [flags]`](commands/gog-drive-tree.md) - Print a read-only folder tree
     - [`gog drive (drv) unshare <fileId> <permissionId>`](commands/gog-drive-unshare.md) - Remove a permission from a file
     - [`gog drive (drv) upload <localPath> [flags]`](commands/gog-drive-upload.md) - Upload a file

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -2,7 +2,7 @@
 
 Every `gog` command has a generated docs page. The source of truth is the live CLI schema; run `make docs-commands` after changing command names, flags, help text, aliases, or arguments.
 
-Generated pages: 706.
+Generated pages: 708.
 
 ## Top-level Commands
 
@@ -419,6 +419,8 @@ Generated pages: 706.
     - [gog drive share](gog-drive-share.md) - Share a file or folder
     - [gog drive shortcut](gog-drive-shortcut.md) - Manage shortcuts to Drive files and folders
       - [gog drive shortcut create](gog-drive-shortcut-create.md) - Create a shortcut to a Drive file or folder
+    - [gog drive sync](gog-drive-sync.md) - Reconcile local files with Drive
+      - [gog drive sync push](gog-drive-sync-push.md) - Push a local directory's contents into a Drive folder (no remote deletes)
     - [gog drive tree](gog-drive-tree.md) - Print a read-only folder tree
     - [gog drive unshare](gog-drive-unshare.md) - Remove a permission from a file
     - [gog drive upload](gog-drive-upload.md) - Upload a file

--- a/docs/commands/gog-drive-sync-push.md
+++ b/docs/commands/gog-drive-sync-push.md
@@ -1,49 +1,18 @@
-# `gog drive`
+# `gog drive sync push`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Google Drive
+Push a local directory's contents into a Drive folder (no remote deletes)
 
 ## Usage
 
 ```bash
-gog drive (drv) <command> [flags]
+gog drive (drv) sync push --parent=STRING <localDirectory> [flags]
 ```
 
 ## Parent
 
-- [gog](gog.md)
-
-## Subcommands
-
-- [gog drive activity](gog-drive-activity.md) - Query Drive Activity audit events
-- [gog drive audit](gog-drive-audit.md) - Audit Drive sharing without mutation
-- [gog drive bulk](gog-drive-bulk.md) - Bulk Drive permission operations
-- [gog drive changes](gog-drive-changes.md) - Track Drive changes for sync and automation
-- [gog drive comments](gog-drive-comments.md) - Manage comments on files
-- [gog drive copy](gog-drive-copy.md) - Copy a file
-- [gog drive delete](gog-drive-delete.md) - Move a file to trash (use --permanent to delete forever)
-- [gog drive download](gog-drive-download.md) - Download a file (exports Google Docs formats)
-- [gog drive drives](gog-drive-drives.md) - List shared drives (Team Drives)
-- [gog drive du](gog-drive-du.md) - Summarize Drive folder sizes
-- [gog drive get](gog-drive-get.md) - Get file metadata
-- [gog drive inventory](gog-drive-inventory.md) - Export a read-only Drive inventory
-- [gog drive labels](gog-drive-labels.md) - Read and modify Drive labels
-- [gog drive ls](gog-drive-ls.md) - List files in a folder (default: root)
-- [gog drive mkdir](gog-drive-mkdir.md) - Create a folder
-- [gog drive move](gog-drive-move.md) - Move a file to a different folder
-- [gog drive permissions](gog-drive-permissions.md) - List permissions on a file
-- [gog drive raw](gog-drive-raw.md) - Dump raw Google Drive API response as JSON (Files.Get; lossless; for scripting and LLM consumption)
-- [gog drive rename](gog-drive-rename.md) - Rename a file or folder
-- [gog drive revisions](gog-drive-revisions.md) - List and inspect file revisions
-- [gog drive search](gog-drive-search.md) - Full-text search across Drive
-- [gog drive share](gog-drive-share.md) - Share a file or folder
-- [gog drive shortcut](gog-drive-shortcut.md) - Manage shortcuts to Drive files and folders
-- [gog drive sync](gog-drive-sync.md) - Reconcile local files with Drive
-- [gog drive tree](gog-drive-tree.md) - Print a read-only folder tree
-- [gog drive unshare](gog-drive-unshare.md) - Remove a permission from a file
-- [gog drive upload](gog-drive-upload.md) - Upload a file
-- [gog drive url](gog-drive-url.md) - Print web URLs for files
+- [gog drive sync](gog-drive-sync.md)
 
 ## Flags
 
@@ -51,6 +20,7 @@ gog drive (drv) <command> [flags]
 | --- | --- | --- | --- |
 | `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email, alias, or auto for authenticated Google API commands |
+| `--all-drives` | `bool` | true | Include shared drives (default: true; use --no-all-drives for My Drive only) |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
@@ -63,6 +33,7 @@ gog drive (drv) <command> [flags]
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `--parent` | `string` |  | Existing destination Drive folder ID |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
 | `--readonly` | `bool` | false | Block mutating API requests at runtime; auth add also requests read-only OAuth scopes |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
@@ -73,5 +44,5 @@ gog drive (drv) <command> [flags]
 
 ## See Also
 
-- [gog](gog.md)
+- [gog drive sync](gog-drive-sync.md)
 - [Command index](README.md)

--- a/docs/commands/gog-drive-sync.md
+++ b/docs/commands/gog-drive-sync.md
@@ -1,49 +1,22 @@
-# `gog drive`
+# `gog drive sync`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Google Drive
+Reconcile local files with Drive
 
 ## Usage
 
 ```bash
-gog drive (drv) <command> [flags]
+gog drive (drv) sync <command>
 ```
 
 ## Parent
 
-- [gog](gog.md)
+- [gog drive](gog-drive.md)
 
 ## Subcommands
 
-- [gog drive activity](gog-drive-activity.md) - Query Drive Activity audit events
-- [gog drive audit](gog-drive-audit.md) - Audit Drive sharing without mutation
-- [gog drive bulk](gog-drive-bulk.md) - Bulk Drive permission operations
-- [gog drive changes](gog-drive-changes.md) - Track Drive changes for sync and automation
-- [gog drive comments](gog-drive-comments.md) - Manage comments on files
-- [gog drive copy](gog-drive-copy.md) - Copy a file
-- [gog drive delete](gog-drive-delete.md) - Move a file to trash (use --permanent to delete forever)
-- [gog drive download](gog-drive-download.md) - Download a file (exports Google Docs formats)
-- [gog drive drives](gog-drive-drives.md) - List shared drives (Team Drives)
-- [gog drive du](gog-drive-du.md) - Summarize Drive folder sizes
-- [gog drive get](gog-drive-get.md) - Get file metadata
-- [gog drive inventory](gog-drive-inventory.md) - Export a read-only Drive inventory
-- [gog drive labels](gog-drive-labels.md) - Read and modify Drive labels
-- [gog drive ls](gog-drive-ls.md) - List files in a folder (default: root)
-- [gog drive mkdir](gog-drive-mkdir.md) - Create a folder
-- [gog drive move](gog-drive-move.md) - Move a file to a different folder
-- [gog drive permissions](gog-drive-permissions.md) - List permissions on a file
-- [gog drive raw](gog-drive-raw.md) - Dump raw Google Drive API response as JSON (Files.Get; lossless; for scripting and LLM consumption)
-- [gog drive rename](gog-drive-rename.md) - Rename a file or folder
-- [gog drive revisions](gog-drive-revisions.md) - List and inspect file revisions
-- [gog drive search](gog-drive-search.md) - Full-text search across Drive
-- [gog drive share](gog-drive-share.md) - Share a file or folder
-- [gog drive shortcut](gog-drive-shortcut.md) - Manage shortcuts to Drive files and folders
-- [gog drive sync](gog-drive-sync.md) - Reconcile local files with Drive
-- [gog drive tree](gog-drive-tree.md) - Print a read-only folder tree
-- [gog drive unshare](gog-drive-unshare.md) - Remove a permission from a file
-- [gog drive upload](gog-drive-upload.md) - Upload a file
-- [gog drive url](gog-drive-url.md) - Print web URLs for files
+- [gog drive sync push](gog-drive-sync-push.md) - Push a local directory's contents into a Drive folder (no remote deletes)
 
 ## Flags
 
@@ -73,5 +46,5 @@ gog drive (drv) <command> [flags]
 
 ## See Also
 
-- [gog](gog.md)
+- [gog drive](gog-drive.md)
 - [Command index](README.md)

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -221,6 +221,7 @@ Flag aliases:
 - `gog drive get <fileId>`
 - `gog drive download <fileId> [--out PATH|-] [--format F]` (`--format` only applies to Google Workspace files; `--format md` exports a Google Doc as Markdown)
 - `gog drive upload <localPath> [--name N] [--parent ID] [--convert] [--convert-to doc|sheet|slides] [--keep-frontmatter]` (Markdown → Google Doc with `--convert` or `--convert-to doc`: leading `---`/`---` frontmatter is stripped before upload unless `--keep-frontmatter`; delimiter-based, not a full YAML parse; large non-JSON uploads print progress to stderr)
+- `gog drive sync push <localDirectory> --parent ID [--dry-run] [--[no-]all-drives]` (recursively reconciles local contents without deleting remote-only files; duplicate names, wrong types, Google-native files, and local symlinks fail before mutation)
 - `gog drive mkdir <name> [--parent ID]`
 - `gog drive delete <fileId> [--permanent]`
 - `gog drive move <fileId> --parent ID`

--- a/internal/cmd/drive.go
+++ b/internal/cmd/drive.go
@@ -64,6 +64,7 @@ type DriveCmd struct {
 	Download    DriveDownloadCmd    `cmd:"" name:"download" help:"Download a file (exports Google Docs formats)"`
 	Copy        DriveCopyCmd        `cmd:"" name:"copy" help:"Copy a file"`
 	Upload      DriveUploadCmd      `cmd:"" name:"upload" help:"Upload a file"`
+	Sync        DriveSyncCmd        `cmd:"" name:"sync" help:"Reconcile local files with Drive"`
 	Mkdir       DriveMkdirCmd       `cmd:"" name:"mkdir" help:"Create a folder"`
 	Delete      DriveDeleteCmd      `cmd:"" name:"delete" help:"Move a file to trash (use --permanent to delete forever)" aliases:"rm,del"`
 	Move        DriveMoveCmd        `cmd:"" name:"move" help:"Move a file to a different folder"`
@@ -222,7 +223,7 @@ func (c *DriveMkdirCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(ctx, stdoutWriter(ctx), map[string]any{"folder": created})
+		return outfmt.WriteJSON(ctx, stdoutWriter(ctx), map[string]any{strFolder: created})
 	}
 
 	u.Out().Linef("id\t%s", created.Id)
@@ -481,7 +482,7 @@ func escapeDriveQueryString(s string) string {
 func driveType(mimeType string) string {
 	switch mimeType {
 	case driveMimeFolder:
-		return "folder"
+		return strFolder
 	case driveMimeGoogleDoc:
 		return "doc"
 	case driveMimeGoogleSheet:

--- a/internal/cmd/drive_sync_push.go
+++ b/internal/cmd/drive_sync_push.go
@@ -1,0 +1,929 @@
+package cmd
+
+import (
+	"context"
+	"crypto/md5" // #nosec G501 -- Google Drive exposes MD5 checksums for binary file reconciliation.
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"google.golang.org/api/drive/v3"
+	gapi "google.golang.org/api/googleapi"
+
+	"github.com/steipete/gogcli/internal/config"
+	"github.com/steipete/gogcli/internal/outfmt"
+)
+
+const (
+	driveSyncCreateFolder = "create_folder"
+	driveSyncCreateFile   = "create_file"
+	driveSyncUpdateFile   = "update_file"
+	driveSyncSkipFile     = "skip_file"
+	driveSyncFields       = "id,name,mimeType,size,md5Checksum,driveId"
+)
+
+type DriveSyncCmd struct {
+	Push DriveSyncPushCmd `cmd:"" name:"push" help:"Push a local directory's contents into a Drive folder (no remote deletes)"`
+}
+
+type DriveSyncPushCmd struct {
+	LocalDir  string `arg:"" name:"localDirectory" help:"Local directory to push" type:"path"`
+	Parent    string `name:"parent" help:"Existing destination Drive folder ID" required:""`
+	AllDrives bool   `name:"all-drives" help:"Include shared drives (default: true; use --no-all-drives for My Drive only)" default:"true" negatable:"_"`
+}
+
+type driveSyncLocalEntry struct {
+	Path       string
+	ParentPath string
+	Name       string
+	MimeType   string
+	MD5        string
+	Size       int64
+	IsDir      bool
+}
+
+type driveSyncLocalTree struct {
+	Root     string
+	Entries  map[string]driveSyncLocalEntry
+	Children map[string][]driveSyncLocalEntry
+	root     *os.Root
+	dirInfos map[string]os.FileInfo
+}
+
+type driveSyncAction struct {
+	Action     string `json:"action"`
+	Path       string `json:"path"`
+	FileID     string `json:"file_id,omitempty"`
+	ParentID   string `json:"parent_id,omitempty"`
+	MimeType   string `json:"mime_type,omitempty"`
+	MD5        string `json:"md5,omitempty"`
+	Reason     string `json:"reason"`
+	Size       int64  `json:"size,omitempty"`
+	ParentPath string `json:"parent_path,omitempty"`
+}
+
+type driveSyncSummary struct {
+	CreateFolders int `json:"create_folders"`
+	CreateFiles   int `json:"create_files"`
+	UpdateFiles   int `json:"update_files"`
+	SkipFiles     int `json:"skip_files"`
+}
+
+type driveSyncPlan struct {
+	Actions   []driveSyncAction
+	folderIDs map[string]string
+	entries   map[string]driveSyncLocalEntry
+	localRoot *os.Root
+	dirInfos  map[string]os.FileInfo
+}
+
+type driveSyncClient interface {
+	Get(ctx context.Context, fileID string) (*drive.File, error)
+	Children(ctx context.Context, parentID string) ([]*drive.File, error)
+	CreateFolder(ctx context.Context, name, parentID string) (*drive.File, error)
+	CreateFile(ctx context.Context, entry driveSyncLocalEntry, parentID string, content io.Reader) (*drive.File, error)
+	UpdateFile(ctx context.Context, fileID string, entry driveSyncLocalEntry, content io.Reader) (*drive.File, error)
+}
+
+type googleDriveSyncClient struct {
+	service *drive.Service
+	driveID string
+}
+
+func (c *DriveSyncPushCmd) Run(ctx context.Context, flags *RootFlags) error {
+	if strings.TrimSpace(c.LocalDir) == "" {
+		return usage("empty localDirectory")
+	}
+	localDir := c.LocalDir
+	parentID := strings.TrimSpace(c.Parent)
+	if parentID == "" {
+		return usage("missing --parent")
+	}
+
+	tree, err := scanDriveSyncLocalTree(localDir)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tree.Close() }()
+
+	_, svc, err := requireDriveService(ctx, flags)
+	if err != nil {
+		return err
+	}
+	client := &googleDriveSyncClient{service: svc}
+	plan, err := buildDriveSyncPlan(ctx, tree, parentID, c.AllDrives, client)
+	if err != nil {
+		return err
+	}
+
+	dryRun := flags != nil && flags.DryRun
+	if !dryRun {
+		if err := applyDriveSyncPlan(ctx, plan, client); err != nil {
+			return err
+		}
+	}
+
+	return writeDriveSyncPlan(ctx, tree.Root, parentID, dryRun, plan.Actions)
+}
+
+func scanDriveSyncLocalTree(localDir string) (driveSyncLocalTree, error) {
+	expanded, err := config.ExpandPath(localDir)
+	if err != nil {
+		return driveSyncLocalTree{}, err
+	}
+	root, rootInfo, absolutePath, err := openDriveSyncRoot(expanded)
+	if err != nil {
+		return driveSyncLocalTree{}, err
+	}
+
+	tree := driveSyncLocalTree{
+		Root:     absolutePath,
+		Entries:  make(map[string]driveSyncLocalEntry),
+		Children: make(map[string][]driveSyncLocalEntry),
+		root:     root,
+		dirInfos: map[string]os.FileInfo{"": rootInfo},
+	}
+	if err := scanDriveSyncDirectories(&tree); err != nil {
+		_ = tree.Close()
+		return driveSyncLocalTree{}, err
+	}
+	return tree, nil
+}
+
+func openDriveSyncRoot(localDir string) (*os.Root, os.FileInfo, string, error) {
+	absolutePath, err := filepath.Abs(localDir)
+	if err != nil {
+		return nil, nil, "", fmt.Errorf("resolve local directory: %w", err)
+	}
+	absolutePath = filepath.Clean(absolutePath)
+	before, err := os.Lstat(absolutePath)
+	if err != nil {
+		return nil, nil, "", fmt.Errorf("inspect local directory: %w", err)
+	}
+	if before.Mode()&os.ModeSymlink != 0 {
+		return nil, nil, "", fmt.Errorf("local symlink not supported: %q", absolutePath)
+	}
+	if !before.IsDir() {
+		return nil, nil, "", usagef("localDirectory is not a directory: %q", absolutePath)
+	}
+	canonicalPath, err := filepath.EvalSymlinks(absolutePath)
+	if err != nil {
+		return nil, nil, "", fmt.Errorf("resolve local directory symlinks: %w", err)
+	}
+
+	volume := filepath.VolumeName(canonicalPath)
+	filesystemRoot := volume + string(filepath.Separator)
+	current, err := os.OpenRoot(filesystemRoot)
+	if err != nil {
+		return nil, nil, "", fmt.Errorf("open filesystem root for local directory: %w", err)
+	}
+
+	relative := strings.TrimPrefix(canonicalPath, filesystemRoot)
+	components := strings.Split(relative, string(filepath.Separator))
+	visited := filesystemRoot
+	for _, component := range components {
+		if component == "" {
+			continue
+		}
+		visited = filepath.Join(visited, component)
+		next, _, openErr := openDriveSyncChildRoot(current, component, visited)
+		if openErr != nil {
+			_ = current.Close()
+			return nil, nil, "", openErr
+		}
+		_ = current.Close()
+		current = next
+	}
+	openedFile, err := current.Open(".")
+	if err != nil {
+		_ = current.Close()
+		return nil, nil, "", fmt.Errorf("verify local directory: %w", err)
+	}
+	opened, statErr := openedFile.Stat()
+	closeErr := openedFile.Close()
+	if statErr != nil {
+		_ = current.Close()
+		return nil, nil, "", fmt.Errorf("verify local directory: %w", statErr)
+	}
+	if closeErr != nil {
+		_ = current.Close()
+		return nil, nil, "", fmt.Errorf("verify local directory: %w", closeErr)
+	}
+	after, err := os.Lstat(absolutePath)
+	if err != nil {
+		_ = current.Close()
+		return nil, nil, "", fmt.Errorf("reinspect local directory: %w", err)
+	}
+	if after.Mode()&os.ModeSymlink != 0 || !os.SameFile(before, opened) || !os.SameFile(opened, after) {
+		_ = current.Close()
+		return nil, nil, "", fmt.Errorf("local directory changed while opening: %q", absolutePath)
+	}
+	return current, opened, absolutePath, nil
+}
+
+func openDriveSyncChildRoot(parent *os.Root, name, displayPath string) (*os.Root, os.FileInfo, error) {
+	before, err := parent.Lstat(name)
+	if err != nil {
+		return nil, nil, fmt.Errorf("inspect local directory %q: %w", displayPath, err)
+	}
+	if before.Mode()&os.ModeSymlink != 0 {
+		return nil, nil, fmt.Errorf("local symlink not supported: %q", displayPath)
+	}
+	if !before.IsDir() {
+		return nil, nil, usagef("localDirectory is not a directory: %q", displayPath)
+	}
+
+	child, err := parent.OpenRoot(name)
+	if err != nil {
+		return nil, nil, fmt.Errorf("open local directory %q: %w", displayPath, err)
+	}
+	openedFile, err := child.Open(".")
+	if err != nil {
+		_ = child.Close()
+		return nil, nil, fmt.Errorf("verify local directory %q: %w", displayPath, err)
+	}
+	opened, statErr := openedFile.Stat()
+	closeErr := openedFile.Close()
+	if statErr != nil {
+		_ = child.Close()
+		return nil, nil, fmt.Errorf("verify local directory %q: %w", displayPath, statErr)
+	}
+	if closeErr != nil {
+		_ = child.Close()
+		return nil, nil, fmt.Errorf("verify local directory %q: %w", displayPath, closeErr)
+	}
+	after, err := parent.Lstat(name)
+	if err != nil {
+		_ = child.Close()
+		return nil, nil, fmt.Errorf("reinspect local directory %q: %w", displayPath, err)
+	}
+	if after.Mode()&os.ModeSymlink != 0 || !os.SameFile(before, opened) || !os.SameFile(opened, after) {
+		_ = child.Close()
+		return nil, nil, fmt.Errorf("local directory changed while opening: %q", displayPath)
+	}
+	return child, opened, nil
+}
+
+func scanDriveSyncDirectories(tree *driveSyncLocalTree) error {
+	pending := []string{""}
+	for len(pending) > 0 {
+		relative := pending[0]
+		pending = pending[1:]
+		directory, err := openDriveSyncDirectory(tree.root, tree.dirInfos, relative)
+		if err != nil {
+			return err
+		}
+		children, scanErr := scanDriveSyncDirectory(tree, directory, relative)
+		closeErr := directory.Close()
+		if scanErr != nil {
+			return scanErr
+		}
+		if closeErr != nil {
+			return fmt.Errorf("close local directory %q: %w", relative, closeErr)
+		}
+		pending = append(pending, children...)
+	}
+	return nil
+}
+
+func scanDriveSyncDirectory(tree *driveSyncLocalTree, directory *os.Root, relativeParent string) ([]string, error) {
+	directoryFile, err := directory.Open(".")
+	if err != nil {
+		return nil, fmt.Errorf("read local directory %q: %w", relativeParent, err)
+	}
+	entries, readErr := directoryFile.ReadDir(-1)
+	closeErr := directoryFile.Close()
+	if readErr != nil {
+		return nil, fmt.Errorf("read local directory %q: %w", relativeParent, readErr)
+	}
+	if closeErr != nil {
+		return nil, fmt.Errorf("read local directory %q: %w", relativeParent, closeErr)
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Name() < entries[j].Name() })
+
+	childDirectories := make([]string, 0)
+	for _, dirEntry := range entries {
+		name := dirEntry.Name()
+		relative := path.Join(relativeParent, name)
+		if nameErr := validateDriveSyncLocalName(name, relative); nameErr != nil {
+			return nil, nameErr
+		}
+		info, infoErr := directory.Lstat(name)
+		if infoErr != nil {
+			return nil, fmt.Errorf("inspect local path %q: %w", relative, infoErr)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return nil, fmt.Errorf("local symlink not supported: %q", relative)
+		}
+
+		entry := driveSyncLocalEntry{
+			Path:       relative,
+			ParentPath: relativeParent,
+			Name:       name,
+			IsDir:      info.IsDir(),
+		}
+		switch {
+		case info.IsDir():
+			child, childInfo, childErr := openDriveSyncChildRoot(directory, name, relative)
+			if childErr != nil {
+				return nil, childErr
+			}
+			closeErr := child.Close()
+			if closeErr != nil {
+				return nil, fmt.Errorf("close local directory %q: %w", relative, closeErr)
+			}
+			tree.dirInfos[relative] = childInfo
+			childDirectories = append(childDirectories, relative)
+		case info.Mode().IsRegular():
+			entry.Size = info.Size()
+			entry.MimeType = guessMimeType(name)
+			entry.MD5, infoErr = driveSyncChecksum(directory, name, relative)
+			if infoErr != nil {
+				return nil, infoErr
+			}
+		default:
+			return nil, fmt.Errorf("unsupported local file type: %q", relative)
+		}
+
+		tree.Entries[relative] = entry
+		tree.Children[relativeParent] = append(tree.Children[relativeParent], entry)
+	}
+	return childDirectories, nil
+}
+
+func (tree *driveSyncLocalTree) Close() error {
+	if tree.root == nil {
+		return nil
+	}
+	err := tree.root.Close()
+	tree.root = nil
+	tree.dirInfos = nil
+	return err
+}
+
+func openDriveSyncDirectory(treeRoot *os.Root, dirInfos map[string]os.FileInfo, relative string) (*os.Root, error) {
+	current, currentInfo, err := openDriveSyncChildRoot(treeRoot, ".", ".")
+	if err != nil {
+		return nil, err
+	}
+	if expected := dirInfos[""]; expected == nil || !os.SameFile(expected, currentInfo) {
+		_ = current.Close()
+		return nil, fmt.Errorf("local root directory changed after preflight")
+	}
+	if relative == "" {
+		return current, nil
+	}
+
+	prefix := ""
+	for _, component := range strings.Split(relative, "/") {
+		prefix = path.Join(prefix, component)
+		next, nextInfo, openErr := openDriveSyncChildRoot(current, component, prefix)
+		_ = current.Close()
+		if openErr != nil {
+			return nil, openErr
+		}
+		expected := dirInfos[prefix]
+		if expected == nil || !os.SameFile(expected, nextInfo) {
+			_ = next.Close()
+			return nil, fmt.Errorf("local directory changed after preflight: %q", prefix)
+		}
+		current = next
+	}
+	return current, nil
+}
+
+func validateDriveSyncLocalName(name, relative string) error {
+	if !utf8.ValidString(name) {
+		return fmt.Errorf("local name is not valid UTF-8: %q", relative)
+	}
+	return nil
+}
+
+func driveSyncChecksum(directory *os.Root, name, displayPath string) (string, error) {
+	file, _, err := openDriveSyncRegularFile(directory, name, displayPath)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	checksum, err := driveSyncOpenFileChecksum(file)
+	if err != nil {
+		return "", fmt.Errorf("checksum %q: %w", displayPath, err)
+	}
+	return checksum, nil
+}
+
+func openDriveSyncRegularFile(directory *os.Root, name, displayPath string) (*os.File, os.FileInfo, error) {
+	before, err := directory.Lstat(name)
+	if err != nil {
+		return nil, nil, err
+	}
+	if before.Mode()&os.ModeSymlink != 0 {
+		return nil, nil, fmt.Errorf("local symlink not supported: %q", displayPath)
+	}
+	if !before.Mode().IsRegular() {
+		return nil, nil, fmt.Errorf("local path is not a regular file: %q", displayPath)
+	}
+
+	file, err := directory.Open(name)
+	if err != nil {
+		return nil, nil, err
+	}
+	opened, err := file.Stat()
+	if err != nil {
+		_ = file.Close()
+		return nil, nil, err
+	}
+	after, err := directory.Lstat(name)
+	if err != nil {
+		_ = file.Close()
+		return nil, nil, err
+	}
+	if after.Mode()&os.ModeSymlink != 0 || !os.SameFile(before, opened) || !os.SameFile(opened, after) {
+		_ = file.Close()
+		return nil, nil, fmt.Errorf("local file changed while opening: %q", displayPath)
+	}
+	return file, opened, nil
+}
+
+func driveSyncOpenFileChecksum(file *os.File) (string, error) {
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return "", err
+	}
+	hasher := md5.New() // #nosec G401 -- Google Drive's binary checksum contract is MD5.
+	if _, err := io.Copy(hasher, file); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(hasher.Sum(nil)), nil
+}
+
+func buildDriveSyncPlan(ctx context.Context, tree driveSyncLocalTree, parentID string, allDrives bool, client driveSyncClient) (*driveSyncPlan, error) {
+	parent, err := client.Get(ctx, parentID)
+	if err != nil {
+		return nil, fmt.Errorf("inspect Drive parent %q: %w", parentID, err)
+	}
+	if parent.MimeType != driveMimeFolder {
+		return nil, fmt.Errorf("drive parent %q is not a folder (mimeType=%s)", parentID, parent.MimeType)
+	}
+	if !allDrives && parent.DriveId != "" {
+		return nil, fmt.Errorf("drive parent %q belongs to shared drive %q; remove --no-all-drives", parentID, parent.DriveId)
+	}
+
+	planner := driveSyncPlanner{
+		client:    client,
+		tree:      tree,
+		folderIDs: map[string]string{"": parentID},
+	}
+	if err := planner.planDirectory(ctx, "", parentID, true); err != nil {
+		return nil, err
+	}
+	sort.Slice(planner.directories, func(i, j int) bool {
+		leftDepth := strings.Count(planner.directories[i].Path, "/")
+		rightDepth := strings.Count(planner.directories[j].Path, "/")
+		if leftDepth != rightDepth {
+			return leftDepth < rightDepth
+		}
+		return planner.directories[i].Path < planner.directories[j].Path
+	})
+	sort.Slice(planner.files, func(i, j int) bool {
+		return planner.files[i].Path < planner.files[j].Path
+	})
+
+	actions := append([]driveSyncAction(nil), planner.directories...)
+	actions = append(actions, planner.files...)
+	for index := range actions {
+		actions[index].ParentID = planner.folderIDs[actions[index].ParentPath]
+	}
+	return &driveSyncPlan{
+		Actions:   actions,
+		folderIDs: planner.folderIDs,
+		entries:   tree.Entries,
+		localRoot: tree.root,
+		dirInfos:  tree.dirInfos,
+	}, nil
+}
+
+type driveSyncPlanner struct {
+	client      driveSyncClient
+	tree        driveSyncLocalTree
+	folderIDs   map[string]string
+	directories []driveSyncAction
+	files       []driveSyncAction
+}
+
+func (p *driveSyncPlanner) planDirectory(ctx context.Context, localParent, remoteParentID string, remoteExists bool) error {
+	remoteByName := make(map[string][]*drive.File)
+	if remoteExists {
+		children, err := p.client.Children(ctx, remoteParentID)
+		if err != nil {
+			return fmt.Errorf("list Drive folder for %q: %w", localParent, err)
+		}
+		for _, child := range children {
+			if child != nil {
+				remoteByName[child.Name] = append(remoteByName[child.Name], child)
+			}
+		}
+	}
+
+	for _, local := range p.tree.Children[localParent] {
+		matches := remoteByName[local.Name]
+		if len(matches) > 1 {
+			return fmt.Errorf("ambiguous Drive sibling for local path %q: found %d matches", local.Path, len(matches))
+		}
+		var remote *drive.File
+		if len(matches) == 1 {
+			remote = matches[0]
+		}
+		if local.IsDir {
+			if err := p.planLocalDirectory(ctx, local, remote); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := p.planLocalFile(local, remote); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (p *driveSyncPlanner) planLocalDirectory(ctx context.Context, local driveSyncLocalEntry, remote *drive.File) error {
+	if remote == nil {
+		p.directories = append(p.directories, driveSyncAction{
+			Action:     driveSyncCreateFolder,
+			Path:       local.Path,
+			MimeType:   driveMimeFolder,
+			Reason:     "missing",
+			ParentPath: local.ParentPath,
+		})
+		return p.planDirectory(ctx, local.Path, "", false)
+	}
+	if remote.MimeType != driveMimeFolder {
+		return driveSyncTypeConflict(local, remote)
+	}
+	p.folderIDs[local.Path] = remote.Id
+	return p.planDirectory(ctx, local.Path, remote.Id, true)
+}
+
+func (p *driveSyncPlanner) planLocalFile(local driveSyncLocalEntry, remote *drive.File) error {
+	action := driveSyncAction{
+		Path:       local.Path,
+		MimeType:   local.MimeType,
+		MD5:        local.MD5,
+		Size:       local.Size,
+		ParentPath: local.ParentPath,
+	}
+	if remote == nil {
+		action.Action = driveSyncCreateFile
+		action.Reason = "missing"
+		p.files = append(p.files, action)
+		return nil
+	}
+	if remote.MimeType == driveMimeFolder || strings.HasPrefix(remote.MimeType, "application/vnd.google-apps.") {
+		return driveSyncTypeConflict(local, remote)
+	}
+	action.FileID = remote.Id
+	if remote.Md5Checksum != "" && remote.Size == local.Size && strings.EqualFold(remote.Md5Checksum, local.MD5) {
+		action.Action = driveSyncSkipFile
+		action.Reason = "size and md5 match"
+		p.files = append(p.files, action)
+		return nil
+	}
+	action.Action = driveSyncUpdateFile
+	switch {
+	case remote.Md5Checksum == "":
+		action.Reason = "remote md5 unavailable"
+	case remote.Size != local.Size:
+		action.Reason = "size differs"
+	default:
+		action.Reason = "md5 differs"
+	}
+	p.files = append(p.files, action)
+	return nil
+}
+
+func driveSyncTypeConflict(local driveSyncLocalEntry, remote *drive.File) error {
+	want := "binary file"
+	if local.IsDir {
+		want = strFolder
+	}
+	return fmt.Errorf("drive type conflict for local path %q: need %s, found mimeType=%s", local.Path, want, remote.MimeType)
+}
+
+func applyDriveSyncPlan(ctx context.Context, plan *driveSyncPlan, client driveSyncClient) error {
+	var stagingDir string
+	defer func() {
+		if stagingDir != "" {
+			_ = os.RemoveAll(stagingDir)
+		}
+	}()
+
+	for index := range plan.Actions {
+		action := &plan.Actions[index]
+		switch action.Action {
+		case driveSyncCreateFolder:
+			parentID, ok := plan.folderIDs[action.ParentPath]
+			if !ok || parentID == "" {
+				return fmt.Errorf("missing resolved Drive parent for %q", action.Path)
+			}
+			created, err := client.CreateFolder(ctx, path.Base(action.Path), parentID)
+			if err != nil {
+				return fmt.Errorf("create Drive folder %q: %w", action.Path, err)
+			}
+			if created == nil || created.Id == "" {
+				return fmt.Errorf("create Drive folder %q: response missing file ID", action.Path)
+			}
+			action.FileID = created.Id
+			action.ParentID = parentID
+			plan.folderIDs[action.Path] = created.Id
+		case driveSyncCreateFile, driveSyncUpdateFile:
+			if stagingDir == "" {
+				createdDir, mkdirErr := os.MkdirTemp("", "gog-drive-sync-")
+				if mkdirErr != nil {
+					return fmt.Errorf("create Drive sync staging directory: %w", mkdirErr)
+				}
+				stagingDir = createdDir
+			}
+			if err := applyDriveSyncFile(ctx, action, plan, client, stagingDir); err != nil {
+				return err
+			}
+		case driveSyncSkipFile:
+		default:
+			return fmt.Errorf("unsupported Drive sync action %q", action.Action)
+		}
+	}
+	return nil
+}
+
+func applyDriveSyncFile(ctx context.Context, action *driveSyncAction, plan *driveSyncPlan, client driveSyncClient, stagingDir string) error {
+	entry, ok := plan.entries[action.Path]
+	if !ok {
+		return fmt.Errorf("missing local entry for %q", action.Path)
+	}
+	snapshot, cleanup, err := stageDriveSyncFile(plan, entry, action.Path, stagingDir)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	if action.Action == driveSyncCreateFile {
+		parentID, found := plan.folderIDs[action.ParentPath]
+		if !found || parentID == "" {
+			return fmt.Errorf("missing resolved Drive parent for %q", action.Path)
+		}
+		created, createErr := client.CreateFile(ctx, entry, parentID, snapshot)
+		if createErr != nil {
+			return fmt.Errorf("create Drive file %q: %w", action.Path, createErr)
+		}
+		if created == nil || created.Id == "" {
+			return fmt.Errorf("create Drive file %q: response missing file ID", action.Path)
+		}
+		if verifyErr := verifyDriveSyncUpload(entry, created); verifyErr != nil {
+			return fmt.Errorf("verify created Drive file %q (id=%s): %w", action.Path, created.Id, verifyErr)
+		}
+		action.FileID = created.Id
+		action.ParentID = parentID
+		return nil
+	}
+
+	updated, err := client.UpdateFile(ctx, action.FileID, entry, snapshot)
+	if err != nil {
+		return fmt.Errorf("update Drive file %q: %w", action.Path, err)
+	}
+	if updated == nil || updated.Id != action.FileID {
+		return fmt.Errorf("update Drive file %q: response did not preserve file ID", action.Path)
+	}
+	if verifyErr := verifyDriveSyncUpload(entry, updated); verifyErr != nil {
+		return fmt.Errorf("verify updated Drive file %q (id=%s): %w", action.Path, updated.Id, verifyErr)
+	}
+	return nil
+}
+
+func stageDriveSyncFile(plan *driveSyncPlan, entry driveSyncLocalEntry, displayPath, stagingDir string) (*os.File, func(), error) {
+	localParent, err := openDriveSyncDirectory(plan.localRoot, plan.dirInfos, entry.ParentPath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("reopen local parent for %q: %w", displayPath, err)
+	}
+	file, info, err := openDriveSyncRegularFile(localParent, entry.Name, displayPath)
+	closeParentErr := localParent.Close()
+	if err != nil {
+		return nil, nil, fmt.Errorf("open local file %q: %w", displayPath, err)
+	}
+	if closeParentErr != nil {
+		_ = file.Close()
+		return nil, nil, fmt.Errorf("close local parent for %q: %w", displayPath, closeParentErr)
+	}
+	if info.Size() != entry.Size {
+		_ = file.Close()
+		return nil, nil, fmt.Errorf("local file changed after preflight: %q", displayPath)
+	}
+
+	snapshot, err := os.CreateTemp(stagingDir, "content-")
+	if err != nil {
+		_ = file.Close()
+		return nil, nil, fmt.Errorf("create local snapshot for %q: %w", displayPath, err)
+	}
+	cleanup := func() {
+		_ = snapshot.Close()
+		_ = os.Remove(snapshot.Name())
+	}
+	hasher := md5.New() // #nosec G401 -- Google Drive's binary checksum contract is MD5.
+	written, copyErr := io.Copy(io.MultiWriter(snapshot, hasher), file)
+	closeSourceErr := file.Close()
+	if copyErr != nil {
+		cleanup()
+		return nil, nil, fmt.Errorf("snapshot local file %q: %w", displayPath, copyErr)
+	}
+	if closeSourceErr != nil {
+		cleanup()
+		return nil, nil, fmt.Errorf("close local file %q: %w", displayPath, closeSourceErr)
+	}
+	checksum := hex.EncodeToString(hasher.Sum(nil))
+	if written != entry.Size || !strings.EqualFold(checksum, entry.MD5) {
+		cleanup()
+		return nil, nil, fmt.Errorf("local file changed while snapshotting: %q", displayPath)
+	}
+	if syncErr := snapshot.Sync(); syncErr != nil {
+		cleanup()
+		return nil, nil, fmt.Errorf("sync local snapshot for %q: %w", displayPath, syncErr)
+	}
+	if _, seekErr := snapshot.Seek(0, io.SeekStart); seekErr != nil {
+		cleanup()
+		return nil, nil, fmt.Errorf("rewind local snapshot for %q: %w", displayPath, seekErr)
+	}
+	return snapshot, cleanup, nil
+}
+
+func verifyDriveSyncUpload(entry driveSyncLocalEntry, uploaded *drive.File) error {
+	if uploaded.Size != entry.Size {
+		return fmt.Errorf("provider size=%d, expected %d", uploaded.Size, entry.Size)
+	}
+	if uploaded.Md5Checksum == "" {
+		return fmt.Errorf("provider response missing md5Checksum")
+	}
+	if !strings.EqualFold(uploaded.Md5Checksum, entry.MD5) {
+		return fmt.Errorf("provider md5=%s, expected %s", uploaded.Md5Checksum, entry.MD5)
+	}
+	return nil
+}
+
+func (c *googleDriveSyncClient) Get(ctx context.Context, fileID string) (*drive.File, error) {
+	file, err := c.service.Files.Get(fileID).
+		SupportsAllDrives(true).
+		Fields(gapi.Field(driveSyncFields)).
+		Context(ctx).
+		Do()
+	if err != nil {
+		return nil, err
+	}
+	c.driveID = file.DriveId
+	return file, nil
+}
+
+func (c *googleDriveSyncClient) Children(ctx context.Context, parentID string) ([]*drive.File, error) {
+	return listDriveSyncChildren(ctx, c.service, parentID, c.driveID)
+}
+
+func listDriveSyncChildren(ctx context.Context, svc *drive.Service, parentID, driveID string) ([]*drive.File, error) {
+	query := buildDriveListQuery(parentID, "")
+	files := make([]*drive.File, 0, 64)
+	var pageToken string
+	for {
+		call := svc.Files.List().
+			Q(query).
+			PageSize(driveDefaultPageSize).
+			PageToken(pageToken).
+			OrderBy("folder,name")
+		if driveID != "" {
+			call = driveFilesListCallWithDriveSupport(call, true, driveID)
+		} else {
+			call = call.SupportsAllDrives(true).
+				IncludeItemsFromAllDrives(false).
+				Corpora("user")
+		}
+		response, err := call.Fields(
+			gapi.Field("nextPageToken"),
+			gapi.Field("incompleteSearch"),
+			gapi.Field("files("+driveSyncFields+")"),
+		).Context(ctx).Do()
+		if err != nil {
+			return nil, err
+		}
+		if response.IncompleteSearch {
+			return nil, fmt.Errorf("drive returned an incomplete child listing for parent %q", parentID)
+		}
+		files = append(files, response.Files...)
+		if response.NextPageToken == "" {
+			return files, nil
+		}
+		pageToken = response.NextPageToken
+	}
+}
+
+func (c *googleDriveSyncClient) CreateFolder(ctx context.Context, name, parentID string) (*drive.File, error) {
+	return c.service.Files.Create(&drive.File{
+		Name:     name,
+		MimeType: driveMimeFolder,
+		Parents:  []string{parentID},
+	}).
+		SupportsAllDrives(true).
+		Fields(gapi.Field(driveSyncFields)).
+		Context(ctx).
+		Do()
+}
+
+func (c *googleDriveSyncClient) CreateFile(ctx context.Context, entry driveSyncLocalEntry, parentID string, content io.Reader) (*drive.File, error) {
+	return c.service.Files.Create(&drive.File{
+		Name:    entry.Name,
+		Parents: []string{parentID},
+	}).
+		SupportsAllDrives(true).
+		Media(content, gapi.ContentType(entry.MimeType)).
+		Fields(gapi.Field(driveSyncFields)).
+		Context(ctx).
+		Do()
+}
+
+func (c *googleDriveSyncClient) UpdateFile(ctx context.Context, fileID string, entry driveSyncLocalEntry, content io.Reader) (*drive.File, error) {
+	return c.service.Files.Update(fileID, &drive.File{}).
+		SupportsAllDrives(true).
+		Media(content, gapi.ContentType(entry.MimeType)).
+		Fields(gapi.Field(driveSyncFields)).
+		Context(ctx).
+		Do()
+}
+
+func writeDriveSyncPlan(ctx context.Context, localDir, parentID string, dryRun bool, actions []driveSyncAction) error {
+	summary := summarizeDriveSyncActions(actions)
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(ctx, stdoutWriter(ctx), map[string]any{
+			"actions":   actions,
+			"dry_run":   dryRun,
+			"local_dir": localDir,
+			"parent_id": parentID,
+			"summary":   summary,
+		})
+	}
+
+	rows := append([]driveSyncAction(nil), actions...)
+	rows = append(rows, driveSyncAction{
+		Action: "summary",
+		Reason: fmt.Sprintf(
+			"create_folders=%d create_files=%d update_files=%d skip_files=%d",
+			summary.CreateFolders,
+			summary.CreateFiles,
+			summary.UpdateFiles,
+			summary.SkipFiles,
+		),
+	})
+	return outfmt.WriteTable(ctx, stdoutWriter(ctx), rows, []outfmt.Column[driveSyncAction]{
+		{Header: "ACTION", Value: func(row driveSyncAction) string { return driveSyncOutputField(row.Action) }},
+		{Header: "PATH", Value: func(row driveSyncAction) string { return driveSyncOutputField(row.Path) }},
+		{Header: "ID", Value: func(row driveSyncAction) string { return driveSyncOutputField(row.FileID) }},
+		{Header: "REASON", Value: func(row driveSyncAction) string { return driveSyncOutputField(row.Reason) }},
+	})
+}
+
+func summarizeDriveSyncActions(actions []driveSyncAction) driveSyncSummary {
+	var summary driveSyncSummary
+	for _, action := range actions {
+		switch action.Action {
+		case driveSyncCreateFolder:
+			summary.CreateFolders++
+		case driveSyncCreateFile:
+			summary.CreateFiles++
+		case driveSyncUpdateFile:
+			summary.UpdateFiles++
+		case driveSyncSkipFile:
+			summary.SkipFiles++
+		}
+	}
+	return summary
+}
+
+func driveSyncOutputField(value string) string {
+	var output strings.Builder
+	output.Grow(len(value))
+	for _, current := range value {
+		if unicode.IsControl(current) || unicode.Is(unicode.Cf, current) {
+			switch {
+			case current <= 0xff:
+				fmt.Fprintf(&output, "\\x%02x", current)
+			case current <= 0xffff:
+				fmt.Fprintf(&output, "\\u%04x", current)
+			default:
+				fmt.Fprintf(&output, "\\U%08x", current)
+			}
+			continue
+		}
+		output.WriteRune(current)
+	}
+	return output.String()
+}

--- a/internal/cmd/drive_sync_push_test.go
+++ b/internal/cmd/drive_sync_push_test.go
@@ -1,0 +1,677 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"crypto/md5"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/drive/v3"
+
+	"github.com/steipete/gogcli/internal/outfmt"
+)
+
+type fakeDriveSyncClient struct {
+	files         map[string]*drive.File
+	children      map[string][]*drive.File
+	writes        []string
+	nextID        int
+	corruptUpload bool
+	beforeRead    func()
+}
+
+func newFakeDriveSyncClient() *fakeDriveSyncClient {
+	parent := &drive.File{Id: "parent", Name: "parent", MimeType: driveMimeFolder}
+	return &fakeDriveSyncClient{
+		files:    map[string]*drive.File{parent.Id: parent},
+		children: make(map[string][]*drive.File),
+	}
+}
+
+func (f *fakeDriveSyncClient) Get(_ context.Context, fileID string) (*drive.File, error) {
+	file := f.files[fileID]
+	if file == nil {
+		return nil, fmt.Errorf("missing file %s", fileID)
+	}
+	return file, nil
+}
+
+func (f *fakeDriveSyncClient) Children(_ context.Context, parentID string) ([]*drive.File, error) {
+	return append([]*drive.File(nil), f.children[parentID]...), nil
+}
+
+func (f *fakeDriveSyncClient) CreateFolder(_ context.Context, name, parentID string) (*drive.File, error) {
+	f.nextID++
+	file := &drive.File{Id: fmt.Sprintf("folder-%d", f.nextID), Name: name, MimeType: driveMimeFolder, Parents: []string{parentID}}
+	f.add(parentID, file)
+	f.writes = append(f.writes, driveSyncCreateFolder+":"+name)
+	return file, nil
+}
+
+func (f *fakeDriveSyncClient) CreateFile(_ context.Context, entry driveSyncLocalEntry, parentID string, content io.Reader) (*drive.File, error) {
+	if f.beforeRead != nil {
+		f.beforeRead()
+	}
+	data, err := io.ReadAll(content)
+	if err != nil {
+		return nil, err
+	}
+	f.nextID++
+	file := &drive.File{
+		Id:          fmt.Sprintf("file-%d", f.nextID),
+		Name:        entry.Name,
+		MimeType:    entry.MimeType,
+		Parents:     []string{parentID},
+		Size:        int64(len(data)),
+		Md5Checksum: testDriveSyncMD5(data),
+	}
+	if f.corruptUpload {
+		file.Md5Checksum = testDriveSyncMD5([]byte("different"))
+	}
+	f.add(parentID, file)
+	f.writes = append(f.writes, driveSyncCreateFile+":"+entry.Path)
+	return file, nil
+}
+
+func (f *fakeDriveSyncClient) UpdateFile(_ context.Context, fileID string, entry driveSyncLocalEntry, content io.Reader) (*drive.File, error) {
+	if f.beforeRead != nil {
+		f.beforeRead()
+	}
+	data, err := io.ReadAll(content)
+	if err != nil {
+		return nil, err
+	}
+	file := f.files[fileID]
+	if file == nil {
+		return nil, fmt.Errorf("missing update target %s", fileID)
+	}
+	file.Size = int64(len(data))
+	file.Md5Checksum = testDriveSyncMD5(data)
+	if f.corruptUpload {
+		file.Md5Checksum = testDriveSyncMD5([]byte("different"))
+	}
+	f.writes = append(f.writes, driveSyncUpdateFile+":"+entry.Path)
+	return file, nil
+}
+
+func (f *fakeDriveSyncClient) add(parentID string, file *drive.File) {
+	f.files[file.Id] = file
+	f.children[parentID] = append(f.children[parentID], file)
+}
+
+func testDriveSyncMD5(data []byte) string {
+	sum := md5.Sum(data)
+	return hex.EncodeToString(sum[:])
+}
+
+func writeDriveSyncFixture(t *testing.T) string {
+	t.Helper()
+
+	root := t.TempDir()
+	if err := os.Mkdir(filepath.Join(root, "nested"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "a.txt"), []byte("alpha"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "nested", "b.txt"), []byte("bravo"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+func scanDriveSyncTestTree(t *testing.T, root string) driveSyncLocalTree {
+	t.Helper()
+
+	tree, err := scanDriveSyncLocalTree(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if closeErr := tree.Close(); closeErr != nil {
+			t.Errorf("close local tree: %v", closeErr)
+		}
+	})
+	return tree
+}
+
+func TestDriveSyncPushPlanApplyAndRepeat(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	root := writeDriveSyncFixture(t)
+	client := newFakeDriveSyncClient()
+
+	tree := scanDriveSyncTestTree(t, root)
+	plan, err := buildDriveSyncPlan(ctx, tree, "parent", true, client)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantActions := []string{
+		driveSyncCreateFolder + ":nested",
+		driveSyncCreateFile + ":a.txt",
+		driveSyncCreateFile + ":nested/b.txt",
+	}
+	if got := driveSyncActionNames(plan.Actions); strings.Join(got, ",") != strings.Join(wantActions, ",") {
+		t.Fatalf("initial actions = %v, want %v", got, wantActions)
+	}
+	if applyErr := applyDriveSyncPlan(ctx, plan, client); applyErr != nil {
+		t.Fatal(applyErr)
+	}
+	if got := len(client.writes); got != 3 {
+		t.Fatalf("writes = %d, want 3", got)
+	}
+	nestedID := plan.Actions[0].FileID
+	nestedFileID := plan.Actions[2].FileID
+	if nestedID == "" || nestedFileID == "" {
+		t.Fatalf("missing created IDs: %+v", plan.Actions)
+	}
+
+	repeatPlan, err := buildDriveSyncPlan(ctx, tree, "parent", true, client)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantActions = []string{
+		driveSyncSkipFile + ":a.txt",
+		driveSyncSkipFile + ":nested/b.txt",
+	}
+	if got := driveSyncActionNames(repeatPlan.Actions); strings.Join(got, ",") != strings.Join(wantActions, ",") {
+		t.Fatalf("repeat actions = %v, want %v", got, wantActions)
+	}
+	if applyErr := applyDriveSyncPlan(ctx, repeatPlan, client); applyErr != nil {
+		t.Fatal(applyErr)
+	}
+	if got := len(client.writes); got != 3 {
+		t.Fatalf("repeat writes = %d, want 3", got)
+	}
+
+	remoteOnly := &drive.File{Id: "remote-only", Name: "remote-only.txt", MimeType: mimeTextPlain, Size: 4, Md5Checksum: testDriveSyncMD5([]byte("keep"))}
+	client.add("parent", remoteOnly)
+	if writeErr := os.WriteFile(filepath.Join(root, "nested", "b.txt"), []byte("changed"), 0o600); writeErr != nil {
+		t.Fatal(writeErr)
+	}
+	changedTree := scanDriveSyncTestTree(t, root)
+	changedPlan, err := buildDriveSyncPlan(ctx, changedTree, "parent", true, client)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantActions = []string{
+		driveSyncSkipFile + ":a.txt",
+		driveSyncUpdateFile + ":nested/b.txt",
+	}
+	if got := driveSyncActionNames(changedPlan.Actions); strings.Join(got, ",") != strings.Join(wantActions, ",") {
+		t.Fatalf("changed actions = %v, want %v", got, wantActions)
+	}
+	if changedPlan.Actions[1].FileID != nestedFileID {
+		t.Fatalf("update target = %q, want %q", changedPlan.Actions[1].FileID, nestedFileID)
+	}
+	if err := applyDriveSyncPlan(ctx, changedPlan, client); err != nil {
+		t.Fatal(err)
+	}
+	if changedPlan.Actions[1].FileID != nestedFileID {
+		t.Fatalf("updated file ID changed: %q", changedPlan.Actions[1].FileID)
+	}
+	if client.files[remoteOnly.Id] != remoteOnly {
+		t.Fatal("remote-only file was changed or removed")
+	}
+	if client.files[nestedID] == nil {
+		t.Fatal("nested folder missing after update")
+	}
+}
+
+func driveSyncActionNames(actions []driveSyncAction) []string {
+	result := make([]string, 0, len(actions))
+	for _, action := range actions {
+		result = append(result, action.Action+":"+action.Path)
+	}
+	return result
+}
+
+func TestDriveSyncPushPreflightConflictsDoNotWrite(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	root := writeDriveSyncFixture(t)
+	tree := scanDriveSyncTestTree(t, root)
+
+	t.Run("duplicate", func(t *testing.T) {
+		t.Parallel()
+
+		client := newFakeDriveSyncClient()
+		client.add("parent", &drive.File{Id: "a1", Name: "a.txt", MimeType: mimeTextPlain})
+		client.add("parent", &drive.File{Id: "a2", Name: "a.txt", MimeType: mimeTextPlain})
+		_, err := buildDriveSyncPlan(ctx, tree, "parent", true, client)
+		if err == nil || !strings.Contains(err.Error(), "ambiguous Drive sibling") {
+			t.Fatalf("error = %v", err)
+		}
+		if len(client.writes) != 0 {
+			t.Fatalf("unexpected writes: %v", client.writes)
+		}
+	})
+
+	t.Run("wrong type", func(t *testing.T) {
+		t.Parallel()
+
+		client := newFakeDriveSyncClient()
+		client.add("parent", &drive.File{Id: "a-folder", Name: "a.txt", MimeType: driveMimeFolder})
+		_, err := buildDriveSyncPlan(ctx, tree, "parent", true, client)
+		if err == nil || !strings.Contains(err.Error(), "drive type conflict") {
+			t.Fatalf("error = %v", err)
+		}
+		if len(client.writes) != 0 {
+			t.Fatalf("unexpected writes: %v", client.writes)
+		}
+	})
+
+	t.Run("Google-native file", func(t *testing.T) {
+		t.Parallel()
+
+		client := newFakeDriveSyncClient()
+		client.add("parent", &drive.File{Id: "a-doc", Name: "a.txt", MimeType: driveMimeGoogleDoc})
+		_, err := buildDriveSyncPlan(ctx, tree, "parent", true, client)
+		if err == nil || !strings.Contains(err.Error(), "drive type conflict") {
+			t.Fatalf("error = %v", err)
+		}
+		if len(client.writes) != 0 {
+			t.Fatalf("unexpected writes: %v", client.writes)
+		}
+	})
+}
+
+func TestDriveSyncPushRejectsProviderChecksumMismatch(t *testing.T) {
+	t.Parallel()
+
+	root := writeDriveSyncFixture(t)
+	tree := scanDriveSyncTestTree(t, root)
+	client := newFakeDriveSyncClient()
+	client.corruptUpload = true
+	plan, err := buildDriveSyncPlan(context.Background(), tree, "parent", true, client)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = applyDriveSyncPlan(context.Background(), plan, client)
+	if err == nil || !strings.Contains(err.Error(), "provider md5=") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestDriveSyncPushUploadsVerifiedSnapshotWhenSourceChanges(t *testing.T) {
+	t.Parallel()
+
+	root := writeDriveSyncFixture(t)
+	tree := scanDriveSyncTestTree(t, root)
+	client := newFakeDriveSyncClient()
+	existing := &drive.File{
+		Id:          "existing-a",
+		Name:        "a.txt",
+		MimeType:    mimeTextPlain,
+		Size:        3,
+		Md5Checksum: testDriveSyncMD5([]byte("old")),
+	}
+	client.add("parent", existing)
+	mutated := false
+	client.beforeRead = func() {
+		if mutated {
+			return
+		}
+		mutated = true
+		if err := os.WriteFile(filepath.Join(root, "a.txt"), []byte("omega"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	plan, err := buildDriveSyncPlan(context.Background(), tree, "parent", true, client)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := applyDriveSyncPlan(context.Background(), plan, client); err != nil {
+		t.Fatal(err)
+	}
+	if !mutated {
+		t.Fatal("source mutation hook did not run")
+	}
+	if existing.Id != "existing-a" || existing.Md5Checksum != testDriveSyncMD5([]byte("alpha")) {
+		t.Fatalf("updated file did not use verified snapshot: %+v", existing)
+	}
+}
+
+func TestDriveSyncPushBoundsDirectoryHandles(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	const directoryCount = 512
+	for index := range directoryCount {
+		if err := os.Mkdir(filepath.Join(root, fmt.Sprintf("dir-%04d", index)), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	tree := scanDriveSyncTestTree(t, root)
+	if len(tree.Entries) != directoryCount || len(tree.dirInfos) != directoryCount+1 {
+		t.Fatalf("entries=%d dirInfos=%d", len(tree.Entries), len(tree.dirInfos))
+	}
+}
+
+func TestDriveSyncPushFolderOnlyDoesNotRequireTemp(t *testing.T) {
+	root := t.TempDir()
+	if err := os.Mkdir(filepath.Join(root, "empty"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	tree := scanDriveSyncTestTree(t, root)
+	client := newFakeDriveSyncClient()
+	plan, err := buildDriveSyncPlan(context.Background(), tree, "parent", true, client)
+	if err != nil {
+		t.Fatal(err)
+	}
+	unavailable := filepath.Join(t.TempDir(), "does-not-exist")
+	t.Setenv("TMPDIR", unavailable)
+	t.Setenv("TMP", unavailable)
+	t.Setenv("TEMP", unavailable)
+	if err := applyDriveSyncPlan(context.Background(), plan, client); err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Join(client.writes, ","); got != "create_folder:empty" {
+		t.Fatalf("writes = %q", got)
+	}
+}
+
+func TestDriveSyncPushRejectsSymlinkBeforeService(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == literalWindows {
+		t.Skip("symlink setup requires privileges on Windows")
+	}
+
+	root := t.TempDir()
+	target := filepath.Join(root, "target.txt")
+	if err := os.WriteFile(target, []byte("secret"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, filepath.Join(root, "link.txt")); err != nil {
+		t.Fatal(err)
+	}
+	_, err := scanDriveSyncLocalTree(root)
+	if err == nil || !strings.Contains(err.Error(), "local symlink not supported") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestDriveSyncPushRejectsRootSymlink(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == literalWindows {
+		t.Skip("symlink setup requires privileges on Windows")
+	}
+
+	base := t.TempDir()
+	realRoot := filepath.Join(base, "real")
+	if err := os.Mkdir(realRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	linkedRoot := filepath.Join(base, "linked")
+	if err := os.Symlink(realRoot, linkedRoot); err != nil {
+		t.Fatal(err)
+	}
+	_, err := scanDriveSyncLocalTree(linkedRoot)
+	if err == nil || !strings.Contains(err.Error(), "local symlink not supported") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestDriveSyncPushPinsSourceDirectoriesAcrossPathReplacement(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == literalWindows {
+		t.Skip("symlink setup requires privileges on Windows")
+	}
+
+	ctx := context.Background()
+	root := writeDriveSyncFixture(t)
+	tree := scanDriveSyncTestTree(t, root)
+	client := newFakeDriveSyncClient()
+	plan, err := buildDriveSyncPlan(ctx, tree, "parent", true, client)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	movedRoot := root + "-moved"
+	if err := os.Rename(root, movedRoot); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(movedRoot) })
+	outside := t.TempDir()
+	if err := os.WriteFile(filepath.Join(outside, "a.txt"), []byte("outside"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, root); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := applyDriveSyncPlan(ctx, plan, client); err != nil {
+		t.Fatal(err)
+	}
+	var uploaded *drive.File
+	for _, file := range client.children["parent"] {
+		if file.Name == "a.txt" {
+			uploaded = file
+			break
+		}
+	}
+	if uploaded == nil || uploaded.Md5Checksum != testDriveSyncMD5([]byte("alpha")) {
+		t.Fatalf("uploaded wrong source after path replacement: %+v", uploaded)
+	}
+}
+
+func TestDriveSyncPushRejectsInvalidUTF8Name(t *testing.T) {
+	t.Parallel()
+	invalidName := string([]byte{'b', 0xff, 'd'})
+	err := validateDriveSyncLocalName(invalidName, invalidName)
+	if err == nil || !strings.Contains(err.Error(), "local name is not valid UTF-8") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestDriveSyncPushNoAllDrivesRejectsSharedParent(t *testing.T) {
+	t.Parallel()
+
+	root := writeDriveSyncFixture(t)
+	tree := scanDriveSyncTestTree(t, root)
+	client := newFakeDriveSyncClient()
+	client.files["parent"].DriveId = "shared-drive"
+
+	_, err := buildDriveSyncPlan(context.Background(), tree, "parent", false, client)
+	if err == nil || !strings.Contains(err.Error(), "remove --no-all-drives") {
+		t.Fatalf("error = %v", err)
+	}
+	if len(client.writes) != 0 {
+		t.Fatalf("unexpected writes: %v", client.writes)
+	}
+}
+
+func TestDriveSyncPushOutputDeterministicAndSingleLine(t *testing.T) {
+	t.Parallel()
+
+	unsafePath := "bad\n\x1b\u202ename.txt"
+	actions := []driveSyncAction{
+		{Action: driveSyncCreateFile, Path: unsafePath, ParentID: "parent", MimeType: mimeTextPlain, MD5: "abc", Size: 3, Reason: "missing"},
+	}
+	var jsonOut bytes.Buffer
+	jsonCtx := outfmt.WithMode(newCmdRuntimeOutputContext(t, &jsonOut, io.Discard), outfmt.Mode{JSON: true})
+	if err := writeDriveSyncPlan(jsonCtx, "/tmp/local", "parent", true, actions); err != nil {
+		t.Fatal(err)
+	}
+	var payload struct {
+		DryRun  bool              `json:"dry_run"`
+		Actions []driveSyncAction `json:"actions"`
+		Summary driveSyncSummary  `json:"summary"`
+	}
+	if err := json.Unmarshal(jsonOut.Bytes(), &payload); err != nil {
+		t.Fatal(err)
+	}
+	if !payload.DryRun || len(payload.Actions) != 1 || payload.Actions[0].Path != unsafePath || payload.Summary.CreateFiles != 1 {
+		t.Fatalf("unexpected JSON payload: %s", jsonOut.String())
+	}
+
+	var plainOut bytes.Buffer
+	plainCtx := outfmt.WithMode(newCmdRuntimeOutputContext(t, &plainOut, io.Discard), outfmt.Mode{Plain: true})
+	if err := writeDriveSyncPlan(plainCtx, "/tmp/local", "parent", true, actions); err != nil {
+		t.Fatal(err)
+	}
+	want := "ACTION\tPATH\tID\tREASON\n" +
+		"create_file\tbad\\x0a\\x1b\\u202ename.txt\t\tmissing\n" +
+		"summary\t\t\tcreate_folders=0 create_files=1 update_files=0 skip_files=0\n"
+	if got := plainOut.String(); got != want {
+		t.Fatalf("plain output = %q, want %q", got, want)
+	}
+	if strings.Contains(plainOut.String(), "\x1b") || strings.Contains(plainOut.String(), "\u202e") {
+		t.Fatalf("plain output contains terminal controls: %q", plainOut.String())
+	}
+}
+
+func TestGoogleDriveSyncClientUsesSharedDriveFlags(t *testing.T) {
+	t.Parallel()
+
+	var requests []string
+	svc, closeServer := newDriveTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requireSupportsAllDrives(t, r)
+		requests = append(requests, r.Method+" "+r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/files/parent"):
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": "parent", "name": "parent", "mimeType": driveMimeFolder, "driveId": "shared-drive"})
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/files"):
+			requireQuery(t, r, "includeItemsFromAllDrives", "true")
+			requireQuery(t, r, "corpora", "drive")
+			requireQuery(t, r, "driveId", "shared-drive")
+			if r.URL.Query().Get("pageToken") == "" {
+				_ = json.NewEncoder(w).Encode(map[string]any{"files": []any{}, "nextPageToken": "next"})
+			} else {
+				requireQuery(t, r, "pageToken", "next")
+				_ = json.NewEncoder(w).Encode(map[string]any{"files": []any{}})
+			}
+		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/upload/"):
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": "file-new", "name": "a.txt"})
+		case r.Method == http.MethodPost:
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": "folder-new", "name": "nested", "mimeType": driveMimeFolder})
+		case r.Method == http.MethodPatch:
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": "file-existing", "name": "a.txt"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer closeServer()
+
+	client := &googleDriveSyncClient{service: svc}
+	ctx := context.Background()
+	if _, err := client.Get(ctx, "parent"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.Children(ctx, "parent"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.CreateFolder(ctx, "nested", "parent"); err != nil {
+		t.Fatal(err)
+	}
+	entry := driveSyncLocalEntry{Name: "a.txt", Path: "a.txt", MimeType: mimeTextPlain}
+	if _, err := client.CreateFile(ctx, entry, "parent", strings.NewReader("a")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.UpdateFile(ctx, "file-existing", entry, strings.NewReader("b")); err != nil {
+		t.Fatal(err)
+	}
+	sort.Strings(requests)
+	if len(requests) != 6 {
+		t.Fatalf("requests = %v", requests)
+	}
+}
+
+func TestListDriveSyncChildrenRejectsIncompleteSearch(t *testing.T) {
+	t.Parallel()
+
+	svc, closeServer := newDriveTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"files": []any{}, "incompleteSearch": true})
+	}))
+	defer closeServer()
+
+	_, err := listDriveSyncChildren(context.Background(), svc, "parent", "")
+	if err == nil || !strings.Contains(err.Error(), "incomplete child listing") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestExecuteDriveSyncPushDryRunPlansWithoutWrites(t *testing.T) {
+	t.Parallel()
+
+	root := filepath.Join(t.TempDir(), " backup ")
+	if err := os.Mkdir(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "a.txt"), []byte("alpha"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	writeCount := 0
+	svc, closeServer := newDriveTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method != http.MethodGet {
+			writeCount++
+			http.Error(w, "unexpected write", http.StatusInternalServerError)
+			return
+		}
+		if strings.HasSuffix(r.URL.Path, "/files/parent") {
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": "parent", "name": "parent", "mimeType": driveMimeFolder})
+			return
+		}
+		if strings.HasSuffix(r.URL.Path, "/files") {
+			requireQuery(t, r, "corpora", "user")
+			_ = json.NewEncoder(w).Encode(map[string]any{"files": []any{}})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer closeServer()
+
+	result := executeWithDriveTestService(t, []string{
+		"--account", "test@example.com",
+		"--json",
+		"--dry-run",
+		"drive", "sync", "push", root,
+		"--parent", "parent",
+	}, svc)
+	if result.err != nil {
+		t.Fatalf("execute: %v\nstderr: %s", result.err, result.stderr)
+	}
+	if writeCount != 0 {
+		t.Fatalf("dry-run writes = %d", writeCount)
+	}
+	var payload struct {
+		DryRun  bool              `json:"dry_run"`
+		Actions []driveSyncAction `json:"actions"`
+	}
+	if err := json.Unmarshal([]byte(result.stdout), &payload); err != nil {
+		t.Fatalf("parse output: %v\n%s", err, result.stdout)
+	}
+	if !payload.DryRun || len(payload.Actions) != 1 || payload.Actions[0].Action != driveSyncCreateFile {
+		t.Fatalf("unexpected dry-run plan: %s", result.stdout)
+	}
+}
+
+func TestDriveSyncPushHelp(t *testing.T) {
+	t.Parallel()
+
+	result := executeWithTestRuntime(t, []string{"drive", "sync", "push", "--help"}, nil)
+	if result.err != nil {
+		t.Fatal(result.err)
+	}
+	for _, want := range []string{"<localDirectory>", "--parent=STRING", "--[no-]all-drives", "no remote deletes"} {
+		if !strings.Contains(result.stdout, want) {
+			t.Fatalf("help missing %q:\n%s", want, result.stdout)
+		}
+	}
+}

--- a/internal/cmd/drive_sync_push_test.go
+++ b/internal/cmd/drive_sync_push_test.go
@@ -609,7 +609,7 @@ func TestListDriveSyncChildrenRejectsIncompleteSearch(t *testing.T) {
 func TestExecuteDriveSyncPushDryRunPlansWithoutWrites(t *testing.T) {
 	t.Parallel()
 
-	root := filepath.Join(t.TempDir(), " backup ")
+	root := filepath.Join(t.TempDir(), " backup")
 	if err := os.Mkdir(root, 0o755); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cmd/strings.go
+++ b/internal/cmd/strings.go
@@ -1,7 +1,8 @@
 package cmd
 
 const (
-	strDate = "date"
-	strFile = "file"
-	strList = "list"
+	strDate   = "date"
+	strFile   = "file"
+	strFolder = "folder"
+	strList   = "list"
 )


### PR DESCRIPTION
## Summary

- add `gog drive sync push <localDirectory> --parent <folderId>` for recursive, non-destructive uploads
- create missing folders and binary files, skip unchanged content, and update changed files by Drive ID
- retain remote-only items; never delete or mirror
- preflight the complete local and remote trees before writes, rejecting ambiguous names, wrong item types, native Google files, symlinks, invalid paths, and incomplete search results
- protect local traversal and upload content against path replacement and concurrent source mutation
- support My Drive and shared-drive request semantics with deterministic JSON and plain output

Fixes #925.

## Maintainer repair

The original proposal and live contract came from @Avg8888. The implementation was rewritten after maintainer review to close fail-closed, filesystem-race, bounded-resource, output-safety, and shared-drive gaps. Contributor co-authorship is preserved in the commit and changelog.

## Proof

- `make ci`
- exact-tree AutoReview clean: no accepted or actionable findings, confidence 0.90
- signed exact-head candidate: live Drive behavior contract passed 10/10 against a disposable hierarchy
- shared-drive request semantics, exact corpus pagination, and incomplete-search rejection covered by HTTP-level tests; no shared drive was available for live validation

Signed candidate SHA-256: `d226a155192d9dd727d453fda94498c52b90b40a6ceecf1f308e3c1df558a944`
