### PR TITLE
feat(drive): add conditional file replacement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.34.2 - 2026-07-27
 
 - Security: update gRPC-Go, PostCSS, and Sharp/libvips to patched releases, clearing three high-severity dependency alerts. (#940)
+- Drive: add opt-in `upload --replace --if-version` conflict protection using a fail-closed ETag precondition, without changing unconditional replacement. (#929) — thanks @karstenevers.
 - Gmail: acknowledge terminal watch OAuth failures only after durably recording reauthentication recovery state, preserving the last processed history cursor for catch-up after renewal. (#930) — thanks @litang9.
 - Gmail: mark unsent drafts in human-readable message and thread output while preserving JSON and plain output contracts. (#931, #932) — thanks @MaxGhenis.
 - Gmail: report exact file-input byte counts in compose dry-run output, including forwarded-message notes with trailing newlines. (#936, #937) — thanks @chrischall.

--- a/docs/commands/gog-drive-upload.md
+++ b/docs/commands/gog-drive-upload.md
@@ -32,6 +32,7 @@ gog drive (drv) upload <localPath> [flags]
 | `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
 | `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `--if-version` | `*int64` |  | Replace only if the current Drive version matches; uses an atomic precondition and reports a conflict if the file changes (requires --replace; re-read and reapply on conflict) |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
 | `--keep-frontmatter` | `bool` |  | Keep YAML frontmatter (---) in Markdown when converting to a Google Doc (--convert or --convert-to doc; default: strip) |
 | `--keep-revision-forever` | `bool` |  | Keep the new head revision forever (binary files only) |
@@ -41,7 +42,7 @@ gog drive (drv) upload <localPath> [flags]
 | `--parent` | `string` |  | Destination folder ID (create only) |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
 | `--readonly` | `bool` | false | Block mutating API requests at runtime; auth add also requests read-only OAuth scopes |
-| `--replace` | `string` |  | Replace the content of an existing Drive file ID (preserves shared link/permissions) |
+| `--replace` | `string` |  | Replace the content of an existing Drive file ID (preserves shared link/permissions; unconditional unless --if-version is set) |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |

--- a/docs/commands/gog-upload.md
+++ b/docs/commands/gog-upload.md
@@ -32,6 +32,7 @@ gog upload (up,put) <localPath> [flags]
 | `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
 | `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `--if-version` | `*int64` |  | Replace only if the current Drive version matches; uses an atomic precondition and reports a conflict if the file changes (requires --replace; re-read and reapply on conflict) |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
 | `--keep-frontmatter` | `bool` |  | Keep YAML frontmatter (---) in Markdown when converting to a Google Doc (--convert or --convert-to doc; default: strip) |
 | `--keep-revision-forever` | `bool` |  | Keep the new head revision forever (binary files only) |
@@ -41,7 +42,7 @@ gog upload (up,put) <localPath> [flags]
 | `--parent` | `string` |  | Destination folder ID (create only) |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
 | `--readonly` | `bool` | false | Block mutating API requests at runtime; auth add also requests read-only OAuth scopes |
-| `--replace` | `string` |  | Replace the content of an existing Drive file ID (preserves shared link/permissions) |
+| `--replace` | `string` |  | Replace the content of an existing Drive file ID (preserves shared link/permissions; unconditional unless --if-version is set) |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |

--- a/internal/app/runtime.go
+++ b/internal/app/runtime.go
@@ -14,6 +14,7 @@ import (
 	"google.golang.org/api/classroom/v1"
 	"google.golang.org/api/cloudidentity/v1"
 	"google.golang.org/api/docs/v1"
+	drivev2 "google.golang.org/api/drive/v2"
 	"google.golang.org/api/drive/v3"
 	"google.golang.org/api/driveactivity/v2"
 	"google.golang.org/api/drivelabels/v2"
@@ -54,6 +55,7 @@ type (
 	DocsServiceFactory           func(context.Context, string) (*docs.Service, error)
 	DocsHTTPClientFactory        func(context.Context, string) (*http.Client, error)
 	DriveServiceFactory          func(context.Context, string) (*drive.Service, error)
+	DriveV2ServiceFactory        func(context.Context, string) (*drivev2.Service, error)
 	DriveActivityServiceFactory  func(context.Context, string) (*driveactivity.Service, error)
 	DriveLabelsServiceFactory    func(context.Context, string) (*drivelabels.Service, error)
 	FormsServiceFactory          func(context.Context, string) (*forms.Service, error)
@@ -100,6 +102,7 @@ type Services struct {
 	Docs            DocsServiceFactory
 	DocsHTTP        DocsHTTPClientFactory
 	Drive           DriveServiceFactory
+	DriveV2         DriveV2ServiceFactory
 	DriveActivity   DriveActivityServiceFactory
 	DriveLabels     DriveLabelsServiceFactory
 	Forms           FormsServiceFactory

--- a/internal/cmd/drive_testutil_test.go
+++ b/internal/cmd/drive_testutil_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	drivev2 "google.golang.org/api/drive/v2"
 	"google.golang.org/api/drive/v3"
 
 	"github.com/steipete/gogcli/internal/app"
@@ -36,6 +37,20 @@ func withDriveTestServiceFactory(ctx context.Context, factory app.DriveServiceFa
 		*runtime = *existing
 	}
 	runtime.Services.Drive = factory
+	return app.WithRuntime(ctx, runtime)
+}
+
+func withDriveV2TestService(ctx context.Context, svc *drivev2.Service) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	runtime := &app.Runtime{}
+	if existing, ok := app.FromContext(ctx); ok {
+		*runtime = *existing
+	}
+	runtime.Services.DriveV2 = func(context.Context, string) (*drivev2.Service, error) {
+		return svc, nil
+	}
 	return app.WithRuntime(ctx, runtime)
 }
 

--- a/internal/cmd/drive_upload.go
+++ b/internal/cmd/drive_upload.go
@@ -3,15 +3,21 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"errors"
+	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 
+	drivev2 "google.golang.org/api/drive/v2"
 	"google.golang.org/api/drive/v3"
 	gapi "google.golang.org/api/googleapi"
 
 	"github.com/steipete/gogcli/internal/config"
+	"github.com/steipete/gogcli/internal/errfmt"
+	gogapi "github.com/steipete/gogcli/internal/googleapi"
 	"github.com/steipete/gogcli/internal/outfmt"
 	"github.com/steipete/gogcli/internal/ui"
 )
@@ -20,7 +26,8 @@ type DriveUploadCmd struct {
 	LocalPath           string `arg:"" name:"localPath" help:"Path to local file"`
 	Name                string `name:"name" help:"Override filename (create) or rename target (replace)"`
 	Parent              string `name:"parent" help:"Destination folder ID (create only)"`
-	ReplaceFileID       string `name:"replace" help:"Replace the content of an existing Drive file ID (preserves shared link/permissions)"`
+	ReplaceFileID       string `name:"replace" help:"Replace the content of an existing Drive file ID (preserves shared link/permissions; unconditional unless --if-version is set)"`
+	IfVersion           *int64 `name:"if-version" help:"Replace only if the current Drive version matches; uses an atomic precondition and reports a conflict if the file changes (requires --replace; re-read and reapply on conflict)"`
 	MimeType            string `name:"mime-type" help:"Override MIME type inference"`
 	KeepRevisionForever bool   `name:"keep-revision-forever" help:"Keep the new head revision forever (binary files only)"`
 	Convert             bool   `name:"convert" help:"Auto-convert to native Google format based on file extension (create only)"`
@@ -33,6 +40,7 @@ type driveUploadOptions struct {
 	fileName            string
 	parent              string
 	replaceFileID       string
+	ifVersion           *int64
 	mimeType            string
 	convertMimeType     string
 	isExplicitName      bool
@@ -161,7 +169,7 @@ func (c *DriveUploadCmd) Run(ctx context.Context, flags *RootFlags) error {
 	defer media.Close()
 	opts.size = size
 
-	if dryRunErr := dryRunExit(ctx, flags, "drive.upload", map[string]any{
+	dryRunRequest := map[string]any{
 		"path":                  opts.localPath,
 		"name":                  driveUploadRemoteName(opts),
 		"parent":                opts.parent,
@@ -171,16 +179,27 @@ func (c *DriveUploadCmd) Run(ctx context.Context, flags *RootFlags) error {
 		"convert":               opts.convert,
 		"convert_mime_type":     opts.convertMimeType,
 		"keep_revision_forever": opts.keepRevisionForever,
-	}); dryRunErr != nil {
+	}
+	if opts.ifVersion != nil {
+		dryRunRequest["if_version"] = *opts.ifVersion
+	}
+	if dryRunErr := dryRunExit(ctx, flags, "drive.upload", dryRunRequest); dryRunErr != nil {
 		return dryRunErr
+	}
+
+	uploadReader := driveUploadReader(ctx, media, opts)
+	if opts.ifVersion != nil {
+		_, svc, serviceErr := requireDriveV2Service(ctx, flags)
+		if serviceErr != nil {
+			return serviceErr
+		}
+		return runDriveConditionalReplaceUpload(ctx, svc, uploadReader, opts)
 	}
 
 	_, svc, err := requireDriveService(ctx, flags)
 	if err != nil {
 		return err
 	}
-
-	uploadReader := driveUploadReader(ctx, media, opts)
 	if opts.replaceFileID == "" {
 		return runDriveCreateUpload(ctx, svc, uploadReader, opts)
 	}
@@ -206,8 +225,18 @@ func prepareDriveUpload(c *DriveUploadCmd) (driveUploadOptions, error) {
 		mimeType:            strings.TrimSpace(c.MimeType),
 		keepRevisionForever: c.KeepRevisionForever,
 	}
+	if c.IfVersion != nil {
+		expectedVersion := *c.IfVersion
+		opts.ifVersion = &expectedVersion
+	}
 	opts.isExplicitName = opts.fileName != ""
 
+	if opts.ifVersion != nil && opts.replaceFileID == "" {
+		return driveUploadOptions{}, usage("--if-version requires --replace")
+	}
+	if opts.ifVersion != nil && *opts.ifVersion <= 0 {
+		return driveUploadOptions{}, usage("--if-version must be a positive integer")
+	}
 	if opts.replaceFileID != "" && opts.parent != "" {
 		return driveUploadOptions{}, usage("--parent cannot be combined with --replace (use drive move)")
 	}
@@ -321,12 +350,73 @@ func runDriveReplaceUpload(ctx context.Context, svc *drive.Service, file io.Read
 	if opts.keepRevisionForever {
 		call = call.KeepRevisionForever(true)
 	}
-
 	updated, err := call.Do()
 	if err != nil {
 		return err
 	}
 	return writeDriveUploadResult(ctx, updated, true, opts.replaceFileID)
+}
+
+func runDriveConditionalReplaceUpload(ctx context.Context, svc *drivev2.Service, file io.Reader, opts driveUploadOptions) error {
+	existing, err := svc.Files.Get(opts.replaceFileID).
+		SupportsAllDrives(true).
+		Fields("id, mimeType, version, etag").
+		Context(ctx).
+		Do()
+	if err != nil {
+		return err
+	}
+	if strings.HasPrefix(existing.MimeType, "application/vnd.google-apps.") {
+		return usagef("cannot replace content for Google Workspace files (mimeType=%s)", existing.MimeType)
+	}
+	if existing.Version <= 0 {
+		return fmt.Errorf("cannot safely replace Drive file %s: metadata response did not include a version; no update was attempted", opts.replaceFileID)
+	}
+	etag := strings.TrimSpace(existing.Etag)
+	if etag == "" {
+		return fmt.Errorf("cannot safely replace Drive file %s: metadata response did not include an ETag; no update was attempted", opts.replaceFileID)
+	}
+	if existing.Version != *opts.ifVersion {
+		return fmt.Errorf("conditional Drive replacement conflict for file %s: expected version %d, current version is %d; re-read the file and reapply your edit", opts.replaceFileID, *opts.ifVersion, existing.Version)
+	}
+
+	meta := &drivev2.File{}
+	if opts.fileName != "" {
+		meta.Title = opts.fileName
+	}
+	// Conditional replacement must be a single atomic attempt. ChunkSize(0)
+	// prevents the generated client from switching large media to its internally
+	// retrying resumable uploader, while the request context disables retries in
+	// gog's authenticated RetryTransport.
+	updateCtx := gogapi.WithoutRetries(ctx)
+	call := svc.Files.Update(opts.replaceFileID, meta).
+		SupportsAllDrives(true).
+		Media(file, gapi.ContentType(opts.mimeType), gapi.ChunkSize(0)).
+		Fields("id, title, mimeType, fileSize, alternateLink").
+		Context(updateCtx)
+	if opts.keepRevisionForever {
+		call = call.Pinned(true)
+	}
+	call.Header().Set("If-Match", etag)
+
+	updated, err := call.Do()
+	if err != nil {
+		var apiErr *gapi.Error
+		if errors.As(err, &apiErr) && apiErr.Code == http.StatusPreconditionFailed {
+			return errfmt.NewUserFacingError(
+				fmt.Sprintf("conditional Drive replacement conflict for file %s: the file changed after metadata was read; replacement was not applied. Re-read the file and reapply your edit", opts.replaceFileID),
+				err,
+			)
+		}
+		return err
+	}
+	return writeDriveUploadResult(ctx, &drive.File{
+		Id:          updated.Id,
+		Name:        updated.Title,
+		MimeType:    updated.MimeType,
+		Size:        updated.FileSize,
+		WebViewLink: updated.AlternateLink,
+	}, true, opts.replaceFileID)
 }
 
 func writeDriveUploadResult(ctx context.Context, file *drive.File, replaced bool, replacedFileID string) error {

--- a/internal/cmd/drive_upload_replace_test.go
+++ b/internal/cmd/drive_upload_replace_test.go
@@ -14,8 +14,12 @@ import (
 	"strings"
 	"testing"
 
+	drivev2 "google.golang.org/api/drive/v2"
 	"google.golang.org/api/drive/v3"
+	gapi "google.golang.org/api/googleapi"
 	"google.golang.org/api/option"
+
+	gogapi "github.com/steipete/gogcli/internal/googleapi"
 )
 
 func TestDriveUpload_Replace_JSON(t *testing.T) {
@@ -37,6 +41,9 @@ func TestDriveUpload_Replace_JSON(t *testing.T) {
 			return
 		case strings.HasPrefix(r.URL.Path, "/upload/drive/v3/files/") && r.Method == http.MethodPatch:
 			sawPatch = true
+			if got := r.Header.Get("If-Match"); got != "" {
+				t.Errorf("unexpected If-Match header for unconditional replacement: %q", got)
+			}
 			id := strings.TrimPrefix(r.URL.Path, "/upload/drive/v3/files/")
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]any{
@@ -319,6 +326,438 @@ func TestDriveUpload_Replace_KeepRevisionForeverAndMimeType(t *testing.T) {
 	if !sawMimeType {
 		t.Fatalf("expected upload body to include custom mime type %q", customMimeType)
 	}
+}
+
+func TestDriveUpload_IfVersionValidationAndDryRun(t *testing.T) {
+	local := writeDriveUploadReplaceTestFile(t)
+
+	t.Run("accepted with replace and included in dry-run", func(t *testing.T) {
+		var out bytes.Buffer
+		ctx := newCmdRuntimeJSONOutputContext(t, &out, io.Discard)
+		err := runKong(t, &DriveUploadCmd{}, []string{local, "--replace", "file1", "--if-version", "42"}, ctx, &RootFlags{DryRun: true})
+		if got := ExitCode(err); got != 0 {
+			t.Fatalf("expected successful dry-run, got exit code %d (err=%v)", got, err)
+		}
+
+		var payload struct {
+			Request map[string]any `json:"request"`
+		}
+		if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+			t.Fatalf("Unmarshal: %v (out=%q)", err, out.String())
+		}
+		if got := payload.Request["if_version"]; got != float64(42) {
+			t.Fatalf("if_version = %#v, want 42", got)
+		}
+	})
+
+	t.Run("unconditional dry-run remains compatible", func(t *testing.T) {
+		var out bytes.Buffer
+		ctx := newCmdRuntimeJSONOutputContext(t, &out, io.Discard)
+		err := runKong(t, &DriveUploadCmd{}, []string{local, "--replace", "file1"}, ctx, &RootFlags{DryRun: true})
+		if got := ExitCode(err); got != 0 {
+			t.Fatalf("expected successful dry-run, got exit code %d (err=%v)", got, err)
+		}
+
+		var payload struct {
+			Request map[string]any `json:"request"`
+		}
+		if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+			t.Fatalf("Unmarshal: %v (out=%q)", err, out.String())
+		}
+		if _, ok := payload.Request["if_version"]; ok {
+			t.Fatalf("unconditional dry-run unexpectedly included if_version: %#v", payload.Request)
+		}
+	})
+
+	for _, tc := range []struct {
+		name string
+		cmd  DriveUploadCmd
+		want string
+	}{
+		{
+			name: "requires replace",
+			cmd:  DriveUploadCmd{LocalPath: local, IfVersion: driveUploadVersionPtr(42)},
+			want: "--if-version requires --replace",
+		},
+		{
+			name: "zero version",
+			cmd:  DriveUploadCmd{LocalPath: local, ReplaceFileID: "file1", IfVersion: driveUploadVersionPtr(0)},
+			want: "positive integer",
+		},
+		{
+			name: "negative version",
+			cmd:  DriveUploadCmd{LocalPath: local, ReplaceFileID: "file1", IfVersion: driveUploadVersionPtr(-1)},
+			want: "positive integer",
+		},
+		{
+			name: "existing parent incompatibility",
+			cmd:  DriveUploadCmd{LocalPath: local, Parent: "folder1", ReplaceFileID: "file1", IfVersion: driveUploadVersionPtr(42)},
+			want: "--parent cannot be combined with --replace",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.cmd.Run(newCmdRuntimeOutputContext(t, io.Discard, io.Discard), &RootFlags{})
+			if got := ExitCode(err); got != 2 {
+				t.Fatalf("expected usage exit code 2, got %d (err=%v)", got, err)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %q, want substring %q", err, tc.want)
+			}
+		})
+	}
+
+	for _, value := range []string{"", "not-a-version"} {
+		t.Run("parse rejects "+strconv.Quote(value), func(t *testing.T) {
+			_ = captureStderr(t, func() {
+				err := Execute([]string{"--dry-run", "drive", "upload", local, "--replace", "file1", "--if-version", value})
+				if got := ExitCode(err); got != 2 {
+					t.Fatalf("expected usage exit code 2, got %d (err=%v)", got, err)
+				}
+			})
+		})
+	}
+}
+
+func TestDriveUpload_ConditionalReplace_MatchingVersionUsesETag(t *testing.T) {
+	const etag = `"etag-42"`
+	var updateCount int
+	var ifMatch string
+	svc := newDriveUploadReplaceTestService(t, false, func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimPrefix(r.URL.Path, "/drive/v2")
+		switch {
+		case strings.HasPrefix(path, "/files/") && r.Method == http.MethodGet:
+			fields := r.URL.Query().Get("fields")
+			if !strings.Contains(fields, "version") || !strings.Contains(fields, "etag") {
+				t.Errorf("metadata fields %q do not request version and ETag", fields)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":       "file1",
+				"mimeType": "application/pdf",
+				"version":  "42",
+				"etag":     etag,
+			})
+		case strings.HasPrefix(r.URL.Path, "/upload/drive/v2/files/") && r.Method == http.MethodPut:
+			updateCount++
+			ifMatch = r.Header.Get("If-Match")
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":       "file1",
+				"title":    "Existing.pdf",
+				"mimeType": "application/pdf",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	ctx := withDriveV2TestService(newCmdRuntimeOutputContext(t, io.Discard, io.Discard), svc)
+	err := runKong(t, &DriveUploadCmd{}, []string{writeDriveUploadReplaceTestFile(t), "--replace", "file1", "--if-version", "42"}, ctx, &RootFlags{Account: "a@b.com", Force: true})
+	if err != nil {
+		t.Fatalf("conditional replace: %v", err)
+	}
+	if updateCount != 1 {
+		t.Fatalf("update count = %d, want 1", updateCount)
+	}
+	if ifMatch != etag {
+		t.Fatalf("If-Match = %q, want %q", ifMatch, etag)
+	}
+}
+
+func TestDriveUpload_ConditionalReplace_StaleVersionStopsBeforePatch(t *testing.T) {
+	var updateCount int
+	svc := newDriveUploadReplaceTestService(t, false, func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimPrefix(r.URL.Path, "/drive/v2")
+		switch {
+		case strings.HasPrefix(path, "/files/") && r.Method == http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":       "file1",
+				"mimeType": "application/pdf",
+				"version":  "43",
+				"etag":     `"etag-43"`,
+			})
+		case strings.HasPrefix(r.URL.Path, "/upload/drive/v2/files/") && r.Method == http.MethodPut:
+			updateCount++
+			http.Error(w, "unexpected update", http.StatusInternalServerError)
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	ctx := withDriveV2TestService(newCmdRuntimeOutputContext(t, io.Discard, io.Discard), svc)
+	err := runKong(t, &DriveUploadCmd{}, []string{writeDriveUploadReplaceTestFile(t), "--replace", "file1", "--if-version", "42"}, ctx, &RootFlags{Account: "a@b.com", Force: true})
+	if err == nil {
+		t.Fatal("expected conflict")
+	}
+	for _, want := range []string{"conflict", "expected version 42", "current version is 43", "re-read"} {
+		if !strings.Contains(strings.ToLower(err.Error()), want) {
+			t.Fatalf("error %q does not contain %q", err, want)
+		}
+	}
+	if updateCount != 0 {
+		t.Fatalf("update count = %d, want 0", updateCount)
+	}
+}
+
+func TestDriveUpload_ConditionalReplace_PreconditionFailureIsConflict(t *testing.T) {
+	const etag = `"etag-before-race"`
+	var updateCount int
+	svc := newDriveUploadReplaceTestService(t, true, func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimPrefix(r.URL.Path, "/drive/v2")
+		switch {
+		case strings.HasPrefix(path, "/files/") && r.Method == http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":       "file1",
+				"mimeType": "application/pdf",
+				"version":  "42",
+				"etag":     etag,
+			})
+		case strings.HasPrefix(r.URL.Path, "/upload/drive/v2/files/") && r.Method == http.MethodPut:
+			updateCount++
+			if got := r.Header.Get("If-Match"); got != etag {
+				t.Errorf("If-Match = %q, want %q", got, etag)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusPreconditionFailed)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"error": map[string]any{
+					"code":    http.StatusPreconditionFailed,
+					"message": "condition not met",
+					"errors": []map[string]any{{
+						"reason": "conditionNotMet",
+					}},
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	var out bytes.Buffer
+	ctx := withDriveV2TestService(newCmdRuntimeOutputContext(t, &out, io.Discard), svc)
+	err := runKong(t, &DriveUploadCmd{}, []string{writeDriveUploadReplaceTestFile(t), "--replace", "file1", "--if-version", "42"}, ctx, &RootFlags{Account: "a@b.com", Force: true})
+	if err == nil {
+		t.Fatal("expected conflict")
+	}
+	for _, want := range []string{"conflict", "changed after metadata was read", "not applied", "re-read"} {
+		if !strings.Contains(strings.ToLower(err.Error()), want) {
+			t.Fatalf("error %q does not contain %q", err, want)
+		}
+	}
+	if updateCount != 1 {
+		t.Fatalf("update count = %d, want exactly 1", updateCount)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("unexpected success output: %q", out.String())
+	}
+}
+
+func TestDriveUpload_ConditionalReplace_RetryableFailureIsNotRetried(t *testing.T) {
+	const etag = `"etag-before-write"`
+	var getCount int
+	var updateCount int
+	var fallbackCount int
+	svc := newDriveUploadReplaceTestService(t, true, func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimPrefix(r.URL.Path, "/drive/v2")
+		switch {
+		case strings.HasPrefix(path, "/files/") && r.Method == http.MethodGet:
+			getCount++
+			if getCount == 1 {
+				http.Error(w, "retry metadata read", http.StatusTooManyRequests)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":       "file1",
+				"mimeType": "application/pdf",
+				"version":  "42",
+				"etag":     etag,
+			})
+		case strings.HasPrefix(r.URL.Path, "/upload/drive/v2/files/") && r.Method == http.MethodPut:
+			updateCount++
+			if got := r.Header.Get("If-Match"); got != etag {
+				fallbackCount++
+			}
+			w.Header().Set("Content-Type", "application/json")
+			if updateCount == 1 {
+				http.Error(w, "ambiguous server failure", http.StatusInternalServerError)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":       "file1",
+				"title":    "Existing.pdf",
+				"mimeType": "application/pdf",
+			})
+		case r.Method == http.MethodPut || r.Method == http.MethodPatch || r.Method == http.MethodPost:
+			fallbackCount++
+			http.Error(w, "unexpected fallback", http.StatusInternalServerError)
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	var out bytes.Buffer
+	ctx := withDriveV2TestService(newCmdRuntimeOutputContext(t, &out, io.Discard), svc)
+	err := runKong(t, &DriveUploadCmd{}, []string{writeDriveUploadReplaceTestFile(t), "--replace", "file1", "--if-version", "42"}, ctx, &RootFlags{Account: "a@b.com", Force: true})
+	if err == nil {
+		t.Fatal("expected server error")
+	}
+	if getCount != 2 {
+		t.Fatalf("metadata GET count = %d, want 2 to preserve normal retries", getCount)
+	}
+	if updateCount != 1 {
+		t.Fatalf("update count = %d, want exactly 1", updateCount)
+	}
+	if fallbackCount != 0 {
+		t.Fatalf("fallback count = %d, want 0", fallbackCount)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("unexpected success output: %q", out.String())
+	}
+}
+
+func TestDriveUpload_ConditionalReplace_LargeMediaUsesSingleRequest(t *testing.T) {
+	const etag = `"etag-large"`
+	var updateCount int
+	var uploadType string
+	svc := newDriveUploadReplaceTestService(t, true, func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimPrefix(r.URL.Path, "/drive/v2")
+		switch {
+		case strings.HasPrefix(path, "/files/") && r.Method == http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":       "file1",
+				"mimeType": "application/pdf",
+				"version":  "42",
+				"etag":     etag,
+			})
+		case strings.HasPrefix(r.URL.Path, "/upload/drive/v2/files/") && r.Method == http.MethodPut:
+			updateCount++
+			uploadType = r.URL.Query().Get("uploadType")
+			if got := r.Header.Get("If-Match"); got != etag {
+				t.Errorf("If-Match = %q, want %q", got, etag)
+			}
+			if _, err := io.Copy(io.Discard, r.Body); err != nil {
+				t.Errorf("read upload body: %v", err)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":       "file1",
+				"title":    "Large.pdf",
+				"mimeType": "application/pdf",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	local := filepath.Join(t.TempDir(), "large.pdf")
+	if err := os.WriteFile(local, nil, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if err := os.Truncate(local, int64(gapi.DefaultUploadChunkSize)+1); err != nil {
+		t.Fatalf("Truncate: %v", err)
+	}
+
+	ctx := withDriveV2TestService(newCmdRuntimeOutputContext(t, io.Discard, io.Discard), svc)
+	err := runKong(t, &DriveUploadCmd{}, []string{local, "--replace", "file1", "--if-version", "42"}, ctx, &RootFlags{Account: "a@b.com", Force: true})
+	if err != nil {
+		t.Fatalf("conditional replace: %v", err)
+	}
+	if updateCount != 1 {
+		t.Fatalf("update count = %d, want exactly 1", updateCount)
+	}
+	if uploadType != "multipart" {
+		t.Fatalf("uploadType = %q, want multipart single-request upload", uploadType)
+	}
+}
+
+func TestDriveUpload_ConditionalReplace_MissingPreconditionMaterialFailsClosed(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		version     string
+		etag        string
+		wantMessage string
+	}{
+		{name: "missing version", etag: `"etag-42"`, wantMessage: "did not include a version"},
+		{name: "missing ETag", version: "42", wantMessage: "did not include an ETag"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var updateCount int
+			svc := newDriveUploadReplaceTestService(t, false, func(w http.ResponseWriter, r *http.Request) {
+				path := strings.TrimPrefix(r.URL.Path, "/drive/v2")
+				switch {
+				case strings.HasPrefix(path, "/files/") && r.Method == http.MethodGet:
+					w.Header().Set("Content-Type", "application/json")
+					response := map[string]any{
+						"id":       "file1",
+						"mimeType": "application/pdf",
+					}
+					if tc.version != "" {
+						response["version"] = tc.version
+					}
+					if tc.etag != "" {
+						response["etag"] = tc.etag
+					}
+					_ = json.NewEncoder(w).Encode(response)
+				case strings.HasPrefix(r.URL.Path, "/upload/drive/v2/files/") && r.Method == http.MethodPut:
+					updateCount++
+					http.Error(w, "unexpected update", http.StatusInternalServerError)
+				default:
+					http.NotFound(w, r)
+				}
+			})
+
+			ctx := withDriveV2TestService(newCmdRuntimeOutputContext(t, io.Discard, io.Discard), svc)
+			err := runKong(t, &DriveUploadCmd{}, []string{writeDriveUploadReplaceTestFile(t), "--replace", "file1", "--if-version", "42"}, ctx, &RootFlags{Account: "a@b.com", Force: true})
+			if err == nil || !strings.Contains(err.Error(), tc.wantMessage) {
+				t.Fatalf("error = %v, want substring %q", err, tc.wantMessage)
+			}
+			if !strings.Contains(err.Error(), "no update was attempted") {
+				t.Fatalf("error should state that no update was attempted: %v", err)
+			}
+			if updateCount != 0 {
+				t.Fatalf("update count = %d, want 0", updateCount)
+			}
+		})
+	}
+}
+
+func driveUploadVersionPtr(version int64) *int64 {
+	return &version
+}
+
+func writeDriveUploadReplaceTestFile(t *testing.T) string {
+	t.Helper()
+	local := filepath.Join(t.TempDir(), "upload.pdf")
+	if err := os.WriteFile(local, []byte("%PDF-1.4"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	return local
+}
+
+func newDriveUploadReplaceTestService(t *testing.T, withRetryTransport bool, handler http.HandlerFunc) *drivev2.Service {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	client := srv.Client()
+	if withRetryTransport {
+		retryTransport := gogapi.NewRetryTransport(client.Transport)
+		retryTransport.BaseDelay = 0
+		client = &http.Client{Transport: retryTransport}
+	}
+	svc, err := drivev2.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(client),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	return svc
 }
 
 func TestDriveUpload_Create_KeepRevisionForever(t *testing.T) {

--- a/internal/cmd/runtime_services.go
+++ b/internal/cmd/runtime_services.go
@@ -14,6 +14,7 @@ import (
 	"google.golang.org/api/classroom/v1"
 	"google.golang.org/api/cloudidentity/v1"
 	"google.golang.org/api/docs/v1"
+	drivev2 "google.golang.org/api/drive/v2"
 	"google.golang.org/api/drive/v3"
 	driveactivityapi "google.golang.org/api/driveactivity/v2"
 	drivelabelsapi "google.golang.org/api/drivelabels/v2"
@@ -75,6 +76,9 @@ func composeRuntimeGoogleServices(runtime *app.Runtime, factory googleapi.Factor
 	}
 	if services.Drive == nil {
 		services.Drive = factory.Drive
+	}
+	if services.DriveV2 == nil {
+		services.DriveV2 = factory.DriveV2
 	}
 	if services.DriveActivity == nil {
 		services.DriveActivity = factory.DriveActivity
@@ -267,6 +271,14 @@ func driveService(ctx context.Context, account string) (*drive.Service, error) {
 		return nil, serviceError(err, "drive")
 	}
 	return runtime.Services.Drive(ctx, account)
+}
+
+func driveV2Service(ctx context.Context, account string) (*drivev2.Service, error) {
+	runtime, err := runtimeWithService(ctx, "drive v2")
+	if err != nil || runtime.Services.DriveV2 == nil {
+		return nil, serviceError(err, "drive v2")
+	}
+	return runtime.Services.DriveV2(ctx, account)
 }
 
 func driveActivityService(ctx context.Context, account string) (*driveactivityapi.Service, error) {

--- a/internal/cmd/service_helpers.go
+++ b/internal/cmd/service_helpers.go
@@ -6,6 +6,7 @@ import (
 	"google.golang.org/api/calendar/v3"
 	"google.golang.org/api/classroom/v1"
 	"google.golang.org/api/docs/v1"
+	drivev2 "google.golang.org/api/drive/v2"
 	"google.golang.org/api/drive/v3"
 	"google.golang.org/api/driveactivity/v2"
 	"google.golang.org/api/gmail/v1"
@@ -23,6 +24,10 @@ func requireDocsService(ctx context.Context, flags *RootFlags) (*docs.Service, e
 
 func requireDriveService(ctx context.Context, flags *RootFlags) (string, *drive.Service, error) {
 	return requireGoogleService(ctx, flags, driveService)
+}
+
+func requireDriveV2Service(ctx context.Context, flags *RootFlags) (string, *drivev2.Service, error) {
+	return requireGoogleService(ctx, flags, driveV2Service)
 }
 
 func requireDriveActivityService(ctx context.Context, flags *RootFlags) (string, *driveactivity.Service, error) {

--- a/internal/googleapi/drive.go
+++ b/internal/googleapi/drive.go
@@ -3,6 +3,7 @@ package googleapi
 import (
 	"context"
 
+	drivev2 "google.golang.org/api/drive/v2"
 	"google.golang.org/api/drive/v3"
 
 	"github.com/steipete/gogcli/internal/googleauth"
@@ -10,4 +11,8 @@ import (
 
 func NewDrive(ctx context.Context, email string) (*drive.Service, error) {
 	return newGoogleServiceForAccount(ctx, email, googleauth.ServiceDrive, "drive", drive.NewService)
+}
+
+func NewDriveV2(ctx context.Context, email string) (*drivev2.Service, error) {
+	return newGoogleServiceForAccount(ctx, email, googleauth.ServiceDrive, "drive", drivev2.NewService)
 }

--- a/internal/googleapi/factory.go
+++ b/internal/googleapi/factory.go
@@ -12,6 +12,7 @@ import (
 	"google.golang.org/api/classroom/v1"
 	"google.golang.org/api/cloudidentity/v1"
 	"google.golang.org/api/docs/v1"
+	drivev2 "google.golang.org/api/drive/v2"
 	"google.golang.org/api/drive/v3"
 	driveactivity "google.golang.org/api/driveactivity/v2"
 	drivelabels "google.golang.org/api/drivelabels/v2"
@@ -99,6 +100,10 @@ func (f Factory) DocsHTTP(ctx context.Context, account string) (*http.Client, er
 
 func (f Factory) Drive(ctx context.Context, account string) (*drive.Service, error) {
 	return NewDrive(f.withAuth(ctx), account)
+}
+
+func (f Factory) DriveV2(ctx context.Context, account string) (*drivev2.Service, error) {
+	return NewDriveV2(f.withAuth(ctx), account)
 }
 
 func (f Factory) DriveActivity(ctx context.Context, account string) (*driveactivity.Service, error) {

--- a/internal/googleapi/services_more_test.go
+++ b/internal/googleapi/services_more_test.go
@@ -29,6 +29,10 @@ func TestNewServicesWithStoredToken(t *testing.T) {
 		t.Fatalf("NewDrive: %v", err)
 	}
 
+	if _, err := NewDriveV2(ctx, "a@b.com"); err != nil {
+		t.Fatalf("NewDriveV2: %v", err)
+	}
+
 	if _, err := NewDocs(ctx, "a@b.com"); err != nil {
 		t.Fatalf("NewDocs: %v", err)
 	}

--- a/internal/googleapi/transport.go
+++ b/internal/googleapi/transport.go
@@ -22,6 +22,24 @@ const (
 
 var errRequestBodyTooLarge = errors.New("request body too large to buffer for retry")
 
+type retriesDisabledContextKey struct{}
+
+// WithoutRetries marks requests made with ctx as single-attempt operations.
+// The configured base transport still handles authentication.
+func WithoutRetries(ctx context.Context) context.Context {
+	return context.WithValue(ctx, retriesDisabledContextKey{}, true)
+}
+
+func retriesDisabled(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+
+	disabled, _ := ctx.Value(retriesDisabledContextKey{}).(bool)
+
+	return disabled
+}
+
 // RetryTransport wraps an http.RoundTripper with retry logic for
 // rate limits (429) and server errors (5xx).
 type RetryTransport struct {
@@ -53,6 +71,7 @@ func (t *RetryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if t.CircuitBreaker != nil && t.CircuitBreaker.IsOpen() {
 		return nil, &CircuitBreakerError{}
 	}
+	retryDisabled := retriesDisabled(req.Context())
 
 	replayable, err := ensureReplayableBody(req)
 	if err != nil {
@@ -94,7 +113,7 @@ func (t *RetryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 		// Rate limit (429)
 		if resp.StatusCode == http.StatusTooManyRequests {
-			if retries429 >= t.MaxRetries429 || !replayable {
+			if retryDisabled || retries429 >= t.MaxRetries429 || !replayable {
 				return resp, nil // Return the 429 response after max retries
 			}
 
@@ -121,7 +140,7 @@ func (t *RetryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 				t.CircuitBreaker.RecordFailure()
 			}
 
-			if retries5xx >= t.MaxRetries5xx || !replayable {
+			if retryDisabled || retries5xx >= t.MaxRetries5xx || !replayable {
 				return resp, nil
 			}
 
@@ -140,7 +159,7 @@ func (t *RetryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 			continue
 		}
 
-		if resp.StatusCode == http.StatusForbidden && t.RefreshAuth != nil && !retriedAuth && replayable {
+		if resp.StatusCode == http.StatusForbidden && t.RefreshAuth != nil && !retriedAuth && replayable && !retryDisabled {
 			insufficientScopes, detectErr := responseIndicatesInsufficientScopes(resp)
 			if detectErr != nil {
 				slog.Debug("could not inspect auth failure response for retry", "err", detectErr)

--- a/internal/googleapi/transport_more_test.go
+++ b/internal/googleapi/transport_more_test.go
@@ -229,6 +229,45 @@ func TestRetryTransportRoundTripRetries5xx(t *testing.T) {
 	}
 }
 
+func TestRetryTransportRoundTripWithoutRetries(t *testing.T) {
+	for _, status := range []int{http.StatusTooManyRequests, http.StatusInternalServerError} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			calls := 0
+			base := roundTripFunc(func(*http.Request) (*http.Response, error) {
+				calls++
+				return newTestResponse(status, "retryable failure"), nil
+			})
+			rt := &RetryTransport{
+				Base:          base,
+				MaxRetries429: 1,
+				MaxRetries5xx: 1,
+				BaseDelay:     0,
+			}
+
+			ctx := WithoutRetries(context.Background())
+
+			req, err := http.NewRequestWithContext(ctx, http.MethodPut, "http://example.com", strings.NewReader("payload"))
+			if err != nil {
+				t.Fatalf("new request: %v", err)
+			}
+
+			resp, err := rt.RoundTrip(req)
+			if err != nil {
+				t.Fatalf("round trip: %v", err)
+			}
+			_ = resp.Body.Close()
+
+			if resp.StatusCode != status {
+				t.Fatalf("status = %d, want %d", resp.StatusCode, status)
+			}
+
+			if calls != 1 {
+				t.Fatalf("calls = %d, want exactly 1", calls)
+			}
+		})
+	}
+}
+
 func TestRetryTransportRefreshesAuthOnceForInsufficientScope403(t *testing.T) {
 	tokenSource := &refreshableTestTokenSource{token: "stale-token"}
 	var gotBodies []string


### PR DESCRIPTION
## Summary

Add opt-in atomic conflict protection to `gog drive upload --replace`.

Callers that previously read a Drive file can pass its version:

```bash
gog drive upload file.pdf --replace FILE_ID --if-version VERSION
```

Existing replacement remains available and unchanged:

```bash
gog drive upload file.pdf --replace FILE_ID
```

## Motivation

Replacement previously performed a metadata read followed by an unconditional media update. If another collaborator changed the file between those requests, the newer content could be overwritten.

A separate version comparison is insufficient because the file can still change after the comparison and before the update. The final media update must carry an atomic server-side precondition.

## Implementation

Conditional replacement:

1. Reads the current Drive `version` and ETag.
2. Fails closed if either value is missing.
3. Compares the current version with `--if-version`.
4. Sends the retrieved ETag as `If-Match` on one media `Files.Update` request.
5. Reports HTTP 412 as a conflict without retrying or falling back to an unconditional update.

Drive v3 does not expose the file ETag needed for this precondition. Therefore, only the opt-in conditional path uses Drive v2, which exposes both `version` and `etag`. Normal uploads and unconditional replacement remain on Drive v3.

The Drive v2 service is created through gog’s existing authenticated Google API service factory. OAuth tokens are not exported or exposed, and no second authentication implementation is introduced.

The Drive v2 media update uses HTTP `PUT` rather than the v3 `PATCH`, but the `If-Match` precondition is attached to the final media write and closes the check/write race atomically.

## Design tradeoff

Drive v3 does not expose the file ETag needed for an atomic `If-Match` precondition. This implementation therefore uses Drive v2 only for the opt-in conditional replacement path.

Google currently documents Drive v2 without an announced sunset date, but recommends v3 for general use. If v2 is deprecated later, this path will need an alternative atomic precondition mechanism.

The v2 dependency is isolated from normal uploads and unconditional v3 replacement. Conditional replacement also fails closed rather than falling back to an unsafe update.

## Conflict behavior

- A version mismatch stops before the media update and reports a conflict.
- A missing version or ETag fails closed and performs no update.
- HTTP 412 reports that the file changed after metadata was read and tells the caller to re-read and reapply the edit.
- Conditional replacement is attempted once.
- It never retries or falls back to an unconditional update.
- Existing `--replace` behavior remains unconditional when `--if-version` is absent.

## Backward compatibility

The new behavior is opt-in. Existing callers can continue using:

```bash
gog drive upload file.pdf --replace FILE_ID
```

without supplying a version and without any change to current output or replacement behavior.

## Tests

Added `httptest` coverage for:

- existing unconditional replacement compatibility;
- flag parsing and validation;
- incompatible option combinations;
- conditional dry-run output;
- matching versions and exact `If-Match` propagation;
- stale versions stopping before the update;
- HTTP 412 conflicts without retry or success output;
- missing version and ETag fail-closed behavior;
- the existing authentication service boundary.

Validation completed:

- targeted Drive upload and service tests;
- `make fmt`;
- `make test`;
- `make ci`.

`make ci` completed successfully with:

- lint: `0 issues`;
- all Go tests passing;
- all Node tests passing;
- generated command documentation passing;
- documentation site, link, and coverage checks passing.

## Credential-backed Drive evidence

PR head `779c18a6a14e681b25c9ae7081c9be22214121fb` was validated against Google Drive on July 19, 2026 using the local fork and one disposable text file.

- A conditional replacement with the matching expected version succeeded and preserved the file ID and name.
- Drive advanced the file version from `3` to `6`, and the downloaded replacement matched the local payload byte-for-byte.
- A second replacement using the stale expected version `3` reported a conflict against current version `6`.
- After the stale conflict, the Drive version, modification time, size, and downloaded SHA-256 remained unchanged; the rejected payload was not applied.
- The focused `httptest` suite also passed for exact `If-Match` propagation, HTTP 412 conflict handling, single-attempt media updates, missing-precondition fail-closed behavior, and prevention of unconditional retry or fallback.
- The disposable Drive file was moved to Trash after validation.

Drive version values are monotonic but not necessarily consecutive. Google documents that the counter reflects every server-side change, including changes not visible to the user. The conditional implementation relies only on exact equality and does not assume that a successful replacement increments the version by one.

The account and Drive file ID are redacted from the posted evidence. gog’s existing authentication boundary was used; no OAuth token, client secret, authorization code, or credential material was printed or recorded.

## References

- [Drive v2 File resource](https://developers.google.com/workspace/drive/api/reference/rest/v2/files)
- [Drive v2 `files.update`](https://developers.google.com/workspace/drive/api/reference/rest/v2/files/update)
- [Drive API v2 and v3 comparison](https://developers.google.com/workspace/drive/api/guides/v3versusv2)
- [Google ETag protocol behavior](https://developers.google.com/gdata/docs/2.0/reference)
