### PR TITLE
fix(outfmt): preserve single-object Gmail results containing attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.34.2 - 2026-07-27
 
+- Gmail: preserve single-object result envelopes for attachment-bearing `--results-only` output. (#943) — thanks @hashtag1974.
 - Sheets: keep positional updates within the requested range, preserving comma-bearing single-cell values and accurate named-range dry runs. (#941) — thanks @cathrynlavery.
 - Gmail: add source-specific `internalDateIso` timestamps to message and thread listings while preserving the legacy sender-header `date`. (#945, #946) — thanks @chrischall.
 - Gmail: prevent standalone draft updates from acquiring self-referential reply headers, with explicit recovery for affected drafts. (#942, #944) — thanks @chrischall.

--- a/internal/cmd/gmail_drafts.go
+++ b/internal/cmd/gmail_drafts.go
@@ -466,7 +466,7 @@ func writeDraftResult(ctx context.Context, u *ui.UI, draft *gmail.Draft, threadI
 		if len(attachments) > 0 {
 			result["attachments"] = attachments
 		}
-		return outfmt.WriteJSON(ctx, stdoutWriter(ctx), result)
+		return outfmt.WriteJSON(ctx, stdoutWriter(ctx), outfmt.PrimaryResult(result))
 	}
 	u.Out().Linef("draft_id\t%s", draft.Id)
 	if draft.Message != nil && draft.Message.Id != "" {

--- a/internal/cmd/gmail_drafts_cmd_test.go
+++ b/internal/cmd/gmail_drafts_cmd_test.go
@@ -386,12 +386,21 @@ func TestGmailDraftsCreateCmd_JSON_ResultsOnlyPreservesCompleteAttachmentResult(
 	if !ok {
 		t.Fatalf("expected complete Gmail draft-create object, got %T: %s", gotValue, got)
 	}
-	for _, key := range []string{"draftId", "message", "threadId", "attachments"} {
+	expectedKeys := []string{
+		"draftId",
+		"message",
+		"threadId",
+		"attachments",
+		"inReplyTo",
+		"references",
+		"replyContextSource",
+	}
+	for _, key := range expectedKeys {
 		if _, ok := parsed[key]; !ok {
 			t.Fatalf("synthetic pre-transform shape is missing %q: %s", key, got)
 		}
 	}
-	if len(parsed) != 4 {
+	if len(parsed) != len(expectedKeys) {
 		t.Fatalf("unexpected synthetic pre-transform keys: %s", got)
 	}
 }

--- a/internal/cmd/gmail_drafts_cmd_test.go
+++ b/internal/cmd/gmail_drafts_cmd_test.go
@@ -9,12 +9,14 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
 	"google.golang.org/api/gmail/v1"
 
 	"github.com/steipete/gogcli/internal/mailmime"
+	"github.com/steipete/gogcli/internal/outfmt"
 )
 
 type gmailQuoteSource struct {
@@ -321,6 +323,76 @@ func TestGmailDraftsCreateCmd_JSON(t *testing.T) {
 	}
 	if parsed.DraftID != "d1" {
 		t.Fatalf("unexpected json: %#v", parsed)
+	}
+}
+
+func TestGmailDraftsCreateCmd_JSON_ResultsOnlyPreservesCompleteAttachmentResult(t *testing.T) {
+	attachmentPath := filepath.Join(t.TempDir(), "fixture.txt")
+	if err := os.WriteFile(attachmentPath, []byte("fixture"), 0o600); err != nil {
+		t.Fatalf("write attachment: %v", err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/gmail/v1/users/me/drafts") && r.Method == http.MethodPost {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id": "d1",
+				"message": map[string]any{
+					"id":       "m1",
+					"threadId": "t1",
+				},
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	run := func(resultsOnly bool) []byte {
+		t.Helper()
+		svc := newGmailServiceFromServer(t, srv)
+		flags := &RootFlags{Account: "synthetic@example.com"}
+		var jsonOut bytes.Buffer
+		ctx := withGmailTestService(newCmdRuntimeJSONOutputContext(t, &jsonOut, io.Discard), svc)
+		if resultsOnly {
+			ctx = outfmt.WithJSONTransform(ctx, outfmt.JSONTransform{ResultsOnly: true})
+		}
+		if err := runKong(t, &GmailDraftsCreateCmd{}, []string{
+			"--to", "recipient@example.com",
+			"--subject", "Synthetic subject",
+			"--body", "Synthetic body",
+			"--attach", attachmentPath,
+		}, ctx, flags); err != nil {
+			t.Fatalf("execute: %v", err)
+		}
+		return jsonOut.Bytes()
+	}
+
+	baseline := run(false)
+	got := run(true)
+	var wantValue any
+	if err := json.Unmarshal(baseline, &wantValue); err != nil {
+		t.Fatalf("baseline json parse: %v", err)
+	}
+	var gotValue any
+	if err := json.Unmarshal(got, &gotValue); err != nil {
+		t.Fatalf("results-only json parse: %v", err)
+	}
+	if !reflect.DeepEqual(gotValue, wantValue) {
+		t.Fatalf("--results-only changed the complete Gmail draft-create result:\ngot:\n%s\nwant:\n%s", got, baseline)
+	}
+
+	parsed, ok := gotValue.(map[string]any)
+	if !ok {
+		t.Fatalf("expected complete Gmail draft-create object, got %T: %s", gotValue, got)
+	}
+	for _, key := range []string{"draftId", "message", "threadId", "attachments"} {
+		if _, ok := parsed[key]; !ok {
+			t.Fatalf("synthetic pre-transform shape is missing %q: %s", key, got)
+		}
+	}
+	if len(parsed) != 4 {
+		t.Fatalf("unexpected synthetic pre-transform keys: %s", got)
 	}
 }
 

--- a/internal/cmd/gmail_get.go
+++ b/internal/cmd/gmail_get.go
@@ -113,7 +113,7 @@ func (c *GmailGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 				payload["attachments"] = attachmentOutputs(attachments)
 			}
 		}
-		return outfmt.WriteJSON(ctx, stdoutWriter(ctx), payload)
+		return outfmt.WriteJSON(ctx, stdoutWriter(ctx), outfmt.PrimaryResult(payload))
 	}
 
 	u.Out().Linef("id\t%s%s", msg.Id, gmailHumanMessageStatusMarker(ctx, msg.LabelIds))

--- a/internal/cmd/gmail_get_cmd_test.go
+++ b/internal/cmd/gmail_get_cmd_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -269,6 +270,56 @@ func gmailGetAttachmentHandler(subject, body string) http.Handler {
 			},
 		})
 	})
+}
+
+func TestGmailGetCmd_JSON_ResultsOnlyPreservesCompleteAttachmentResult(t *testing.T) {
+	srv := httptest.NewServer(gmailGetAttachmentHandler("Synthetic attachment", "synthetic body"))
+	defer srv.Close()
+
+	run := func(resultsOnly bool) []byte {
+		t.Helper()
+		args := []string{"--json"}
+		if resultsOnly {
+			args = append(args, "--results-only")
+		}
+		args = append(args,
+			"--account", "synthetic@example.com",
+			"gmail", "get", "m1",
+			"--format", "full",
+		)
+		result := executeWithGmailTestService(t, args, newGmailServiceFromServer(t, srv))
+		if result.err != nil {
+			t.Fatalf("execute: %v\nstderr=%q", result.err, result.stderr)
+		}
+		return []byte(result.stdout)
+	}
+
+	baseline := run(false)
+	got := run(true)
+	var wantValue any
+	if err := json.Unmarshal(baseline, &wantValue); err != nil {
+		t.Fatalf("baseline json parse: %v", err)
+	}
+	var gotValue any
+	if err := json.Unmarshal(got, &gotValue); err != nil {
+		t.Fatalf("results-only json parse: %v", err)
+	}
+	if !reflect.DeepEqual(gotValue, wantValue) {
+		t.Fatalf("--results-only changed the complete Gmail get result:\ngot:\n%s\nwant:\n%s", got, baseline)
+	}
+
+	parsed, ok := gotValue.(map[string]any)
+	if !ok {
+		t.Fatalf("expected complete Gmail get object, got %T: %s", gotValue, got)
+	}
+	for _, key := range []string{"message", "headers", "body", "attachments"} {
+		if _, ok := parsed[key]; !ok {
+			t.Fatalf("synthetic pre-transform shape is missing %q: %s", key, got)
+		}
+	}
+	if len(parsed) != 4 {
+		t.Fatalf("unexpected synthetic pre-transform keys: %s", got)
+	}
 }
 
 func TestGmailGetCmd_Text_Full_WithAttachments(t *testing.T) {

--- a/internal/outfmt/outfmt.go
+++ b/internal/outfmt/outfmt.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 )
@@ -71,6 +72,17 @@ type JSONTransform struct {
 
 type jsonTransformKey struct{}
 
+type primaryResult struct {
+	value any
+}
+
+// PrimaryResult marks a complete JSON value as already being the command's
+// primary result. WriteJSON still applies field selection, but --results-only
+// preserves the complete value instead of inferring a nested collection.
+func PrimaryResult(value any) any {
+	return primaryResult{value: value}
+}
+
 func WithJSONTransform(ctx context.Context, t JSONTransform) context.Context {
 	return context.WithValue(ctx, jsonTransformKey{}, t)
 }
@@ -87,7 +99,18 @@ func JSONTransformFromContext(ctx context.Context) (JSONTransform, bool) {
 }
 
 func WriteJSON(ctx context.Context, w io.Writer, v any) error {
+	alreadyPrimary := false
+
+	if result, ok := v.(primaryResult); ok {
+		v = result.value
+		alreadyPrimary = true
+	}
+
 	if t, ok := JSONTransformFromContext(ctx); ok && (t.ResultsOnly || len(t.Select) > 0) {
+		if alreadyPrimary {
+			t.ResultsOnly = false
+		}
+
 		transformed, err := applyJSONTransform(v, t)
 		if err != nil {
 			return fmt.Errorf("transform json: %w", err)
@@ -173,6 +196,8 @@ func unwrapPrimary(v any) any {
 		}
 		candidates = append(candidates, k)
 	}
+
+	sort.Strings(candidates)
 
 	if len(candidates) == 1 {
 		return m[candidates[0]]

--- a/internal/outfmt/outfmt_test.go
+++ b/internal/outfmt/outfmt_test.go
@@ -127,6 +127,110 @@ func TestWriteJSON_ResultsOnlyDoesNotPreferScalarKnownKeyOverArray(t *testing.T)
 	}
 }
 
+func TestWriteJSON_ResultsOnlyPreservesExplicitPrimaryResult(t *testing.T) {
+	ctx := WithJSONTransform(context.Background(), JSONTransform{ResultsOnly: true})
+	input := map[string]any{
+		"draftId": "d1",
+		"message": map[string]any{
+			"id":       "m1",
+			"threadId": "t1",
+		},
+		"threadId": "t1",
+		"attachments": []map[string]any{{
+			"filename": "fixture.txt",
+			"size":     7,
+		}},
+	}
+
+	var baseline bytes.Buffer
+	if err := WriteJSON(context.Background(), &baseline, input); err != nil {
+		t.Fatalf("WriteJSON baseline: %v", err)
+	}
+
+	var got bytes.Buffer
+	if err := WriteJSON(ctx, &got, PrimaryResult(input)); err != nil {
+		t.Fatalf("WriteJSON primary result: %v", err)
+	}
+
+	if got.String() != baseline.String() {
+		t.Fatalf("complete primary result changed:\ngot:\n%s\nwant:\n%s", got.String(), baseline.String())
+	}
+}
+
+func TestWriteJSON_ResultsOnlyGenericArraySelectionIsDeterministic(t *testing.T) {
+	ctx := WithJSONTransform(context.Background(), JSONTransform{ResultsOnly: true})
+	input := map[string]any{
+		"zItems": []map[string]any{{"id": "z"}},
+		"aItems": []map[string]any{{"id": "a"}},
+	}
+
+	for range 50 {
+		var buf bytes.Buffer
+		if err := WriteJSON(ctx, &buf, input); err != nil {
+			t.Fatalf("WriteJSON: %v", err)
+		}
+
+		var got []map[string]any
+		if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+			t.Fatalf("unmarshal: %v (out=%q)", err, buf.String())
+		}
+
+		if len(got) != 1 || got[0]["id"] != "a" {
+			t.Fatalf("generic selection was not deterministic: %s", strings.TrimSpace(buf.String()))
+		}
+	}
+}
+
+func TestWriteJSON_ResultsOnlyAttachmentCommandStillReturnsAttachments(t *testing.T) {
+	ctx := WithJSONTransform(context.Background(), JSONTransform{ResultsOnly: true})
+	input := map[string]any{
+		"threadId": "t1",
+		"attachments": []map[string]any{{
+			"messageId": "m1",
+			"filename":  "fixture.txt",
+		}},
+	}
+
+	var buf bytes.Buffer
+	if err := WriteJSON(ctx, &buf, input); err != nil {
+		t.Fatalf("WriteJSON: %v", err)
+	}
+
+	var got []map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v (out=%q)", err, buf.String())
+	}
+
+	if len(got) != 1 || got[0]["messageId"] != "m1" || got[0]["filename"] != "fixture.txt" {
+		t.Fatalf("attachment-specific result changed: %s", strings.TrimSpace(buf.String()))
+	}
+}
+
+func TestWriteJSON_ResultsOnlyListCommandStillReturnsItems(t *testing.T) {
+	ctx := WithJSONTransform(context.Background(), JSONTransform{ResultsOnly: true})
+	input := map[string]any{
+		"messages": []map[string]any{
+			{"id": "m1", "threadId": "t1"},
+			{"id": "m2", "threadId": "t2"},
+		},
+		"nextPageToken": "next-page",
+	}
+
+	var buf bytes.Buffer
+	if err := WriteJSON(ctx, &buf, input); err != nil {
+		t.Fatalf("WriteJSON: %v", err)
+	}
+
+	var got []map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v (out=%q)", err, buf.String())
+	}
+
+	if len(got) != 2 || got[0]["id"] != "m1" || got[1]["id"] != "m2" {
+		t.Fatalf("list result changed: %s", strings.TrimSpace(buf.String()))
+	}
+}
+
 func TestWriteJSONTransformPreservesLargeNumbers(t *testing.T) {
 	ctx := WithJSONTransform(context.Background(), JSONTransform{Select: []string{"id"}})
 


### PR DESCRIPTION
## Problem

When a Gmail command returns a single-resource JSON result containing a secondary `attachments` array, the generic `--results-only` transformer can select that array as the primary result. This discards the message or draft envelope.

Affected examples:

```bash
gog gmail get <message-id-with-attachment> --json --results-only
gog gmail drafts create ... --json --results-only
```

## Fix

Commands whose complete output is already the primary result now mark it explicitly. `WriteJSON` preserves that complete value under `--results-only` while continuing to apply field selection.

Generic fallback candidate keys are sorted before selection, eliminating map-iteration-dependent behavior.

## Compatibility

- Existing list commands continue returning their item arrays under `--results-only`.
- Attachment-specific commands continue returning their attachment arrays.
- No flags or default JSON output formats change.

## Testing

- Focused `internal/outfmt` and `internal/cmd` regression tests
- Complete decoded-result comparisons for Gmail message-get and draft-create response shapes
- Synthetic fixtures matching the real pre-transform JSON structures
- Deterministic fallback coverage
- List and attachment-specific compatibility coverage
- Full `make ci`


## Real Gmail behavior verification

I rebuilt the executable from clean commit `fac056d8497907d2d96dacc643c050b3a277aa4e` and reran both affected flows against the real Gmail API.

Provenance:

```text
v0.34.1-15-gfac056d8 (fac056d84979 2026-07-29T14:49:49Z)
SHA-256: 0985cbe95ddfbf9b9f0dde916f2c1a0c6329d1c229092b37ce9875745b88d269
```

The repository was clean before and after the build. The build used the official `go1.26.5 darwin/arm64` archive after SHA-256 verification.

With the released pre-fix executable, `gmail get --format full --json --results-only` returned only the two-item `attachments` array, dropping the surrounding message result. With the clean `fac056d8` executable, it returned one object containing:

```json
{
  "attachments": ["<2 REDACTED ATTACHMENT OBJECTS>"],
  "body": "<REDACTED>",
  "headers": "<REDACTED COMPLETE HEADER OBJECT>",
  "message": "<REDACTED COMPLETE MESSAGE OBJECT>"
}
```

The two live reads agreed on attachment count, filenames, MIME types, and sizes. Gmail returned different opaque attachment IDs between calls, so exact whole-array equality is not claimed.

For a real unsent draft-create flow with one synthetic attachment, the pre-fix executable again returned only the attachment array. The clean `fac056d8` executable returned:

```json
{
  "attachments": ["<1 REDACTED ATTACHMENT OBJECT>"],
  "draftId": "<REDACTED>",
  "message": "<REDACTED COMPLETE MESSAGE OBJECT>",
  "threadId": "<REDACTED>"
}
```

The clean-commit rerun confirmed the complete draft object and one attachment entry. Gmail sending was blocked with `--gmail-no-send`; no message was sent.

All personal addresses, names, subjects, bodies, snippets, message/thread/draft/attachment IDs, attachment names, account details, labels, MIME types, dates, sizes, and local paths have been removed or replaced.

