### PR TITLE
fix(gmail): mark drafts as unsent in read output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Gmail: mark unsent drafts in human-readable message and thread output while preserving JSON and plain output contracts. (#931, #932) — thanks @MaxGhenis.
 - Docs: `docs write` now rejects an explicitly empty `--tab`/`--tab-id` value instead of silently targeting the whole document.
 
 ## 0.34.1 - 2026-07-16

--- a/internal/cmd/execute_gmail_get_test.go
+++ b/internal/cmd/execute_gmail_get_test.go
@@ -9,6 +9,79 @@ import (
 	"testing"
 )
 
+func TestExecute_GmailGet_Text_DraftMarker(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var labels []string
+		switch {
+		case strings.Contains(r.URL.Path, "/gmail/v1/users/me/messages/m-draft"):
+			labels = []string{"DRAFT"}
+		case strings.Contains(r.URL.Path, "/gmail/v1/users/me/messages/m-inbound"):
+			labels = []string{"INBOX"}
+		default:
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":       strings.TrimPrefix(r.URL.Path, "/gmail/v1/users/me/messages/"),
+			"threadId": "t1",
+			"labelIds": labels,
+			"payload":  map[string]any{"headers": []map[string]any{}},
+		})
+	}))
+	defer srv.Close()
+
+	svc := newGmailServiceFromServer(t, srv)
+
+	t.Run("human output marks a draft", func(t *testing.T) {
+		result := executeWithGmailTestService(t, []string{
+			"--account", "a@b.com", "gmail", "get", "m-draft",
+		}, svc)
+		if result.err != nil {
+			t.Fatalf("Execute: %v\nstderr=%q", result.err, result.stderr)
+		}
+		if !strings.Contains(result.stdout, "id\tm-draft [DRAFT — NOT SENT]\n") {
+			t.Fatalf("expected marked draft heading, got=%q", result.stdout)
+		}
+	})
+
+	t.Run("human output leaves a non-draft unchanged", func(t *testing.T) {
+		result := executeWithGmailTestService(t, []string{
+			"--account", "a@b.com", "gmail", "get", "m-inbound",
+		}, svc)
+		if result.err != nil {
+			t.Fatalf("Execute: %v\nstderr=%q", result.err, result.stderr)
+		}
+		if !strings.Contains(result.stdout, "id\tm-inbound\n") || strings.Contains(result.stdout, gmailDraftNotSentMarker) {
+			t.Fatalf("expected unchanged non-draft heading, got=%q", result.stdout)
+		}
+	})
+
+	t.Run("plain output is unchanged", func(t *testing.T) {
+		result := executeWithGmailTestService(t, []string{
+			"--plain", "--account", "a@b.com", "gmail", "get", "m-draft",
+		}, svc)
+		if result.err != nil {
+			t.Fatalf("Execute: %v\nstderr=%q", result.err, result.stderr)
+		}
+		if !strings.Contains(result.stdout, "id\tm-draft\n") || strings.Contains(result.stdout, gmailDraftNotSentMarker) {
+			t.Fatalf("expected unchanged plain heading, got=%q", result.stdout)
+		}
+	})
+
+	t.Run("JSON output is unchanged", func(t *testing.T) {
+		result := executeWithGmailTestService(t, []string{
+			"--json", "--account", "a@b.com", "gmail", "get", "m-draft",
+		}, svc)
+		if result.err != nil {
+			t.Fatalf("Execute: %v\nstderr=%q", result.err, result.stderr)
+		}
+		if strings.Contains(result.stdout, gmailDraftNotSentMarker) || !strings.Contains(result.stdout, `"DRAFT"`) {
+			t.Fatalf("expected unchanged JSON labels without display marker, got=%q", result.stdout)
+		}
+	})
+}
+
 func TestExecute_GmailGet_Metadata_JSON(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !strings.Contains(r.URL.Path, "/gmail/v1/users/me/messages/m1") {

--- a/internal/cmd/execute_gmail_text_test.go
+++ b/internal/cmd/execute_gmail_text_test.go
@@ -11,6 +11,76 @@ import (
 	"testing"
 )
 
+func TestExecute_GmailThread_Text_DraftMarker(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/gmail/v1/users/me/threads/t-thread-draft") {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id": "t-thread-draft",
+			"messages": []map[string]any{
+				{
+					"id":       "m-inbound",
+					"labelIds": []string{"INBOX"},
+					"payload":  map[string]any{"headers": []map[string]any{}},
+				},
+				{
+					"id":       "m-draft",
+					"labelIds": []string{"DRAFT"},
+					"payload":  map[string]any{"headers": []map[string]any{}},
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	svc := newGmailServiceFromServer(t, srv)
+
+	t.Run("human output marks only the draft", func(t *testing.T) {
+		result := executeWithGmailTestService(t, []string{
+			"--account", "a@b.com", "gmail", "thread", "get", "t-thread-draft",
+		}, svc)
+		if result.err != nil {
+			t.Fatalf("Execute: %v\nstderr=%q", result.err, result.stderr)
+		}
+		if !strings.Contains(result.stdout, "=== Message 1/2: m-inbound ===") {
+			t.Fatalf("expected unchanged non-draft heading, got=%q", result.stdout)
+		}
+		if !strings.Contains(result.stdout, "=== Message 2/2: m-draft [DRAFT — NOT SENT] ===") {
+			t.Fatalf("expected marked draft heading, got=%q", result.stdout)
+		}
+		if strings.Count(result.stdout, gmailDraftNotSentMarker) != 1 {
+			t.Fatalf("expected exactly one draft marker, got=%q", result.stdout)
+		}
+	})
+
+	t.Run("plain output is unchanged", func(t *testing.T) {
+		result := executeWithGmailTestService(t, []string{
+			"--plain", "--account", "a@b.com", "gmail", "thread", "get", "t-thread-draft",
+		}, svc)
+		if result.err != nil {
+			t.Fatalf("Execute: %v\nstderr=%q", result.err, result.stderr)
+		}
+		if !strings.Contains(result.stdout, "=== Message 2/2: m-draft ===") || strings.Contains(result.stdout, gmailDraftNotSentMarker) {
+			t.Fatalf("expected unchanged plain heading, got=%q", result.stdout)
+		}
+	})
+
+	t.Run("JSON output is unchanged", func(t *testing.T) {
+		result := executeWithGmailTestService(t, []string{
+			"--json", "--account", "a@b.com", "gmail", "thread", "get", "t-thread-draft",
+		}, svc)
+		if result.err != nil {
+			t.Fatalf("Execute: %v\nstderr=%q", result.err, result.stderr)
+		}
+		if strings.Contains(result.stdout, gmailDraftNotSentMarker) || !strings.Contains(result.stdout, `"labelIds": [`) || !strings.Contains(result.stdout, `"DRAFT"`) {
+			t.Fatalf("expected unchanged JSON labels without display marker, got=%q", result.stdout)
+		}
+	})
+}
+
 func TestExecute_GmailThread_Text_Download(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	wd := t.TempDir()

--- a/internal/cmd/gmail_get.go
+++ b/internal/cmd/gmail_get.go
@@ -116,7 +116,7 @@ func (c *GmailGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return outfmt.WriteJSON(ctx, stdoutWriter(ctx), payload)
 	}
 
-	u.Out().Linef("id\t%s", msg.Id)
+	u.Out().Linef("id\t%s%s", msg.Id, gmailHumanMessageStatusMarker(ctx, msg.LabelIds))
 	u.Out().Linef("thread_id\t%s", msg.ThreadId)
 	u.Out().Linef("label_ids\t%s", strings.Join(msg.LabelIds, ","))
 

--- a/internal/cmd/gmail_message_render.go
+++ b/internal/cmd/gmail_message_render.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"context"
+	"slices"
+
+	"github.com/steipete/gogcli/internal/outfmt"
+)
+
+const gmailDraftNotSentMarker = " [DRAFT — NOT SENT]"
+
+func gmailHumanMessageStatusMarker(ctx context.Context, labelIDs []string) string {
+	if outfmt.IsJSON(ctx) || outfmt.IsPlain(ctx) {
+		return ""
+	}
+	if slices.Contains(labelIDs, gmailSystemLabelDraft) {
+		return gmailDraftNotSentMarker
+	}
+	return ""
+}

--- a/internal/cmd/gmail_thread.go
+++ b/internal/cmd/gmail_thread.go
@@ -104,7 +104,7 @@ func (c *GmailThreadGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 		if msg == nil {
 			continue
 		}
-		u.Out().Linef("=== Message %d/%d: %s ===", i+1, len(thread.Messages), msg.Id)
+		u.Out().Linef("=== Message %d/%d: %s%s ===", i+1, len(thread.Messages), msg.Id, gmailHumanMessageStatusMarker(ctx, msg.LabelIds))
 		header := func(name string) string {
 			value := headerValue(msg.Payload, name)
 			if c.SanitizeContent {


### PR DESCRIPTION
## Problem

Human-readable Gmail thread output rendered draft replies with the same message heading as sent messages. That can make users and agents conclude that an unsent reply was delivered.

## Change

- Append ` [DRAFT — NOT SENT]` to human-readable message headings when the exact, case-sensitive Gmail label ID is `DRAFT`.
- Cover both thread reads and the single-message `gmail get` identity line.
- Leave `--plain` and `--json` machine output unchanged; JSON continues to expose the original `labelIds`.

## Test coverage

- Focused Gmail draft-marker and thread tests pass.
- `go test ./...` passes.
- `make ci` passes, including formatting, golangci-lint, dead-code analysis, Go and Node tests, docs coverage, and generated agent-skill checks.
- Independent final diff review found no actionable issues.

## Real-output verification

Built the branch binary and performed this strictly read-only check against the known mixed inbound/draft thread. Output was filtered to message headings only:

```console
$ GOG_AUTO_JSON=0 GOG_READONLY=1 ./gog gmail read 19f6c627fad1dbc6 -a max@policyengine.org | rg "^=== Message"
=== Message 1/2: 19f6c627fad1dbc6 ===
=== Message 2/2: 19f7c2789ca05c37 [DRAFT — NOT SENT] ===
```

Fixes #931

Disclosure: AI assistance was used to inspect the codebase, implement the change, and review the final diff.