### PR TITLE
fix(sheets): never write outside the requested range on positional updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.34.2 - 2026-07-27
 
+- Sheets: keep positional updates within the requested range, preserving comma-bearing single-cell values and accurate named-range dry runs. (#941) — thanks @cathrynlavery.
 - Gmail: add source-specific `internalDateIso` timestamps to message and thread listings while preserving the legacy sender-header `date`. (#945, #946) — thanks @chrischall.
 - Gmail: prevent standalone draft updates from acquiring self-referential reply headers, with explicit recovery for affected drafts. (#942, #944) — thanks @chrischall.
 - Security: update gRPC-Go, PostCSS, and Sharp/libvips to patched releases, clearing three high-severity dependency alerts. (#940)

--- a/docs/commands/gog-sheets-links-set.md
+++ b/docs/commands/gog-sheets-links-set.md
@@ -20,7 +20,7 @@ gog sheets (sheet) links (hyperlinks) set (write) <spreadsheetId> [<cell> [<url>
 | --- | --- | --- | --- |
 | `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email, alias, or auto for authenticated Google API commands |
-| `--cells-json` | `string` |  | Batch: JSON array of {cell,url,text} or {cell,runs:[{text,uri}]} objects, written in one request. |
+| `--cells-json` | `string` |  | Batch: JSON array, @file, or @- for stdin containing {cell,url,text} or {cell,runs:[{text,uri}]} objects, written in one request. |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |

--- a/internal/cmd/sheets.go
+++ b/internal/cmd/sheets.go
@@ -194,6 +194,8 @@ func (c *SheetsUpdateCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	var values [][]interface{}
+	positionalValues := false
+	positionalRangeResolved := true
 	switch {
 	case strings.TrimSpace(c.ValuesJSON) != "":
 		b, err := resolveInlineOrFileBytes(c.ValuesJSON, stdinReader(ctx))
@@ -206,7 +208,12 @@ func (c *SheetsUpdateCmd) Run(ctx context.Context, flags *RootFlags) error {
 			return sheetsValuesPlannerError(err)
 		}
 	case len(c.Values) > 0:
-		values = sheetsvalues.ParseArgs(c.Values)
+		positionalValues = true
+		var err error
+		values, positionalRangeResolved, err = parseSheetsUpdatePositionalValues(rangeSpec, c.Values)
+		if err != nil {
+			return err
+		}
 	default:
 		return usage("provide values as args or via --values-json")
 	}
@@ -236,6 +243,25 @@ func (c *SheetsUpdateCmd) Run(ctx context.Context, flags *RootFlags) error {
 	svc, err := sheetsService(ctx, account)
 	if err != nil {
 		return err
+	}
+
+	if positionalValues && !positionalRangeResolved {
+		catalog, catalogErr := fetchSpreadsheetRangeCatalog(ctx, svc, spreadsheetID)
+		if catalogErr != nil {
+			return catalogErr
+		}
+		gridRange, rangeErr := resolveGridRangeWithCatalog(rangeSpec, catalog, "update")
+		if rangeErr != nil {
+			return rangeErr
+		}
+		values, err = sheetsvalues.ParseArgsForShape(
+			c.Values,
+			gridRangeDimensionSize(gridRange.StartRowIndex, gridRange.EndRowIndex),
+			gridRangeDimensionSize(gridRange.StartColumnIndex, gridRange.EndColumnIndex),
+		)
+		if err != nil {
+			return sheetsValuesPlannerError(err)
+		}
 	}
 
 	vr := &sheets.ValueRange{
@@ -295,6 +321,43 @@ func (c *SheetsUpdateCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return sheetsFormulaVerificationError(formulaErrors)
 	}
 	return nil
+}
+
+func parseSheetsUpdatePositionalValues(rangeSpec string, rawValues []string) ([][]interface{}, bool, error) {
+	parsedRange, err := sheetsa1.Parse(rangeSpec)
+	if err != nil {
+		// Named ranges need spreadsheet metadata to determine their shape.
+		// Keep the legacy parse for dry-run output, then resolve and validate
+		// the range after the Sheets service is available and before writing.
+		return sheetsvalues.ParseArgs(rawValues), false, nil
+	}
+
+	values, err := sheetsvalues.ParseArgsForShape(
+		rawValues,
+		a1RangeDimensionSize(parsedRange.StartRow, parsedRange.EndRow),
+		a1RangeDimensionSize(parsedRange.StartCol, parsedRange.EndCol),
+	)
+	if err != nil {
+		return nil, true, sheetsValuesPlannerError(err)
+	}
+	return values, true, nil
+}
+
+func a1RangeDimensionSize(start, end int) int64 {
+	if start <= 0 || end <= 0 {
+		return 0
+	}
+	return int64(end - start + 1)
+}
+
+func gridRangeDimensionSize(start, end int64) int64 {
+	if end == 0 {
+		return 0
+	}
+	if end <= start {
+		return -1
+	}
+	return end - start
 }
 
 type sheetsFormulaError struct {

--- a/internal/cmd/sheets.go
+++ b/internal/cmd/sheets.go
@@ -222,6 +222,9 @@ func (c *SheetsUpdateCmd) Run(ctx context.Context, flags *RootFlags) error {
 	if valueInputOption == "" {
 		valueInputOption = sheetsDefaultValueInputOption
 	}
+	if positionalValues && !positionalRangeResolved && flags != nil && flags.DryRun {
+		return usage("positional values for a named or unresolved range cannot be previewed offline; use A1 notation or --values-json")
+	}
 
 	if err := dryRunExit(ctx, flags, "sheets.update", map[string]any{
 		"spreadsheet_id":          spreadsheetID,
@@ -324,23 +327,24 @@ func (c *SheetsUpdateCmd) Run(ctx context.Context, flags *RootFlags) error {
 }
 
 func parseSheetsUpdatePositionalValues(rangeSpec string, rawValues []string) ([][]interface{}, bool, error) {
-	parsedRange, err := sheetsa1.Parse(rangeSpec)
-	if err != nil {
-		// Named ranges need spreadsheet metadata to determine their shape.
-		// Keep the legacy parse for dry-run output, then resolve and validate
-		// the range after the Sheets service is available and before writing.
-		return sheetsvalues.ParseArgs(rawValues), false, nil
+	parsedRange, parseErr := sheetsa1.Parse(rangeSpec)
+	if parseErr == nil {
+		values, err := sheetsvalues.ParseArgsForShape(
+			rawValues,
+			a1RangeDimensionSize(parsedRange.StartRow, parsedRange.EndRow),
+			a1RangeDimensionSize(parsedRange.StartCol, parsedRange.EndCol),
+		)
+		if err != nil {
+			return nil, true, sheetsValuesPlannerError(err)
+		}
+		return values, true, nil
 	}
 
-	values, err := sheetsvalues.ParseArgsForShape(
-		rawValues,
-		a1RangeDimensionSize(parsedRange.StartRow, parsedRange.EndRow),
-		a1RangeDimensionSize(parsedRange.StartCol, parsedRange.EndCol),
-	)
-	if err != nil {
-		return nil, true, sheetsValuesPlannerError(err)
-	}
-	return values, true, nil
+	// Named ranges need spreadsheet metadata to determine their shape. Keep the
+	// legacy parse until the Sheets service is available, then resolve and
+	// validate the range before writing. Offline dry-runs reject this form
+	// because they cannot produce an accurate payload preview.
+	return sheetsvalues.ParseArgs(rawValues), false, nil
 }
 
 func a1RangeDimensionSize(start, end int) int64 {

--- a/internal/cmd/sheets_links_set.go
+++ b/internal/cmd/sheets_links_set.go
@@ -44,7 +44,7 @@ type SheetsLinksSetCmd struct {
 	Text          string `arg:"" optional:"" name:"text" help:"Display text (defaults to the URL)."`
 
 	RunsJSON  string `name:"runs-json" help:"Multi-link cell: JSON array of runs, eg. [{\"text\":\"Act A\",\"uri\":\"https://a\"},{\"text\":\" / \"},{\"text\":\"Act B\",\"uri\":\"https://b\"}]. A run with an empty uri is plain text."`
-	CellsJSON string `name:"cells-json" help:"Batch: JSON array of {cell,url,text} or {cell,runs:[{text,uri}]} objects, written in one request."`
+	CellsJSON string `name:"cells-json" help:"Batch: JSON array, @file, or @- for stdin containing {cell,url,text} or {cell,runs:[{text,uri}]} objects, written in one request."`
 }
 
 func (c *SheetsLinksSetCmd) Run(ctx context.Context, flags *RootFlags) error {
@@ -55,7 +55,7 @@ func (c *SheetsLinksSetCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return usage("empty spreadsheetId")
 	}
 
-	specs, err := c.collectSpecs()
+	specs, err := c.collectSpecs(ctx)
 	if err != nil {
 		return err
 	}
@@ -153,13 +153,17 @@ func (c *SheetsLinksSetCmd) Run(ctx context.Context, flags *RootFlags) error {
 
 // collectSpecs builds the list of cells to write from either --cells-json
 // (batch) or the positional/single-cell form, rejecting a mix of the two.
-func (c *SheetsLinksSetCmd) collectSpecs() ([]linkCellSpec, error) {
+func (c *SheetsLinksSetCmd) collectSpecs(ctx context.Context) ([]linkCellSpec, error) {
 	if strings.TrimSpace(c.CellsJSON) != "" {
 		if c.Cell != "" || c.URL != "" || c.Text != "" || c.RunsJSON != "" {
 			return nil, usage("use either positional cell args or --cells-json, not both")
 		}
+		b, err := resolveInlineOrFileBytes(c.CellsJSON, stdinReader(ctx))
+		if err != nil {
+			return nil, usagef("read --cells-json: %v", err)
+		}
 		var specs []linkCellSpec
-		if err := json.Unmarshal([]byte(c.CellsJSON), &specs); err != nil {
+		if err := json.Unmarshal(b, &specs); err != nil {
 			return nil, usagef("parse --cells-json: %v", err)
 		}
 		if len(specs) == 0 {

--- a/internal/cmd/sheets_links_set_test.go
+++ b/internal/cmd/sheets_links_set_test.go
@@ -86,12 +86,12 @@ func linksSetCtx(t *testing.T) context.Context {
 	return newCmdRuntimeJSONOutputContext(t, io.Discard, io.Discard)
 }
 
-// updateCellsCell digs the single CellData map out of recorded request index i.
-func updateCellsCell(t *testing.T, rec *linksSetRecorder, i int) map[string]any {
+// updateCellsCell digs the single CellData map out of the recorded request.
+func updateCellsCell(t *testing.T, rec *linksSetRecorder) map[string]any {
 	t.Helper()
-	uc, ok := rec.requests[i]["updateCells"].(map[string]any)
+	uc, ok := rec.requests[0]["updateCells"].(map[string]any)
 	if !ok {
-		t.Fatalf("request %d not updateCells: %#v", i, rec.requests[i])
+		t.Fatalf("request not updateCells: %#v", rec.requests[0])
 	}
 	rows := uc["rows"].([]any)
 	values := rows[0].(map[string]any)["values"].([]any)
@@ -140,7 +140,7 @@ func TestSheetsLinksSet_SingleLink(t *testing.T) {
 	if len(rec.requests) != 1 {
 		t.Fatalf("expected 1 request, got %d", len(rec.requests))
 	}
-	cell := updateCellsCell(t, rec, 0)
+	cell := updateCellsCell(t, rec)
 	if got := cell["userEnteredValue"].(map[string]any)["stringValue"]; got != "Act A" {
 		t.Errorf("stringValue = %v, want Act A", got)
 	}
@@ -182,7 +182,7 @@ func TestSheetsLinksSet_DefaultTextIsURL(t *testing.T) {
 	if err := runKong(t, &SheetsLinksSetCmd{}, []string{"s1", "Sheet1!A1", "https://only.url/"}, ctx, flags); err != nil {
 		t.Fatalf("links set: %v", err)
 	}
-	cell := updateCellsCell(t, rec, 0)
+	cell := updateCellsCell(t, rec)
 	if got := cell["userEnteredValue"].(map[string]any)["stringValue"]; got != "https://only.url/" {
 		t.Errorf("stringValue = %v, want the url", got)
 	}
@@ -197,7 +197,7 @@ func TestSheetsLinksSet_MultiLinkRuns(t *testing.T) {
 	if err := runKong(t, &SheetsLinksSetCmd{}, []string{"s1", "Sheet1!C3", "--runs-json", runsJSON}, ctx, flags); err != nil {
 		t.Fatalf("links set: %v", err)
 	}
-	cell := updateCellsCell(t, rec, 0)
+	cell := updateCellsCell(t, rec)
 	if got := cell["userEnteredValue"].(map[string]any)["stringValue"]; got != "Act A / Act B" {
 		t.Errorf("stringValue = %q, want concat", got)
 	}
@@ -280,7 +280,7 @@ func TestSheetsLinksSet_BatchCellsJSONFromStdin(t *testing.T) {
 	if len(rec.requests) != 1 {
 		t.Fatalf("expected 1 request, got %d", len(rec.requests))
 	}
-	cell := updateCellsCell(t, rec, 0)
+	cell := updateCellsCell(t, rec)
 	if got := cell["userEnteredValue"].(map[string]any)["stringValue"]; got != "stdin" {
 		t.Fatalf("stringValue = %v, want stdin", got)
 	}

--- a/internal/cmd/sheets_links_set_test.go
+++ b/internal/cmd/sheets_links_set_test.go
@@ -8,8 +8,11 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/steipete/gogcli/internal/outfmt"
 )
 
 type linksSetRecorder struct {
@@ -58,11 +61,23 @@ func linksSetHandler(recorder *linksSetRecorder) http.Handler {
 
 func newLinksSetTestContext(t *testing.T, recorder *linksSetRecorder) (context.Context, *bytes.Buffer) {
 	t.Helper()
+	return newLinksSetTestContextWithInput(t, recorder, strings.NewReader(""))
+}
+
+func newLinksSetTestContextWithInput(
+	t *testing.T,
+	recorder *linksSetRecorder,
+	input io.Reader,
+) (context.Context, *bytes.Buffer) {
+	t.Helper()
 	srv := httptest.NewServer(linksSetHandler(recorder))
 	t.Cleanup(srv.Close)
 	svc := newSheetsServiceFromServer(t, srv)
 	output := &bytes.Buffer{}
-	ctx := newCmdRuntimeJSONOutputContext(t, output, io.Discard)
+	ctx := outfmt.WithMode(
+		newCmdRuntimeIOContext(t, input, output, io.Discard),
+		outfmt.Mode{JSON: true},
+	)
 	return withSheetsTestService(ctx, svc), output
 }
 
@@ -222,6 +237,52 @@ func TestSheetsLinksSet_BatchCellsJSON(t *testing.T) {
 	}
 	if len(rec.requests) != 2 {
 		t.Fatalf("expected 2 requests, got %d", len(rec.requests))
+	}
+}
+
+func TestSheetsLinksSet_BatchCellsJSONFromFile(t *testing.T) {
+	rec := &linksSetRecorder{}
+	ctx, _ := newLinksSetTestContext(t, rec)
+
+	cellsPath := filepath.Join("testdata", "sheets_links_cells.json")
+	flags := &RootFlags{Account: "a@b.com"}
+	if err := runKong(
+		t,
+		&SheetsLinksSetCmd{},
+		[]string{"s1", "--cells-json", "@" + cellsPath},
+		ctx,
+		flags,
+	); err != nil {
+		t.Fatalf("links set from file: %v", err)
+	}
+	if len(rec.requests) != 2 {
+		t.Fatalf("expected 2 requests, got %d", len(rec.requests))
+	}
+}
+
+func TestSheetsLinksSet_BatchCellsJSONFromStdin(t *testing.T) {
+	rec := &linksSetRecorder{}
+	input := strings.NewReader(
+		`[{"cell":"Sheet1!D4","url":"https://stdin.test","text":"stdin"}]`,
+	)
+	ctx, _ := newLinksSetTestContextWithInput(t, rec, input)
+
+	flags := &RootFlags{Account: "a@b.com"}
+	if err := runKong(
+		t,
+		&SheetsLinksSetCmd{},
+		[]string{"s1", "--cells-json", "@-"},
+		ctx,
+		flags,
+	); err != nil {
+		t.Fatalf("links set from stdin: %v", err)
+	}
+	if len(rec.requests) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(rec.requests))
+	}
+	cell := updateCellsCell(t, rec, 0)
+	if got := cell["userEnteredValue"].(map[string]any)["stringValue"]; got != "stdin" {
+		t.Fatalf("stringValue = %v, want stdin", got)
 	}
 }
 

--- a/internal/cmd/sheets_update_positional_test.go
+++ b/internal/cmd/sheets_update_positional_test.go
@@ -122,7 +122,30 @@ func TestSheetsUpdatePositionalNamedSingleCellPreservesCommas(t *testing.T) {
 	}
 }
 
-func TestSheetsUpdatePositionalMultiCellMismatchDoesNotWrite(t *testing.T) {
+func TestSheetsUpdatePositionalPartialMultiCellRangeWritesOneCell(t *testing.T) {
+	recorder := &sheetsUpdatePositionalRecorder{}
+	ctx := newSheetsUpdatePositionalTestContext(t, recorder)
+
+	err := runKong(
+		t,
+		&SheetsUpdateCmd{},
+		[]string{"s1", "Sheet1!A1:B2", "one"},
+		ctx,
+		&RootFlags{Account: "a@b.com"},
+	)
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if recorder.updateCalls != 1 {
+		t.Fatalf("update calls = %d, want 1", recorder.updateCalls)
+	}
+	if len(recorder.values) != 1 || len(recorder.values[0]) != 1 ||
+		recorder.values[0][0] != "one" {
+		t.Fatalf("values = %#v, want one-cell matrix", recorder.values)
+	}
+}
+
+func TestSheetsUpdatePositionalMultiCellExceedsRangeDoesNotWrite(t *testing.T) {
 	recorder := &sheetsUpdatePositionalRecorder{}
 	ctx := newSheetsUpdatePositionalTestContext(t, recorder)
 
@@ -133,8 +156,8 @@ func TestSheetsUpdatePositionalMultiCellMismatchDoesNotWrite(t *testing.T) {
 		ctx,
 		&RootFlags{Account: "a@b.com"},
 	)
-	if err == nil || !strings.Contains(err.Error(), "update range has 2 rows") {
-		t.Fatalf("error = %v, want range-shape mismatch", err)
+	if err == nil || !strings.Contains(err.Error(), "exceeds the update range maximum of 2 rows") {
+		t.Fatalf("error = %v, want range-bounds error", err)
 	}
 	if recorder.updateCalls != 0 {
 		t.Fatalf("update calls = %d, want 0", recorder.updateCalls)

--- a/internal/cmd/sheets_update_positional_test.go
+++ b/internal/cmd/sheets_update_positional_test.go
@@ -122,6 +122,23 @@ func TestSheetsUpdatePositionalNamedSingleCellPreservesCommas(t *testing.T) {
 	}
 }
 
+func TestSheetsUpdatePositionalNamedRangeDryRunRejectsUnresolvedPreview(t *testing.T) {
+	ctx := newCmdRuntimeOutputContext(t, io.Discard, io.Discard)
+	err := runKong(
+		t,
+		&SheetsUpdateCmd{},
+		[]string{"s1", "NamedSingle", "named, cell, value"},
+		ctx,
+		&RootFlags{Account: "a@b.com", DryRun: true},
+	)
+	if err == nil || !strings.Contains(err.Error(), "cannot be previewed offline") {
+		t.Fatalf("dry-run error = %v, want unresolved-range guidance", err)
+	}
+	if ExitCode(err) != 2 {
+		t.Fatalf("dry-run exit code = %d, want 2", ExitCode(err))
+	}
+}
+
 func TestSheetsUpdatePositionalPartialMultiCellRangeWritesOneCell(t *testing.T) {
 	recorder := &sheetsUpdatePositionalRecorder{}
 	ctx := newSheetsUpdatePositionalTestContext(t, recorder)

--- a/internal/cmd/sheets_update_positional_test.go
+++ b/internal/cmd/sheets_update_positional_test.go
@@ -1,0 +1,142 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/sheets/v4"
+)
+
+type sheetsUpdatePositionalRecorder struct {
+	updateCalls int
+	values      [][]interface{}
+}
+
+func newSheetsUpdatePositionalTestContext(
+	t *testing.T,
+	recorder *sheetsUpdatePositionalRecorder,
+) context.Context {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimPrefix(r.URL.Path, "/sheets/v4")
+		path = strings.TrimPrefix(path, "/v4")
+		switch {
+		case strings.Contains(path, "/spreadsheets/s1/values/") && r.Method == http.MethodPut:
+			recorder.updateCalls++
+			var req sheets.ValueRange
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatalf("decode update request: %v", err)
+			}
+			recorder.values = req.Values
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"updatedRange": "Sheet1!G31",
+				"updatedCells": 1,
+			})
+			return
+		case path == "/spreadsheets/s1" && r.Method == http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"spreadsheetId": "s1",
+				"sheets": []map[string]any{
+					{
+						"properties": map[string]any{
+							"sheetId": 0,
+							"title":   "Sheet1",
+						},
+					},
+				},
+				"namedRanges": []map[string]any{
+					{
+						"namedRangeId": "named-single-id",
+						"name":         "NamedSingle",
+						"range": map[string]any{
+							"sheetId":          0,
+							"startRowIndex":    30,
+							"endRowIndex":      31,
+							"startColumnIndex": 6,
+							"endColumnIndex":   7,
+						},
+					},
+				},
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(srv.Close)
+
+	svc := newSheetsServiceFromServer(t, srv)
+	ctx := newCmdRuntimeOutputContext(t, io.Discard, io.Discard)
+	return withSheetsTestService(ctx, svc)
+}
+
+func TestSheetsUpdatePositionalSingleCellPreservesCommas(t *testing.T) {
+	recorder := &sheetsUpdatePositionalRecorder{}
+	ctx := newSheetsUpdatePositionalTestContext(t, recorder)
+
+	err := runKong(
+		t,
+		&SheetsUpdateCmd{},
+		[]string{"s1", "G31", "text, with, commas"},
+		ctx,
+		&RootFlags{Account: "a@b.com"},
+	)
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if recorder.updateCalls != 1 {
+		t.Fatalf("update calls = %d, want 1", recorder.updateCalls)
+	}
+	if len(recorder.values) != 1 || len(recorder.values[0]) != 1 ||
+		recorder.values[0][0] != "text, with, commas" {
+		t.Fatalf("values = %#v, want one comma-containing cell", recorder.values)
+	}
+}
+
+func TestSheetsUpdatePositionalNamedSingleCellPreservesCommas(t *testing.T) {
+	recorder := &sheetsUpdatePositionalRecorder{}
+	ctx := newSheetsUpdatePositionalTestContext(t, recorder)
+
+	err := runKong(
+		t,
+		&SheetsUpdateCmd{},
+		[]string{"s1", "NamedSingle", "named, cell, value"},
+		ctx,
+		&RootFlags{Account: "a@b.com"},
+	)
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if recorder.updateCalls != 1 {
+		t.Fatalf("update calls = %d, want 1", recorder.updateCalls)
+	}
+	if len(recorder.values) != 1 || len(recorder.values[0]) != 1 ||
+		recorder.values[0][0] != "named, cell, value" {
+		t.Fatalf("values = %#v, want one comma-containing cell", recorder.values)
+	}
+}
+
+func TestSheetsUpdatePositionalMultiCellMismatchDoesNotWrite(t *testing.T) {
+	recorder := &sheetsUpdatePositionalRecorder{}
+	ctx := newSheetsUpdatePositionalTestContext(t, recorder)
+
+	err := runKong(
+		t,
+		&SheetsUpdateCmd{},
+		[]string{"s1", "Sheet1!A1:B2", "a,b,c"},
+		ctx,
+		&RootFlags{Account: "a@b.com"},
+	)
+	if err == nil || !strings.Contains(err.Error(), "update range has 2 rows") {
+		t.Fatalf("error = %v, want range-shape mismatch", err)
+	}
+	if recorder.updateCalls != 0 {
+		t.Fatalf("update calls = %d, want 0", recorder.updateCalls)
+	}
+}

--- a/internal/cmd/testdata/sheets_links_cells.json
+++ b/internal/cmd/testdata/sheets_links_cells.json
@@ -1,0 +1,4 @@
+[
+  {"cell":"Sheet1!B2","url":"https://file.test/b2","text":"B2"},
+  {"cell":"Sheet1!B3","runs":[{"text":"B3","uri":"https://file.test/b3"}]}
+]

--- a/internal/sheetsvalues/values.go
+++ b/internal/sheetsvalues/values.go
@@ -62,6 +62,43 @@ func ParseArgs(values []string) [][]interface{} {
 	return parsed
 }
 
+// ParseArgsForShape parses positional update values while ensuring the
+// resulting payload cannot extend beyond a requested range. A zero row or
+// column count means that dimension is open-ended.
+func ParseArgsForShape(values []string, rowCount, columnCount int64) ([][]interface{}, error) {
+	if rowCount < 0 || columnCount < 0 {
+		return nil, invalidf("invalid update range shape")
+	}
+
+	rawValues := strings.TrimSpace(strings.Join(values, " "))
+	if rowCount == 1 && columnCount == 1 {
+		return [][]interface{}{{rawValues}}, nil
+	}
+
+	parsed := ParseArgs(values)
+	if rowCount > 0 && int64(len(parsed)) != rowCount {
+		return nil, invalidf(
+			"positional values have %d rows, but the update range has %d rows",
+			len(parsed),
+			rowCount,
+		)
+	}
+	if columnCount > 0 {
+		for i, row := range parsed {
+			if int64(len(row)) != columnCount {
+				return nil, invalidf(
+					"positional values row %d has %d cells, but the update range has %d columns",
+					i+1,
+					len(row),
+					columnCount,
+				)
+			}
+		}
+	}
+
+	return parsed, nil
+}
+
 func RequireRows(values [][]interface{}) error {
 	if len(values) == 0 {
 		return invalidf("provide at least one row")

--- a/internal/sheetsvalues/values.go
+++ b/internal/sheetsvalues/values.go
@@ -76,18 +76,18 @@ func ParseArgsForShape(values []string, rowCount, columnCount int64) ([][]interf
 	}
 
 	parsed := ParseArgs(values)
-	if rowCount > 0 && int64(len(parsed)) != rowCount {
+	if rowCount > 0 && int64(len(parsed)) > rowCount {
 		return nil, invalidf(
-			"positional values have %d rows, but the update range has %d rows",
+			"positional values have %d rows, which exceeds the update range maximum of %d rows",
 			len(parsed),
 			rowCount,
 		)
 	}
 	if columnCount > 0 {
 		for i, row := range parsed {
-			if int64(len(row)) != columnCount {
+			if int64(len(row)) > columnCount {
 				return nil, invalidf(
-					"positional values row %d has %d cells, but the update range has %d columns",
+					"positional values row %d has %d cells, which exceeds the update range maximum of %d columns",
 					i+1,
 					len(row),
 					columnCount,

--- a/internal/sheetsvalues/values.go
+++ b/internal/sheetsvalues/values.go
@@ -83,6 +83,7 @@ func ParseArgsForShape(values []string, rowCount, columnCount int64) ([][]interf
 			rowCount,
 		)
 	}
+
 	if columnCount > 0 {
 		for i, row := range parsed {
 			if int64(len(row)) > columnCount {

--- a/internal/sheetsvalues/values_test.go
+++ b/internal/sheetsvalues/values_test.go
@@ -51,6 +51,7 @@ func TestParseArgsForShapeSingleCellPreservesDelimiters(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParseArgsForShape() error = %v", err)
 	}
+
 	if len(values) != 1 || len(values[0]) != 1 ||
 		values[0][0] != "text, with, commas | and pipes" {
 		t.Fatalf("values = %#v", values)
@@ -62,6 +63,7 @@ func TestParseArgsForShapeMatchesMultiCellRange(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParseArgsForShape() error = %v", err)
 	}
+
 	if len(values) != 2 || len(values[0]) != 2 || len(values[1]) != 2 ||
 		values[0][0] != "a" || values[0][1] != "b" ||
 		values[1][0] != "c" || values[1][1] != "d" {
@@ -74,6 +76,7 @@ func TestParseArgsForShapeAllowsSmallerMatrix(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParseArgsForShape() error = %v", err)
 	}
+
 	if len(values) != 1 || len(values[0]) != 1 || values[0][0] != "a" {
 		t.Fatalf("values = %#v, want one-cell matrix", values)
 	}

--- a/internal/sheetsvalues/values_test.go
+++ b/internal/sheetsvalues/values_test.go
@@ -69,15 +69,25 @@ func TestParseArgsForShapeMatchesMultiCellRange(t *testing.T) {
 	}
 }
 
-func TestParseArgsForShapeRejectsMismatchedRange(t *testing.T) {
+func TestParseArgsForShapeAllowsSmallerMatrix(t *testing.T) {
+	values, err := ParseArgsForShape([]string{"a"}, 2, 2)
+	if err != nil {
+		t.Fatalf("ParseArgsForShape() error = %v", err)
+	}
+	if len(values) != 1 || len(values[0]) != 1 || values[0][0] != "a" {
+		t.Fatalf("values = %#v, want one-cell matrix", values)
+	}
+}
+
+func TestParseArgsForShapeRejectsExceedingRangeBounds(t *testing.T) {
 	for _, tc := range []struct {
 		name       string
 		values     []string
 		rows, cols int64
 		want       string
 	}{
-		{name: "rows", values: []string{"a,b,c"}, rows: 2, cols: 1, want: "3 rows"},
-		{name: "columns", values: []string{"a,b"}, rows: 2, cols: 2, want: "row 1 has 1 cells"},
+		{name: "rows", values: []string{"a,b,c"}, rows: 2, cols: 1, want: "3 rows, which exceeds"},
+		{name: "columns", values: []string{"a|b|c"}, rows: 1, cols: 2, want: "3 cells, which exceeds"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			_, err := ParseArgsForShape(tc.values, tc.rows, tc.cols)

--- a/internal/sheetsvalues/values_test.go
+++ b/internal/sheetsvalues/values_test.go
@@ -46,6 +46,48 @@ func TestParseArgs(t *testing.T) {
 	}
 }
 
+func TestParseArgsForShapeSingleCellPreservesDelimiters(t *testing.T) {
+	values, err := ParseArgsForShape([]string{"text, with, commas | and pipes"}, 1, 1)
+	if err != nil {
+		t.Fatalf("ParseArgsForShape() error = %v", err)
+	}
+	if len(values) != 1 || len(values[0]) != 1 ||
+		values[0][0] != "text, with, commas | and pipes" {
+		t.Fatalf("values = %#v", values)
+	}
+}
+
+func TestParseArgsForShapeMatchesMultiCellRange(t *testing.T) {
+	values, err := ParseArgsForShape([]string{"a|b,c|d"}, 2, 2)
+	if err != nil {
+		t.Fatalf("ParseArgsForShape() error = %v", err)
+	}
+	if len(values) != 2 || len(values[0]) != 2 || len(values[1]) != 2 ||
+		values[0][0] != "a" || values[0][1] != "b" ||
+		values[1][0] != "c" || values[1][1] != "d" {
+		t.Fatalf("values = %#v", values)
+	}
+}
+
+func TestParseArgsForShapeRejectsMismatchedRange(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		values     []string
+		rows, cols int64
+		want       string
+	}{
+		{name: "rows", values: []string{"a,b,c"}, rows: 2, cols: 1, want: "3 rows"},
+		{name: "columns", values: []string{"a,b"}, rows: 2, cols: 2, want: "row 1 has 1 cells"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ParseArgsForShape(tc.values, tc.rows, tc.cols)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("ParseArgsForShape() error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
 func TestRequireRows(t *testing.T) {
 	if err := RequireRows(nil); err == nil || !strings.Contains(err.Error(), "at least one row") {
 		t.Fatalf("RequireRows() error = %v", err)


### PR DESCRIPTION
## Problem

`gog sheets update <id> "G31" "text, with, commas"` parses the positional value as comma-separated rows, so a single-cell write fans out down the column and silently overwrites neighboring cells. We hit this in production against a live tracker sheet.

## Fix

- When the target range resolves to a single cell, the positional value is written literally — commas and pipes are never treated as separators.
- For finite multi-cell ranges, the parsed matrix is validated against **maximum bounds**: only payloads whose rows or columns EXCEED the range are rejected (loudly, before the Values API call). Matrices smaller than the range pass through unchanged, preserving the partial-write behavior current main and the Values API support (review round 2 — thanks, the exact-equality check in round 1 was indeed a compatibility regression).
- Named ranges resolve through the existing range catalog before shape checks. `--values-json` and append behavior unchanged.
- `links set --cells-json` now accepts `@file` and `@-` (stdin), matching its sibling flags; docs updated.

## Real behavior proof (redacted)

Built from this branch (`v0.34.2-0.20260727222104+dirty`), run against a disposable test spreadsheet created for this proof; spreadsheet ID redacted:

```
$ gog sheets update <SHEET_ID> "A1" "text, with, commas"   # single cell, comma-bearing value
Updated 1 cells in 'gog-pr941-proof-disposable'!A1

$ gog sheets get <SHEET_ID> "A1:A3"   # A1 literal, neighbors untouched
text, with, commas

$ gog sheets update <SHEET_ID> "A1:B2" "r1a|r1b,r2a|r2b,r3a|r3b"   # 3 rows into 2-row range -> must reject BEFORE API call
positional values have 3 rows, which exceeds the update range maximum of 2 rows
exit: 2

$ gog sheets update <SHEET_ID> "C1:D2" "only-one-value"   # partial write within larger finite range -> must succeed (P1 compat)
Updated 1 cells in 'gog-pr941-proof-disposable'!C1

$ gog sheets get <SHEET_ID> "C1:D2"
only-one-value
```

All three review asks demonstrated live: (1) comma-containing single-cell update lands literally in exactly one cell with neighbors untouched, (2) oversize payload rejected before the API call (exit 2), (3) partial positional write within a larger finite range succeeds — the P1 case.

## Tests

`go test ./internal/sheetsvalues`, `go test ./internal/cmd -run 'TestSheetsUpdatePositional|TestSheetsLinksSet'`, and `go test ./...` all green (42 packages). New coverage: `TestSheetsUpdatePositionalPartialMultiCellRangeWritesOneCell` (asserts the recorder receives exactly `[["one"]]`), `TestParseArgsForShapeAllowsSmallerMatrix`, `TestParseArgsForShapeRejectsExceedingRangeBounds`, plus the existing single-cell literal and zero-write-on-error assertions.