### PR TITLE
[codex] acknowledge terminal Gmail OAuth watch failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.34.2 - 2026-07-27
 
 - Security: update gRPC-Go, PostCSS, and Sharp/libvips to patched releases, clearing three high-severity dependency alerts. (#940)
+- Gmail: acknowledge terminal watch OAuth failures only after durably recording reauthentication recovery state, preserving the last processed history cursor for catch-up after renewal. (#930) — thanks @litang9.
 - Gmail: mark unsent drafts in human-readable message and thread output while preserving JSON and plain output contracts. (#931, #932) — thanks @MaxGhenis.
 - Gmail: report exact file-input byte counts in compose dry-run output, including forwarded-message notes with trailing newlines. (#936, #937) — thanks @chrischall.
 - Setup: replace obsolete Google Cloud API enablement links with direct API Library URLs while preserving project-scoped recovery hints. (#933) — thanks @LinXunFeng.

--- a/docs/watch.md
+++ b/docs/watch.md
@@ -137,6 +137,9 @@ Schema (v1):
   "providerExpirationMs": 1730000000000,
   "renewAfterMs": 1730000001000,
   "updatedAtMs": 1730000001000,
+  "authRecoveryPending": true,
+  "authFailureAtMs": 1730000001000,
+  "authFailureReason": "reauthentication_required",
   "hook": {
     "url": "http://127.0.0.1:18789/hooks/agent",
     "token": "...",
@@ -211,6 +214,19 @@ configured `--hook-url`.
 - Pull mode treats invalid Pub/Sub messages as poison messages: log and
   acknowledge them rather than redelivering forever. Wrong-account
   notifications are also terminal in both modes.
+- Expired or revoked Gmail OAuth credentials are terminal for the current
+  notification. Push and pull acknowledge `invalid_grant` failures only after
+  durably marking auth recovery as pending, without advancing the stored Gmail
+  history cursor. This prevents Pub/Sub redelivery storms without discarding the
+  catch-up position. If the recovery marker cannot be saved, the notification
+  remains retryable.
+- After re-authenticating, run `gog gmail watch renew` (or rerun `watch start`).
+  A successful watch registration preserves the last processed history ID while
+  recovery is pending. Gmail sends an immediate notification for the new watch,
+  which catches up from that retained cursor without waiting for another mailbox
+  change. Successful history processing clears the recovery marker. Use
+  `gog gmail watch status` to inspect `auth_recovery_pending`,
+  `auth_failure_at`, and `auth_failure_reason`.
 - Hook failures are retryable. `gog` records the hook failure status, preserves
   the pre-hook watch cursor, and returns a delivery failure to Pub/Sub. This
   lets Pub/Sub redeliver the notification after the downstream agent or gateway

--- a/internal/cmd/gmail_watch_cmds.go
+++ b/internal/cmd/gmail_watch_cmds.go
@@ -14,6 +14,7 @@ import (
 	"google.golang.org/api/idtoken"
 
 	"github.com/steipete/gogcli/internal/authclient"
+	"github.com/steipete/gogcli/internal/gmailwatch"
 	"github.com/steipete/gogcli/internal/outfmt"
 	"github.com/steipete/gogcli/internal/ui"
 )
@@ -99,13 +100,13 @@ func (c *GmailWatchStartCmd) Run(ctx context.Context, kctx *kong.Context, flags 
 		return err
 	}
 	if err := store.Update(func(s *gmailWatchState) error {
-		*s = state
+		gmailwatch.ApplyWatchRegistration(s, state)
 		return nil
 	}); err != nil {
 		return err
 	}
 
-	return writeWatchState(ctx, state, false)
+	return writeWatchState(ctx, store.Get(), false)
 }
 
 type GmailWatchStatusCmd struct {
@@ -171,13 +172,13 @@ func (c *GmailWatchRenewCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if err := store.Update(func(s *gmailWatchState) error {
-		*s = updated
+		gmailwatch.ApplyWatchRegistration(s, updated)
 		return nil
 	}); err != nil {
 		return err
 	}
 
-	return writeWatchState(ctx, updated, false)
+	return writeWatchState(ctx, store.Get(), false)
 }
 
 type GmailWatchStopCmd struct{}
@@ -496,6 +497,15 @@ func writeWatchState(ctx context.Context, state gmailWatchState, showSecrets boo
 	}
 	if state.RateLimitedUntilMs > 0 {
 		u.Out().Linef("rate_limited_until\t%s", formatUnixMillis(state.RateLimitedUntilMs))
+	}
+	if state.AuthRecoveryPending {
+		u.Out().Linef("auth_recovery_pending\ttrue")
+	}
+	if state.AuthFailureAtMs > 0 {
+		u.Out().Linef("auth_failure_at\t%s", formatUnixMillis(state.AuthFailureAtMs))
+	}
+	if state.AuthFailureReason != "" {
+		u.Out().Linef("auth_failure_reason\t%s", state.AuthFailureReason)
 	}
 	return nil
 }

--- a/internal/cmd/gmail_watch_cmds_more_test.go
+++ b/internal/cmd/gmail_watch_cmds_more_test.go
@@ -40,12 +40,16 @@ func TestGmailWatchRenewAndStop_JSON(t *testing.T) {
 	store := newGmailWatchTestStore(t, "a@b.com")
 	_ = store.Update(func(s *gmailWatchState) error {
 		*s = gmailWatchState{
-			Account:      "a@b.com",
-			Topic:        "projects/p/topics/t",
-			Labels:       []string{"INBOX"},
-			HistoryID:    "100",
-			RenewAfterMs: time.Now().Add(10 * time.Minute).UnixMilli(),
-			ExpirationMs: time.Now().Add(20 * time.Minute).UnixMilli(),
+			Account:             "a@b.com",
+			Topic:               "projects/p/topics/t",
+			Labels:              []string{"INBOX"},
+			HistoryID:           "100",
+			LastPushMessageID:   "push-before",
+			RenewAfterMs:        time.Now().Add(10 * time.Minute).UnixMilli(),
+			ExpirationMs:        time.Now().Add(20 * time.Minute).UnixMilli(),
+			AuthRecoveryPending: true,
+			AuthFailureAtMs:     123,
+			AuthFailureReason:   "reauthentication_required",
 		}
 		return nil
 	})
@@ -54,6 +58,13 @@ func TestGmailWatchRenewAndStop_JSON(t *testing.T) {
 	ctx := withGmailTestService(newCmdRuntimeJSONOutputContext(t, io.Discard, io.Discard), svc)
 	if err := runKong(t, &GmailWatchRenewCmd{}, []string{"--ttl", "3600"}, ctx, flags); err != nil {
 		t.Fatalf("renew: %v", err)
+	}
+	renewed := loadGmailWatchTestStore(t, "a@b.com").Get()
+	if renewed.HistoryID != "100" || renewed.LastPushMessageID != "push-before" || !renewed.AuthRecoveryPending {
+		t.Fatalf("renew replaced recovery progress: %#v", renewed)
+	}
+	if renewed.ExpirationMs != 1730000000000 {
+		t.Fatalf("renew did not update registration: %#v", renewed)
 	}
 	if err := runKong(t, &GmailWatchStopCmd{}, []string{}, ctx, flags); err != nil {
 		t.Fatalf("stop: %v", err)
@@ -70,10 +81,13 @@ func TestGmailWatchStatusAndStop_Text(t *testing.T) {
 	store := newGmailWatchTestStore(t, "a@b.com")
 	_ = store.Update(func(s *gmailWatchState) error {
 		*s = gmailWatchState{
-			Account:   "a@b.com",
-			Topic:     "projects/p/topics/t",
-			HistoryID: "100",
-			Hook:      &gmailWatchHook{URL: "http://example.com/hook"},
+			Account:             "a@b.com",
+			Topic:               "projects/p/topics/t",
+			HistoryID:           "100",
+			Hook:                &gmailWatchHook{URL: "http://example.com/hook"},
+			AuthRecoveryPending: true,
+			AuthFailureAtMs:     123,
+			AuthFailureReason:   "reauthentication_required",
 		}
 		return nil
 	})
@@ -98,7 +112,10 @@ func TestGmailWatchStatusAndStop_Text(t *testing.T) {
 	if err := runKong(t, &GmailWatchStopCmd{}, []string{}, ctx, flags); err != nil {
 		t.Fatalf("stop: %v", err)
 	}
-	if !strings.Contains(out.String(), "account") || !strings.Contains(out.String(), "stopped") {
+	if !strings.Contains(out.String(), "account") ||
+		!strings.Contains(out.String(), "auth_recovery_pending\ttrue") ||
+		!strings.Contains(out.String(), "auth_failure_reason\treauthentication_required") ||
+		!strings.Contains(out.String(), "stopped") {
 		t.Fatalf("unexpected output: %q", out.String())
 	}
 }

--- a/internal/cmd/gmail_watch_processor.go
+++ b/internal/cmd/gmail_watch_processor.go
@@ -28,6 +28,7 @@ func (s *gmailWatchServer) watchProcessor() *gmailwatch.Processor {
 		Now:                 s.currentTime,
 		Sleep:               s.sleep,
 		IsStaleHistoryError: isStaleHistoryError,
+		IsTerminalAuthError: isTerminalGmailAuthError,
 		RateLimitUntil:      gmailWatchRateLimitUntil,
 		Logf:                s.logf,
 		Warnf:               s.warnf,

--- a/internal/cmd/gmail_watch_pull.go
+++ b/internal/cmd/gmail_watch_pull.go
@@ -276,6 +276,12 @@ func (s *gmailWatchServer) handlePullMessage(ctx context.Context, msg *gmailPubS
 		msg.Ack()
 		return
 	}
+	var authErr *gmailwatch.TerminalAuthError
+	if errors.As(err, &authErr) {
+		s.warnf("watch: Gmail authorization requires re-authentication; acknowledging pull without advancing history: %v", err)
+		msg.Ack()
+		return
+	}
 	var rateErr *gmailWatchRateLimitError
 	if errors.As(err, &rateErr) {
 		s.warnf("watch: Gmail rate limit circuit open: %v", err)

--- a/internal/cmd/gmail_watch_pull_test.go
+++ b/internal/cmd/gmail_watch_pull_test.go
@@ -13,9 +13,11 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/oauth2"
 	"google.golang.org/api/gmail/v1"
 	"google.golang.org/api/option"
 
+	"github.com/steipete/gogcli/internal/gmailwatch"
 	"github.com/steipete/gogcli/internal/googleapi"
 	"github.com/steipete/gogcli/internal/outfmt"
 	"github.com/steipete/gogcli/internal/ui"
@@ -283,6 +285,40 @@ func TestGmailWatchPullMessage_NacksGmailFailure(t *testing.T) {
 	server.handlePullMessage(context.Background(), msg)
 	if state.acked || !state.nacked {
 		t.Fatalf("gmail failure ack=%v nack=%v", state.acked, state.nacked)
+	}
+}
+
+func TestGmailWatchPullMessage_AcksTerminalAuthAndPreservesProgress(t *testing.T) {
+	store := newMemoryGmailWatchTestStore(gmailWatchState{
+		Account:           "a@b.com",
+		HistoryID:         "100",
+		LastPushMessageID: "before",
+	})
+	server := &gmailWatchServer{
+		cfg:   gmailWatchServeConfig{Account: "a@b.com"},
+		store: store,
+		newService: func(context.Context, string) (*gmail.Service, error) {
+			return nil, &oauth2.RetrieveError{
+				ErrorCode:        "invalid_grant",
+				ErrorDescription: "Token has been expired or revoked.",
+			}
+		},
+		logf:  func(string, ...any) {},
+		warnf: func(string, ...any) {},
+	}
+
+	msg, delivery := trackedPullMessage("push-1", []byte(`{"emailAddress":"a@b.com","historyId":"200"}`))
+	server.handlePullMessage(context.Background(), msg)
+
+	if !delivery.acked || delivery.nacked {
+		t.Fatalf("terminal auth ack=%v nack=%v", delivery.acked, delivery.nacked)
+	}
+	state := store.Get()
+	if state.HistoryID != "100" || state.LastPushMessageID != "before" {
+		t.Fatalf("state advanced after terminal auth failure: %#v", state)
+	}
+	if !state.AuthRecoveryPending || state.AuthFailureReason != gmailwatch.AuthFailureReasonReauthenticationRequired {
+		t.Fatalf("recovery state = %#v", state)
 	}
 }
 

--- a/internal/cmd/gmail_watch_server.go
+++ b/internal/cmd/gmail_watch_server.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/oauth2"
 	"google.golang.org/api/gmail/v1"
 	"google.golang.org/api/googleapi"
 	"google.golang.org/api/idtoken"
@@ -149,6 +150,21 @@ func isNotFoundAPIError(err error) bool {
 		return gerr.Code == http.StatusNotFound
 	}
 	return false
+}
+
+func isTerminalGmailAuthError(err error) bool {
+	var retrieveErr *oauth2.RetrieveError
+	if errors.As(err, &retrieveErr) && strings.EqualFold(strings.TrimSpace(retrieveErr.ErrorCode), "invalid_grant") {
+		return true
+	}
+
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "invalid_grant") ||
+		strings.Contains(message, "refresh_token_reused") ||
+		strings.Contains(message, "invalid refresh token") ||
+		strings.Contains(message, "token has been expired or revoked") ||
+		strings.Contains(message, "sign in again") ||
+		strings.Contains(message, "signed in again")
 }
 
 func gmailWatchRateLimitUntil(err error, now time.Time) (time.Time, bool) {

--- a/internal/cmd/gmail_watch_server_coverage_test.go
+++ b/internal/cmd/gmail_watch_server_coverage_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"golang.org/x/oauth2"
 	"google.golang.org/api/gmail/v1"
 	"google.golang.org/api/option"
 
@@ -74,6 +75,50 @@ func TestGmailWatchServer_ServeHTTP_HandlePushError(t *testing.T) {
 	server.ServeHTTP(rr, req)
 	if rr.Code != http.StatusInternalServerError {
 		t.Fatalf("status: %d", rr.Code)
+	}
+}
+
+func TestGmailWatchServer_AcknowledgesTerminalAuthAndPreservesProgress(t *testing.T) {
+	store := newMemoryGmailWatchTestStore(gmailWatchState{
+		Account:           "a@b.com",
+		HistoryID:         "100",
+		LastPushMessageID: "before",
+	})
+	server := &gmailWatchServer{
+		cfg: gmailWatchServeConfig{
+			Account:     "a@b.com",
+			Path:        "/hook",
+			SharedToken: "tok",
+		},
+		store: store,
+		newService: func(context.Context, string) (*gmail.Service, error) {
+			return nil, &oauth2.RetrieveError{
+				ErrorCode:        "invalid_grant",
+				ErrorDescription: "Token has been expired or revoked.",
+			}
+		},
+		logf:  func(string, ...any) {},
+		warnf: func(string, ...any) {},
+	}
+
+	push := pubsubPushEnvelope{}
+	push.Message.Data = base64.StdEncoding.EncodeToString([]byte(`{"emailAddress":"a@b.com","historyId":"200"}`))
+	push.Message.MessageID = "push-1"
+	body, _ := json.Marshal(push)
+
+	response := httptest.NewRecorder()
+	request := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/hook?token=tok", bytes.NewReader(body))
+	server.ServeHTTP(response, request)
+
+	if response.Code != http.StatusAccepted {
+		t.Fatalf("status = %d", response.Code)
+	}
+	state := store.Get()
+	if state.HistoryID != "100" || state.LastPushMessageID != "before" {
+		t.Fatalf("state advanced after terminal auth failure: %#v", state)
+	}
+	if !state.AuthRecoveryPending || state.AuthFailureReason != gmailwatch.AuthFailureReasonReauthenticationRequired {
+		t.Fatalf("recovery state = %#v", state)
 	}
 }
 

--- a/internal/cmd/gmail_watch_server_helpers_test.go
+++ b/internal/cmd/gmail_watch_server_helpers_test.go
@@ -6,12 +6,14 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
 	"strings"
 	"testing"
 
+	"golang.org/x/oauth2"
 	"google.golang.org/api/gmail/v1"
 	"google.golang.org/api/googleapi"
 	"google.golang.org/api/idtoken"
@@ -337,6 +339,31 @@ func TestIsNotFoundAPIError(t *testing.T) {
 		},
 	}) {
 		t.Fatalf("expected non-notfound for forbidden")
+	}
+}
+
+func TestIsTerminalGmailAuthError(t *testing.T) {
+	typed := &oauth2.RetrieveError{
+		ErrorCode:        "invalid_grant",
+		ErrorDescription: "Token has been expired or revoked.",
+	}
+	if !isTerminalGmailAuthError(fmt.Errorf("refresh access token: %w", typed)) {
+		t.Fatal("expected wrapped invalid_grant to be terminal")
+	}
+
+	for _, message := range []string{
+		"refresh_token_reused",
+		"invalid refresh token",
+		"Token has been expired or revoked.",
+		"please sign in again",
+	} {
+		if !isTerminalGmailAuthError(errors.New(message)) {
+			t.Fatalf("expected terminal auth error: %q", message)
+		}
+	}
+
+	if isTerminalGmailAuthError(errors.New("temporary network timeout")) {
+		t.Fatal("temporary failure must remain retryable")
 	}
 }
 

--- a/internal/cmd/gmail_watch_test.go
+++ b/internal/cmd/gmail_watch_test.go
@@ -98,6 +98,63 @@ func TestGmailWatchStartCmd_JSON(t *testing.T) {
 	}
 }
 
+func TestGmailWatchStartPreservesPendingAuthRecovery(t *testing.T) {
+	setWatchTestConfigHome(t)
+
+	store := newGmailWatchTestStore(t, "a@b.com")
+	if err := store.Update(func(state *gmailWatchState) error {
+		*state = gmailWatchState{
+			Account:             "a@b.com",
+			Topic:               "projects/old/topics/old",
+			HistoryID:           "100",
+			LastPushMessageID:   "push-before",
+			AuthRecoveryPending: true,
+			AuthFailureAtMs:     123,
+			AuthFailureReason:   gmailwatch.AuthFailureReasonReauthenticationRequired,
+		}
+
+		return nil
+	}); err != nil {
+		t.Fatalf("seed state: %v", err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/gmail/v1/users/me/watch") {
+			http.NotFound(w, r)
+
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"historyId":  "300",
+			"expiration": "1730000000000",
+		})
+	}))
+	defer srv.Close()
+
+	ctx := withGmailTestService(
+		newCmdRuntimeJSONOutputContext(t, io.Discard, io.Discard),
+		newGmailServiceFromServer(t, srv),
+	)
+	if err := runKong(t, &GmailWatchStartCmd{}, []string{
+		"--topic", "projects/new/topics/new",
+	}, ctx, &RootFlags{Account: "a@b.com"}); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	started := loadGmailWatchTestStore(t, "a@b.com").Get()
+	if started.Topic != "projects/new/topics/new" || started.ExpirationMs != 1730000000000 {
+		t.Fatalf("registration not updated: %#v", started)
+	}
+	if started.HistoryID != "100" || started.LastPushMessageID != "push-before" {
+		t.Fatalf("start replaced recovery progress: %#v", started)
+	}
+	if !started.AuthRecoveryPending || started.AuthFailureAtMs != 123 ||
+		started.AuthFailureReason != gmailwatch.AuthFailureReasonReauthenticationRequired {
+		t.Fatalf("start replaced recovery marker: %#v", started)
+	}
+}
+
 func TestGmailWatchServerServeHTTP_TruncateBody(t *testing.T) {
 	setWatchTestConfigHome(t)
 

--- a/internal/gmailwatch/http.go
+++ b/internal/gmailwatch/http.go
@@ -148,6 +148,14 @@ func (h *HTTPHandler) ServeHTTP(response http.ResponseWriter, request *http.Requ
 			return
 		}
 
+		var authErr *TerminalAuthError
+		if errors.As(err, &authErr) {
+			h.warnf("watch: Gmail authorization requires re-authentication; acknowledging push without advancing history: %v", err)
+			response.WriteHeader(http.StatusAccepted)
+
+			return
+		}
+
 		var rateErr *RateLimitError
 		if errors.As(err, &rateErr) {
 			if !rateErr.Until.IsZero() {

--- a/internal/gmailwatch/http_test.go
+++ b/internal/gmailwatch/http_test.go
@@ -77,6 +77,24 @@ func TestHTTPHandlerMapsNoMessagesAndRateLimit(t *testing.T) {
 	}
 }
 
+func TestHTTPHandlerAcknowledgesTerminalAuthFailure(t *testing.T) {
+	t.Parallel()
+
+	handler := &HTTPHandler{
+		Config: HTTPConfig{Path: "/hook", BodyLimit: 1024, HasHook: true},
+		Process: func(context.Context, Notification) (*ProcessedPayload, error) {
+			return nil, &TerminalAuthError{Cause: errors.New("invalid_grant")} //nolint:err113 // Test-only failure.
+		},
+	}
+
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, pushRequest(t, "", "200", "push-1"))
+
+	if response.Code != http.StatusAccepted {
+		t.Fatalf("status = %d", response.Code)
+	}
+}
+
 func TestHTTPHandlerReturnsPayloadWithoutHook(t *testing.T) {
 	t.Parallel()
 

--- a/internal/gmailwatch/processor.go
+++ b/internal/gmailwatch/processor.go
@@ -45,6 +45,18 @@ func (e *RateLimitError) Unwrap() error {
 	return e.Cause
 }
 
+type TerminalAuthError struct {
+	Cause error
+}
+
+func (e *TerminalAuthError) Error() string {
+	return fmt.Sprintf("gmail authorization requires re-authentication: %v", e.Cause)
+}
+
+func (e *TerminalAuthError) Unwrap() error {
+	return e.Cause
+}
+
 type DeliveryResult struct {
 	Status string
 	Note   string
@@ -77,6 +89,7 @@ type Processor struct {
 	Now                 func() time.Time
 	Sleep               func(context.Context, time.Duration) error
 	IsStaleHistoryError func(error) bool
+	IsTerminalAuthError func(error) bool
 	RateLimitUntil      func(error, time.Time) (time.Time, bool)
 	Logf                func(string, ...any)
 	Warnf               func(string, ...any)
@@ -163,7 +176,7 @@ func (p *Processor) Handle(ctx context.Context, notification Notification) (*Pay
 
 	source, err := p.NewSource(ctx)
 	if err != nil {
-		return nil, err
+		return nil, p.classifySourceError(err)
 	}
 
 	if source == nil {
@@ -176,7 +189,7 @@ func (p *Processor) Handle(ctx context.Context, notification Notification) (*Pay
 			return p.resync(ctx, source, notification)
 		}
 
-		return nil, p.openRateLimitCircuitIfNeeded(err)
+		return nil, p.classifySourceError(err)
 	}
 
 	nextHistoryID := notification.HistoryID
@@ -194,7 +207,7 @@ func (p *Processor) Handle(ctx context.Context, notification Notification) (*Pay
 
 	batch, err := source.FetchMessages(ctx, historyIDs.FetchIDs)
 	if err != nil {
-		return nil, p.openRateLimitCircuitIfNeeded(err)
+		return nil, p.classifySourceError(err)
 	}
 
 	p.advanceHistory(nextHistoryID, notification.MessageID, "watch: failed to update state: %v")
@@ -219,12 +232,12 @@ func (p *Processor) Handle(ctx context.Context, notification Notification) (*Pay
 func (p *Processor) resync(ctx context.Context, source Source, notification Notification) (*Payload, error) {
 	ids, err := source.ListRecentMessageIDs(ctx, p.Config.ResyncMax)
 	if err != nil {
-		return nil, p.openRateLimitCircuitIfNeeded(err)
+		return nil, p.classifySourceError(err)
 	}
 
 	batch, err := source.FetchMessages(ctx, ids)
 	if err != nil {
-		return nil, p.openRateLimitCircuitIfNeeded(err)
+		return nil, p.classifySourceError(err)
 	}
 
 	p.advanceHistory(notification.HistoryID, notification.MessageID, "watch: failed to update state after resync: %v")
@@ -320,6 +333,18 @@ func (p *Processor) openRateLimitCircuitIfNeeded(err error) error {
 	}
 
 	return &RateLimitError{Until: until, Cause: err}
+}
+
+func (p *Processor) classifySourceError(err error) error {
+	if p.IsTerminalAuthError != nil && p.IsTerminalAuthError(err) {
+		if updateErr := p.Repository.MarkAuthRecoveryPending(p.currentTime()); updateErr != nil {
+			return fmt.Errorf("persist terminal Gmail authorization failure: %w", errors.Join(err, updateErr))
+		}
+
+		return &TerminalAuthError{Cause: err}
+	}
+
+	return p.openRateLimitCircuitIfNeeded(err)
 }
 
 func (p *Processor) currentTime() time.Time {

--- a/internal/gmailwatch/processor_test.go
+++ b/internal/gmailwatch/processor_test.go
@@ -3,6 +3,8 @@ package gmailwatch
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 	"time"
@@ -183,6 +185,119 @@ func TestProcessorRateLimitCircuit(t *testing.T) {
 
 	if source.historyCalls != 1 {
 		t.Fatalf("history calls = %d", source.historyCalls)
+	}
+}
+
+func TestProcessorClassifiesTerminalAuthWithoutAdvancingHistory(t *testing.T) {
+	t.Parallel()
+
+	authFailure := errors.New("invalid_grant") //nolint:err113 // Test-only failure.
+	repository := NewMemory(State{HistoryID: "100", LastPushMessageID: "before"}, Options{})
+	source := &processorSource{historyErr: authFailure}
+	processor := newTestProcessor(repository, source, time.Unix(350, 0))
+	processor.IsTerminalAuthError = func(err error) bool {
+		return errors.Is(err, authFailure)
+	}
+
+	_, err := processor.Handle(context.Background(), Notification{HistoryID: "200", MessageID: "push-1"})
+
+	var authErr *TerminalAuthError
+	if !errors.As(err, &authErr) || !errors.Is(err, authFailure) {
+		t.Fatalf("terminal auth error = %#v", err)
+	}
+
+	state := repository.Get()
+	if state.HistoryID != "100" || state.LastPushMessageID != "before" {
+		t.Fatalf("state advanced after terminal auth failure: %#v", state)
+	}
+
+	if !state.AuthRecoveryPending || state.AuthFailureAtMs != time.Unix(350, 0).UnixMilli() ||
+		state.AuthFailureReason != AuthFailureReasonReauthenticationRequired {
+		t.Fatalf("recovery state = %#v", state)
+	}
+}
+
+func TestProcessorKeepsTerminalAuthRetryableWhenRecoveryStateCannotPersist(t *testing.T) {
+	t.Parallel()
+
+	authFailure := errors.New("invalid_grant")     //nolint:err113 // Test-only failure.
+	persistFailure := errors.New("persist failed") //nolint:err113 // Test-only failure.
+	failWrites := false
+
+	repository := New(filepath.Join(t.TempDir(), "watch.json"), Options{
+		WriteFile: func(path string, data []byte, mode os.FileMode) error {
+			if failWrites {
+				return persistFailure
+			}
+
+			return os.WriteFile(path, data, mode)
+		},
+	})
+	if err := repository.Update(func(state *State) error {
+		state.HistoryID = "100"
+
+		return nil
+	}); err != nil {
+		t.Fatalf("seed state: %v", err)
+	}
+	failWrites = true
+
+	processor := newTestProcessor(repository, &processorSource{historyErr: authFailure}, time.Unix(350, 0))
+	processor.IsTerminalAuthError = func(err error) bool {
+		return errors.Is(err, authFailure)
+	}
+
+	_, err := processor.Handle(context.Background(), Notification{HistoryID: "200", MessageID: "push-1"})
+
+	var authErr *TerminalAuthError
+	if errors.As(err, &authErr) {
+		t.Fatalf("persistence failure classified as terminal: %v", err)
+	}
+
+	if !errors.Is(err, authFailure) || !errors.Is(err, persistFailure) {
+		t.Fatalf("persistence error = %v", err)
+	}
+
+	if state := repository.Get(); state.AuthRecoveryPending || state.HistoryID != "100" {
+		t.Fatalf("state changed after persistence failure: %#v", state)
+	}
+}
+
+func TestProcessorCatchesUpPendingAuthRecovery(t *testing.T) {
+	t.Parallel()
+
+	repository := NewMemory(State{
+		HistoryID:           "100",
+		LastPushMessageID:   "push-before",
+		AuthRecoveryPending: true,
+		AuthFailureAtMs:     123,
+		AuthFailureReason:   AuthFailureReasonReauthenticationRequired,
+	}, Options{})
+	source := &processorSource{
+		history: HistoryPage{
+			HistoryID: "300",
+			Records:   []HistoryRecord{{Added: []string{"m1"}}},
+		},
+		messageBatches: []MessageBatch{{Messages: []Message{{ID: "m1"}}}},
+	}
+	processor := newTestProcessor(repository, source, time.Unix(400, 0))
+
+	payload, err := processor.Handle(context.Background(), Notification{HistoryID: "300", MessageID: "push-recovery"})
+	if err != nil {
+		t.Fatalf("Handle recovery notification: %v", err)
+	}
+
+	if payload.HistoryID != "300" || len(payload.Messages) != 1 {
+		t.Fatalf("recovery payload = %#v", payload)
+	}
+
+	state := repository.Get()
+	if state.HistoryID != "300" || state.LastPushMessageID != "push-recovery" {
+		t.Fatalf("recovered progress = %#v", state)
+	}
+
+	if state.AuthRecoveryPending || state.AuthFailureAtMs != 0 || state.AuthFailureReason != "" {
+		t.Fatalf("recovery marker not cleared: %#v", state)
 	}
 }
 

--- a/internal/gmailwatch/repository_test.go
+++ b/internal/gmailwatch/repository_test.go
@@ -309,3 +309,51 @@ func TestHistoryTransitions(t *testing.T) {
 		t.Fatal("older history was not stale")
 	}
 }
+
+func TestApplyWatchRegistrationPreservesPendingRecovery(t *testing.T) {
+	t.Parallel()
+
+	state := State{
+		Account:             "user@example.com",
+		Topic:               "projects/old/topics/old",
+		HistoryID:           "100",
+		LastPushMessageID:   "push-before",
+		AuthRecoveryPending: true,
+		AuthFailureAtMs:     123,
+		AuthFailureReason:   AuthFailureReasonReauthenticationRequired,
+	}
+	registered := State{
+		Account:      "user@example.com",
+		Topic:        "projects/new/topics/new",
+		HistoryID:    "300",
+		ExpirationMs: 456,
+	}
+
+	ApplyWatchRegistration(&state, registered)
+
+	if state.Topic != registered.Topic || state.ExpirationMs != registered.ExpirationMs {
+		t.Fatalf("registration fields not applied: %#v", state)
+	}
+
+	if state.HistoryID != "100" || state.LastPushMessageID != "push-before" {
+		t.Fatalf("recovery progress replaced: %#v", state)
+	}
+
+	if !state.AuthRecoveryPending || state.AuthFailureAtMs != 123 ||
+		state.AuthFailureReason != AuthFailureReasonReauthenticationRequired {
+		t.Fatalf("recovery marker replaced: %#v", state)
+	}
+}
+
+func TestApplyWatchRegistrationReplacesCompletedProgress(t *testing.T) {
+	t.Parallel()
+
+	state := State{HistoryID: "100", LastPushMessageID: "push-before"}
+	registered := State{HistoryID: "300", ExpirationMs: 456}
+
+	ApplyWatchRegistration(&state, registered)
+
+	if state.HistoryID != "300" || state.LastPushMessageID != "" || state.ExpirationMs != 456 {
+		t.Fatalf("registration state = %#v", state)
+	}
+}

--- a/internal/gmailwatch/state.go
+++ b/internal/gmailwatch/state.go
@@ -36,6 +36,9 @@ type State struct {
 	LastDeliveryStatusNote string   `json:"lastDeliveryStatusNote,omitempty"`
 	LastPushMessageID      string   `json:"lastPushMessageId,omitempty"`
 	RateLimitedUntilMs     int64    `json:"rateLimitedUntilMs,omitempty"`
+	AuthRecoveryPending    bool     `json:"authRecoveryPending,omitempty"`
+	AuthFailureAtMs        int64    `json:"authFailureAtMs,omitempty"`
+	AuthFailureReason      string   `json:"authFailureReason,omitempty"`
 }
 
 func ParseHistoryID(raw string) (uint64, error) {
@@ -86,9 +89,24 @@ func AdvanceHistory(state *State, historyID, pushMessageID string, now time.Time
 	if pushMessageID != "" {
 		state.LastPushMessageID = pushMessageID
 	}
+	state.AuthRecoveryPending = false
+	state.AuthFailureAtMs = 0
+	state.AuthFailureReason = ""
 	state.UpdatedAtMs = now.UnixMilli()
 
 	return nil
+}
+
+func ApplyWatchRegistration(state *State, registered State) {
+	if state.AuthRecoveryPending {
+		registered.HistoryID = state.HistoryID
+		registered.LastPushMessageID = state.LastPushMessageID
+		registered.AuthRecoveryPending = true
+		registered.AuthFailureAtMs = state.AuthFailureAtMs
+		registered.AuthFailureReason = state.AuthFailureReason
+	}
+
+	*state = registered
 }
 
 func RestoreProgress(state *State, before State, historyID, pushMessageID string) bool {

--- a/internal/gmailwatch/transitions.go
+++ b/internal/gmailwatch/transitions.go
@@ -3,6 +3,8 @@ package gmailwatch
 import "time"
 
 const (
+	AuthFailureReasonReauthenticationRequired = "reauthentication_required"
+
 	DeliveryStatusError     = "error"
 	DeliveryStatusHTTPError = "http_error"
 	DeliveryStatusOK        = "ok"
@@ -26,6 +28,17 @@ func (r *Repository) SetHook(hook *Hook, now time.Time) error {
 func (r *Repository) AdvanceHistory(historyID, pushMessageID string, now time.Time) error {
 	return r.Update(func(state *State) error {
 		return AdvanceHistory(state, historyID, pushMessageID, now)
+	})
+}
+
+func (r *Repository) MarkAuthRecoveryPending(now time.Time) error {
+	return r.Update(func(state *State) error {
+		state.AuthRecoveryPending = true
+		state.AuthFailureAtMs = now.UnixMilli()
+		state.AuthFailureReason = AuthFailureReasonReauthenticationRequired
+		state.UpdatedAtMs = now.UnixMilli()
+
+		return nil
 	})
 }
 

--- a/internal/gmailwatch/transitions_test.go
+++ b/internal/gmailwatch/transitions_test.go
@@ -119,3 +119,41 @@ func TestRepositoryRecordDelivery(t *testing.T) {
 		t.Fatalf("delivery state = %#v", state)
 	}
 }
+
+func TestRepositoryAuthRecoveryTransitions(t *testing.T) {
+	t.Parallel()
+
+	failureAt := time.Date(2026, 7, 19, 10, 0, 0, 0, time.UTC)
+	repository := NewMemory(State{
+		HistoryID:         "100",
+		LastPushMessageID: "push-before",
+	}, Options{})
+
+	if err := repository.MarkAuthRecoveryPending(failureAt); err != nil {
+		t.Fatalf("MarkAuthRecoveryPending: %v", err)
+	}
+
+	pending := repository.Get()
+	if !pending.AuthRecoveryPending || pending.AuthFailureAtMs != failureAt.UnixMilli() ||
+		pending.AuthFailureReason != AuthFailureReasonReauthenticationRequired {
+		t.Fatalf("pending state = %#v", pending)
+	}
+
+	if pending.HistoryID != "100" || pending.LastPushMessageID != "push-before" {
+		t.Fatalf("pending state changed progress: %#v", pending)
+	}
+
+	recoveredAt := failureAt.Add(time.Minute)
+	if err := repository.AdvanceHistory("300", "push-recovery", recoveredAt); err != nil {
+		t.Fatalf("AdvanceHistory: %v", err)
+	}
+
+	recovered := repository.Get()
+	if recovered.AuthRecoveryPending || recovered.AuthFailureAtMs != 0 || recovered.AuthFailureReason != "" {
+		t.Fatalf("recovery marker not cleared: %#v", recovered)
+	}
+
+	if recovered.HistoryID != "300" || recovered.LastPushMessageID != "push-recovery" {
+		t.Fatalf("recovered progress = %#v", recovered)
+	}
+}


### PR DESCRIPTION
## Summary

- classify expired or revoked Gmail OAuth credentials as terminal processing failures
- persist a durable auth-recovery marker before acknowledging terminal Pub/Sub deliveries
- preserve the last successfully processed Gmail history cursor across `watch start` and `watch renew`
- use Gmail's immediate watch-registration notification to catch up after re-authentication
- keep transient Gmail API, rate-limit, persistence, and downstream hook failures retryable

## Root cause

The Gmail watch consumers treated every non-rate-limit processing failure as retryable. When the OAuth refresh token returned `invalid_grant`, push delivery responded with HTTP 500 and pull delivery nacked the message. Pub/Sub then redelivered a failure that cannot recover without operator re-authentication, producing an unbounded retry and log storm.

## Recovery contract

Terminal OAuth failures are acknowledged only after `authRecoveryPending` and the failure timestamp/reason are saved without advancing `historyId` or `lastPushMessageId`. A state write failure remains a normal processing error, so Pub/Sub keeps the delivery retryable.

After re-authenticating, run `gog gmail watch renew` or rerun `gog gmail watch start`. Successful registration preserves the old successful cursor while recovery is pending. Gmail sends an immediate notification for a successful watch registration, so the consumer catches up from that cursor without waiting for another mailbox change. Advancing history successfully clears the recovery marker. `gog gmail watch status` exposes the pending recovery state.

Temporary API failures, rate limits, and hook delivery failures retain their existing retry behavior.

## Validation

- `go test ./internal/gmailwatch`
- focused `internal/cmd` tests covering start, renew, status, push acknowledgement, pull acknowledgement, persistence failure, and catch-up
- `make fmt-check`
- `make lint`
- `make deadcode`
- `make build`

The broader `internal/cmd` Gmail-watch test selection still has pre-existing shared-state failures when run as one package on this machine. The same failures reproduce on unmodified `upstream/main`; the focused regression tests above pass.

## Redacted live Gmail/Pub/Sub evidence

Run on 2026-07-19 with commit `7b32e33be8a5`. The run used:

- a real Gmail account and Gmail-generated history event
- a temporary real Pub/Sub pull subscription on the configured topic
- an isolated `--home` and encrypted file keyring
- a temporary Gmail label added to and then removed from one existing INBOX message
- the real `watch start`, pull acknowledgement, `watch renew`, immediate Gmail notification, history fetch, and hook delivery paths

Only the isolated refresh token was replaced with an invalid value. The production token was never revoked or modified.

```text
runtime_binary=7b32e33be8a5
delivery=real_gmail_pubsub_pull
terminal_oauth=invalid_grant pull_acknowledged=yes
recovery_pending=true reason=reauthentication_required cursor_preserved=yes
watch_renewed=yes expiration_updated=yes cursor_preserved=yes
recovery_pending_after_renew=true
renew_notification=real_gmail_pubsub_pull
hook_received=true message_count=3 history_set=true
cursor_advanced=yes recovery_pending_after=false
cleanup=label_removed,label_deleted,subscription_deleted,isolated_credentials_deleted
```

The invalid-token pull logged `Gmail authorization requires re-authentication; acknowledging pull without advancing history` after Google OAuth returned `invalid_grant`. After restoring the isolated token, `watch renew` retained the old cursor and pending marker. Gmail's immediate registration notification arrived through the temporary Pub/Sub subscription; the consumer fetched the retained history, delivered three message records to a local 204 hook, advanced the cursor, cleared the marker, and acknowledged the notification.

Account addresses, project/topic/subscription names, history IDs, Pub/Sub message IDs, Gmail message IDs, label IDs, endpoints, and all credential material are omitted. Cleanup was verified: no temporary process, directory, subscription, label, or credential copy remains.

Related OpenClaw lifecycle fix: openclaw/openclaw#96202.
