### PR TITLE
fix(gmail): stop drafts update referencing the draft's own revision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Gmail: report exact file-input byte counts in compose dry-run output, including forwarded-message notes with trailing newlines. (#936, #937) — thanks @chrischall.
 - Setup: replace obsolete Google Cloud API enablement links with direct API Library URLs while preserving project-scoped recovery hints. (#933) — thanks @LinXunFeng.
 - Docs: `docs write` now rejects an explicitly empty `--tab`/`--tab-id` value instead of silently targeting the whole document.
-- Gmail: stop `drafts update` anchoring `In-Reply-To`/`References` to the draft's own previous revision, keeping thread continuity separate from reply lineage, preserving genuine reply context across repeated updates without growing `References`, refusing drafts as reply targets, reporting the effective reply context, and adding `--clear-reply-context`. (#942)
+- Gmail: stop `drafts update` anchoring `In-Reply-To`/`References` to the draft's own previous revision, keeping thread continuity separate from reply lineage, preserving genuine reply context across repeated updates without growing `References`, refusing drafts as reply targets, reporting the effective reply context, and adding `--clear-reply-context`. (#942, #944)
 
 ## 0.34.1 - 2026-07-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Gmail: report exact file-input byte counts in compose dry-run output, including forwarded-message notes with trailing newlines. (#936, #937) — thanks @chrischall.
 - Setup: replace obsolete Google Cloud API enablement links with direct API Library URLs while preserving project-scoped recovery hints. (#933) — thanks @LinXunFeng.
 - Docs: `docs write` now rejects an explicitly empty `--tab`/`--tab-id` value instead of silently targeting the whole document.
+- Gmail: stop `drafts update` anchoring `In-Reply-To`/`References` to the draft's own previous revision, keeping thread continuity separate from reply lineage, preserving genuine reply context across repeated updates without growing `References`, refusing drafts as reply targets, reporting the effective reply context, and adding `--clear-reply-context`. (#942)
 
 ## 0.34.1 - 2026-07-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.34.2 - 2026-07-27
 
+- Gmail: prevent standalone draft updates from acquiring self-referential reply headers, with explicit recovery for affected drafts. (#942, #944) — thanks @chrischall.
 - Security: update gRPC-Go, PostCSS, and Sharp/libvips to patched releases, clearing three high-severity dependency alerts. (#940)
 - Drive: add opt-in `upload --replace --if-version` conflict protection using a fail-closed ETag precondition, without changing unconditional replacement. (#929) — thanks @karstenevers.
 - Gmail: acknowledge terminal watch OAuth failures only after durably recording reauthentication recovery state, preserving the last processed history cursor for catch-up after renewal. (#930) — thanks @litang9.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@
 - Gmail: report exact file-input byte counts in compose dry-run output, including forwarded-message notes with trailing newlines. (#936, #937) — thanks @chrischall.
 - Setup: replace obsolete Google Cloud API enablement links with direct API Library URLs while preserving project-scoped recovery hints. (#933) — thanks @LinXunFeng.
 - Docs: `docs write` now rejects an explicitly empty `--tab`/`--tab-id` value instead of silently targeting the whole document.
-- Gmail: stop `drafts update` anchoring `In-Reply-To`/`References` to the draft's own previous revision, keeping thread continuity separate from reply lineage, preserving genuine reply context across repeated updates without growing `References`, refusing drafts as reply targets, reporting the effective reply context, and adding `--clear-reply-context`. (#942, #944)
 
 ## 0.34.1 - 2026-07-16
 

--- a/docs/commands/gog-gmail-drafts-update.md
+++ b/docs/commands/gog-gmail-drafts-update.md
@@ -28,6 +28,7 @@ gog gmail (mail,email) drafts (draft) update (edit,set) <draftId> [flags]
 | `--body-html-file` | `string` |  | HTML body file path ('-' for stdin) |
 | `--cc` | `string` |  | CC recipients (comma-separated) |
 | `--clear-attachments` | `bool` |  | Remove all attachments from the draft. By default, omitting --attach preserves the draft's existing attachments. |
+| `--clear-reply-context` | `bool` |  | Strip In-Reply-To/References from the draft, making it a standalone message. By default an update preserves the draft's existing reply headers. |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |

--- a/internal/cmd/gmail_drafts.go
+++ b/internal/cmd/gmail_drafts.go
@@ -767,8 +767,8 @@ func (c *GmailDraftsUpdateCmd) Run(ctx context.Context, flags *RootFlags) error 
 	if replyToMessageID != "" && threadID != "" {
 		return usage("use only one of --reply-to-message-id or --thread-id")
 	}
-	if c.ClearReplyContext && (replyToMessageID != "" || threadID != "") {
-		return usage("use only one of --clear-reply-context or --reply-to-message-id/--thread-id")
+	if c.ClearReplyContext && (replyToMessageID != "" || threadID != "" || c.Quote) {
+		return usage("use only one of --clear-reply-context or --reply-to-message-id/--thread-id/--quote")
 	}
 
 	attachPaths, err := expandComposeAttachmentPaths(c.Attach)

--- a/internal/cmd/gmail_drafts.go
+++ b/internal/cmd/gmail_drafts.go
@@ -278,10 +278,20 @@ type draftComposeInput struct {
 	BodyHTML         string
 	ReplyToMessageID string
 	ReplyToThreadID  string
-	ReplyAll         bool
-	ReplyTo          string
-	Quote            bool
-	Attach           []string
+	// ThreadContinuityID keeps a rebuilt message in the thread it already
+	// belongs to. It is deliberately NOT a reply target: where a message lives
+	// says nothing about what it replies to. Only used when no reply target
+	// resolved a thread of its own.
+	ThreadContinuityID string
+	// InReplyTo/References carry a reply lineage that has already been
+	// resolved elsewhere — on update, the lineage the draft itself already
+	// stores. Applied verbatim, so repeated updates are idempotent.
+	InReplyTo  string
+	References string
+	ReplyAll   bool
+	ReplyTo    string
+	Quote      bool
+	Attach     []string
 	// PrebuiltAttachments carry already-resolved attachment bytes (e.g. existing
 	// draft attachments preserved across an update) alongside any --attach paths.
 	PrebuiltAttachments []mailmime.Attachment
@@ -305,24 +315,49 @@ func (c draftComposeInput) validate() error {
 	return nil
 }
 
-func buildDraftMessage(ctx context.Context, svc *gmail.Service, account string, input draftComposeInput) (*gmail.Message, string, []mailmime.AttachmentMetadata, error) {
+func buildDraftMessage(ctx context.Context, svc *gmail.Service, account string, input draftComposeInput) (*gmail.Message, draftThreading, []mailmime.AttachmentMetadata, error) {
 	sendAs, sendAsErr := listSendAs(ctx, svc)
 	from, err := resolveComposeFrom(ctx, svc, account, input.From, sendAs, sendAsErr)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, draftThreading{}, nil, err
 	}
 
 	info, body, htmlBody, err := prepareComposeReply(ctx, svc, input.ReplyToMessageID, input.ReplyToThreadID, input.Quote, input.Body, input.BodyHTML)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, draftThreading{}, nil, err
 	}
-	threadID := info.ThreadID
+	replyContextSource := ""
+	if strings.TrimSpace(info.InReplyTo) != "" {
+		replyContextSource = replyContextCaller
+	}
+	// No reply target resolved a thread, so fall back to the thread the message
+	// already lives in. Thread continuity only — this must not populate
+	// In-Reply-To/References.
+	if strings.TrimSpace(info.ThreadID) == "" {
+		info.ThreadID = strings.TrimSpace(input.ThreadContinuityID)
+	}
+	// No reply target resolved a lineage either, so re-apply whatever lineage
+	// the caller carried in (an update preserving the draft's own headers).
+	if strings.TrimSpace(info.InReplyTo) == "" && strings.TrimSpace(input.InReplyTo) != "" {
+		info.InReplyTo = input.InReplyTo
+		info.References = input.References
+		if strings.TrimSpace(info.References) == "" {
+			info.References = input.InReplyTo
+		}
+		replyContextSource = replyContextCarried
+	}
+	threading := draftThreading{
+		ThreadID:   info.ThreadID,
+		InReplyTo:  strings.TrimSpace(info.InReplyTo),
+		References: strings.TrimSpace(info.References),
+		Source:     replyContextSource,
+	}
 	atts := attachmentsFromPaths(input.Attach)
 	atts = append(atts, input.PrebuiltAttachments...)
 	atts = append(atts, info.InlineResources...)
 	atts, attachmentMetadata, err := mailmime.PrepareAttachments(atts, os.ReadFile)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, draftThreading{}, nil, err
 	}
 	subject := input.Subject
 	if strings.TrimSpace(subject) == "" {
@@ -343,7 +378,7 @@ func buildDraftMessage(ctx context.Context, svc *gmail.Service, account string, 
 			nil,
 		)
 		if recipientErr != nil {
-			return nil, "", nil, recipientErr
+			return nil, draftThreading{}, nil, recipientErr
 		}
 		toRecipients = formatMailboxes(recipients.To)
 		ccRecipients = formatMailboxes(recipients.Cc)
@@ -373,10 +408,10 @@ func buildDraftMessage(ctx context.Context, svc *gmail.Service, account string, 
 		Bcc: bccRecipients,
 	}, true)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, draftThreading{}, nil, err
 	}
 
-	return msg, threadID, attachmentMetadata, nil
+	return msg, threading, attachmentMetadata, nil
 }
 
 // carryForwardDraftAttachments fetches the bytes of an existing draft message's
@@ -453,15 +488,50 @@ func fetchDraftAttachmentBytes(ctx context.Context, svc *gmail.Service, messageI
 	return gmailcontent.DecodeBase64URLBytes(body.Data)
 }
 
-func writeDraftResult(ctx context.Context, u *ui.UI, draft *gmail.Draft, threadID string, attachments []mailmime.AttachmentMetadata) error {
+// draftThreading is the threading actually written to a draft: where it lives
+// (ThreadID) and what it replies to (InReplyTo/References), reported back so a
+// caller can verify without re-fetching raw headers. Source records where the
+// reply lineage came from — "caller" (an explicit reply target) or "carried"
+// (preserved from the draft's own stored headers); empty when the draft has no
+// reply context at all, which reports as null alongside the headers themselves.
+type draftThreading struct {
+	ThreadID   string
+	InReplyTo  string
+	References string
+	Source     string
+}
+
+const (
+	replyContextCaller  = "caller"
+	replyContextCarried = "carried"
+)
+
+// nilIfEmpty reports a header as an explicit JSON null when unset, so callers
+// can distinguish "no reply context" from "field not reported".
+func nilIfEmpty(s string) any {
+	if strings.TrimSpace(s) == "" {
+		return nil
+	}
+	return s
+}
+
+func writeDraftResult(ctx context.Context, u *ui.UI, draft *gmail.Draft, threading draftThreading, attachments []mailmime.AttachmentMetadata) error {
+	threadID := threading.ThreadID
 	if threadID == "" && draft != nil && draft.Message != nil {
 		threadID = draft.Message.ThreadId
 	}
+	source := threading.Source
+	if source == replyContextCarried {
+		u.Err().Linef("Warning: reply headers preserved from the existing draft (In-Reply-To %s); pass --clear-reply-context to drop them", threading.InReplyTo)
+	}
 	if outfmt.IsJSON(ctx) {
 		result := map[string]any{
-			"draftId":  draft.Id,
-			"message":  draft.Message,
-			"threadId": threadID,
+			"draftId":            draft.Id,
+			"message":            draft.Message,
+			"threadId":           threadID,
+			"inReplyTo":          nilIfEmpty(threading.InReplyTo),
+			"references":         nilIfEmpty(threading.References),
+			"replyContextSource": nilIfEmpty(source),
 		}
 		if len(attachments) > 0 {
 			result["attachments"] = attachments
@@ -474,6 +544,15 @@ func writeDraftResult(ctx context.Context, u *ui.UI, draft *gmail.Draft, threadI
 	}
 	if threadID != "" {
 		u.Out().Linef("thread_id\t%s", threadID)
+	}
+	if threading.InReplyTo != "" {
+		u.Out().Linef("in_reply_to\t%s", threading.InReplyTo)
+	}
+	if threading.References != "" {
+		u.Out().Linef("references\t%s", threading.References)
+	}
+	if source != "" {
+		u.Out().Linef("reply_context_source\t%s", source)
 	}
 	return nil
 }
@@ -631,7 +710,7 @@ func (c *GmailDraftsCreateCmd) Run(ctx context.Context, flags *RootFlags) error 
 		return err
 	}
 
-	msg, threadID, attachmentMetadata, err := buildDraftMessage(ctx, svc, account, input)
+	msg, threading, attachmentMetadata, err := buildDraftMessage(ctx, svc, account, input)
 	if err != nil {
 		return err
 	}
@@ -640,7 +719,7 @@ func (c *GmailDraftsCreateCmd) Run(ctx context.Context, flags *RootFlags) error 
 	if err != nil {
 		return err
 	}
-	return writeDraftResult(ctx, u, draft, threadID, attachmentMetadata)
+	return writeDraftResult(ctx, u, draft, threading, attachmentMetadata)
 }
 
 type GmailDraftsUpdateCmd struct {
@@ -660,7 +739,9 @@ type GmailDraftsUpdateCmd struct {
 	Quote            bool     `name:"quote" help:"Include quoted original message in reply"`
 	Attach           []string `name:"attach" help:"Attachment file path (repeatable). Replaces existing attachments; omit to preserve them, or use --clear-attachments to remove all."`
 	ClearAttachments bool     `name:"clear-attachments" help:"Remove all attachments from the draft. By default, omitting --attach preserves the draft's existing attachments."`
-	From             string   `name:"from" help:"Send from this email address (must be a verified send-as alias)"`
+	//nolint:lll // flag help text
+	ClearReplyContext bool   `name:"clear-reply-context" help:"Strip In-Reply-To/References from the draft, making it a standalone message. By default an update preserves the draft's existing reply headers."`
+	From              string `name:"from" help:"Send from this email address (must be a verified send-as alias)"`
 }
 
 func (c *GmailDraftsUpdateCmd) Run(ctx context.Context, flags *RootFlags) error {
@@ -685,6 +766,9 @@ func (c *GmailDraftsUpdateCmd) Run(ctx context.Context, flags *RootFlags) error 
 	threadID := normalizeGmailThreadID(c.ThreadID)
 	if replyToMessageID != "" && threadID != "" {
 		return usage("use only one of --reply-to-message-id or --thread-id")
+	}
+	if c.ClearReplyContext && (replyToMessageID != "" || threadID != "") {
+		return usage("use only one of --clear-reply-context or --reply-to-message-id/--thread-id")
 	}
 
 	attachPaths, err := expandComposeAttachmentPaths(c.Attach)
@@ -739,6 +823,7 @@ func (c *GmailDraftsUpdateCmd) Run(ctx context.Context, flags *RootFlags) error 
 		"clear_attachments":    c.ClearAttachments,
 		"preserve_attachments": preserveAttachments,
 		"thread_id":            strings.TrimSpace(threadID),
+		"clear_reply_context":  c.ClearReplyContext,
 	}); dryRunErr != nil {
 		return dryRunErr
 	}
@@ -751,6 +836,8 @@ func (c *GmailDraftsUpdateCmd) Run(ctx context.Context, flags *RootFlags) error 
 	existingThreadID := ""
 	existingMessageID := ""
 	existingTo := ""
+	existingInReplyTo := ""
+	existingReferences := ""
 	var existingPayload *gmail.MessagePart
 	if (!toWasSet && !c.ReplyAll) || strings.TrimSpace(replyToMessageID) == "" || preserveAttachments {
 		existing, fetchErr := svc.Users.Drafts.Get("me", draftID).Format("full").Do()
@@ -761,6 +848,8 @@ func (c *GmailDraftsUpdateCmd) Run(ctx context.Context, flags *RootFlags) error 
 			existingThreadID = strings.TrimSpace(existing.Message.ThreadId)
 			existingMessageID = strings.TrimSpace(existing.Message.Id)
 			existingPayload = existing.Message.Payload
+			existingInReplyTo = strings.TrimSpace(headerValue(existing.Message.Payload, "In-Reply-To"))
+			existingReferences = strings.TrimSpace(headerValue(existing.Message.Payload, "References"))
 			if !toWasSet && !c.ReplyAll {
 				existingTo = strings.TrimSpace(headerValue(existing.Message.Payload, "To"))
 			}
@@ -770,9 +859,9 @@ func (c *GmailDraftsUpdateCmd) Run(ctx context.Context, flags *RootFlags) error 
 		to = existingTo
 	}
 
-	// A caller-provided --thread-id targets that thread for reply headers,
-	// overriding the draft's own existing thread; otherwise fall back to the
-	// existing draft thread as before.
+	// The thread the draft already lives in. Used for --quote target discovery
+	// (which skips drafts) and for thread continuity — never as a reply target.
+	// A caller-provided --thread-id overrides it and moves the draft.
 	targetThreadID := existingThreadID
 	if threadID != "" {
 		targetThreadID = threadID
@@ -796,18 +885,34 @@ func (c *GmailDraftsUpdateCmd) Run(ctx context.Context, flags *RootFlags) error 
 		}
 		replyToMessageID = resolvedMessageID
 	}
+	// Only a caller-supplied thread is a reply target. Anchoring to the draft's
+	// own thread would resolve In-Reply-To/References from the newest message
+	// in it — which, for a draft, is the draft's own previous revision: a
+	// message that was never sent and that no recipient can thread against.
 	if strings.TrimSpace(replyToMessageID) == "" {
-		replyToThreadID = targetThreadID
+		replyToThreadID = threadID
 	}
-	if c.Quote && strings.TrimSpace(replyToMessageID) == "" && strings.TrimSpace(replyToThreadID) == "" {
-		return usage("--quote requires --reply-to-message-id or --thread-id or existing draft thread")
+
+	// Reply lineage survives an update because it is carried forward from the
+	// draft's own stored headers, not re-derived. Applying the same values
+	// every time keeps repeated updates idempotent and stops References from
+	// accumulating. An explicit target re-resolves instead; --clear-reply-context
+	// drops the lineage entirely.
+	carriedInReplyTo := ""
+	carriedReferences := ""
+	if !c.ClearReplyContext && strings.TrimSpace(replyToMessageID) == "" && strings.TrimSpace(replyToThreadID) == "" {
+		carriedInReplyTo = existingInReplyTo
+		carriedReferences = existingReferences
 	}
 
 	input.To = to
 	input.ReplyToMessageID = replyToMessageID
 	input.ReplyToThreadID = replyToThreadID
+	input.ThreadContinuityID = targetThreadID
+	input.InReplyTo = carriedInReplyTo
+	input.References = carriedReferences
 
-	msg, threadID, attachmentMetadata, err := buildDraftMessage(ctx, svc, account, input)
+	msg, threading, attachmentMetadata, err := buildDraftMessage(ctx, svc, account, input)
 	if err != nil {
 		return err
 	}
@@ -816,5 +921,5 @@ func (c *GmailDraftsUpdateCmd) Run(ctx context.Context, flags *RootFlags) error 
 	if err != nil {
 		return err
 	}
-	return writeDraftResult(ctx, u, draft, threadID, attachmentMetadata)
+	return writeDraftResult(ctx, u, draft, threading, attachmentMetadata)
 }

--- a/internal/cmd/gmail_drafts_reply_context_test.go
+++ b/internal/cmd/gmail_drafts_reply_context_test.go
@@ -1,0 +1,460 @@
+package cmd
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/gmail/v1"
+)
+
+// draftReplyContextServer stands up a Gmail stub for the drafts-update reply
+// context tests. existingHeaders describes the draft as it is stored today;
+// threads maps a thread id to the messages the API would return for it.
+type draftReplyContextServer struct {
+	existingHeaders []map[string]any
+	existingThread  string
+	threads         map[string][]map[string]any
+
+	posted        gmail.Draft
+	threadFetches []string
+	messageFetch  map[string]bool
+}
+
+func newDraftReplyContextServer(t *testing.T, cfg *draftReplyContextServer) *httptest.Server {
+	t.Helper()
+	cfg.messageFetch = map[string]bool{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/gmail/v1/users/me/drafts/d1") && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id": "d1",
+				"message": map[string]any{
+					"id":       "mDraft",
+					"threadId": cfg.existingThread,
+					"labelIds": []string{"DRAFT"},
+					"payload":  map[string]any{"headers": cfg.existingHeaders},
+				},
+			})
+		case strings.Contains(r.URL.Path, "/gmail/v1/users/me/threads/") && r.Method == http.MethodGet:
+			id := r.URL.Path[strings.LastIndex(r.URL.Path, "/")+1:]
+			cfg.threadFetches = append(cfg.threadFetches, id)
+			msgs, ok := cfg.threads[id]
+			if !ok {
+				http.NotFound(w, r)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": id, "messages": msgs})
+		case strings.Contains(r.URL.Path, "/gmail/v1/users/me/messages/") && r.Method == http.MethodGet:
+			id := r.URL.Path[strings.LastIndex(r.URL.Path, "/")+1:]
+			cfg.messageFetch[id] = true
+			for _, msgs := range cfg.threads {
+				for _, m := range msgs {
+					if m["id"] == id {
+						_ = json.NewEncoder(w).Encode(m)
+						return
+					}
+				}
+			}
+			http.NotFound(w, r)
+		case strings.HasSuffix(r.URL.Path, "/gmail/v1/users/me/drafts/d1") && r.Method == http.MethodPut:
+			body, _ := io.ReadAll(r.Body)
+			if err := json.Unmarshal(body, &cfg.posted); err != nil {
+				t.Fatalf("unmarshal posted draft: %v", err)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":      "d1",
+				"message": map[string]any{"id": "mNew", "threadId": cfg.existingThread},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func (c *draftReplyContextServer) rawPosted(t *testing.T) string {
+	t.Helper()
+	if c.posted.Message == nil {
+		t.Fatal("no draft posted")
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(c.posted.Message.Raw)
+	if err != nil {
+		t.Fatalf("decode raw: %v", err)
+	}
+	return string(raw)
+}
+
+func runReplyCtxUpdate(t *testing.T, srv *httptest.Server, stdout io.Writer, args ...string) error {
+	t.Helper()
+	svc := newGmailServiceFromServer(t, srv)
+	flags := &RootFlags{Account: "me@example.com"}
+	ctx := withGmailTestService(newCmdRuntimeJSONOutputContext(t, stdout, io.Discard), svc)
+	return runKong(t, &GmailDraftsUpdateCmd{}, args, ctx, flags)
+}
+
+// headerLines returns the values of every occurrence of a header in a raw
+// RFC822 message, so a test can assert on absence as well as exact content.
+func headerLines(raw, name string) []string {
+	var out []string
+	prefix := name + ": "
+	for _, line := range strings.Split(raw, "\r\n") {
+		if line == "" {
+			break // end of headers
+		}
+		if strings.HasPrefix(line, prefix) {
+			out = append(out, strings.TrimPrefix(line, prefix))
+		}
+	}
+	return out
+}
+
+// A draft that is not a reply must not gain reply headers when it is updated.
+// Regression: the update path fed the draft's own threadId back in as a reply
+// target, so In-Reply-To pointed at the draft's own previous revision — a
+// message that was never sent.
+func TestGmailDraftsUpdateCmd_NonReplyDraftGainsNoReplyHeaders(t *testing.T) {
+	cfg := &draftReplyContextServer{
+		existingThread: "tSolo",
+		existingHeaders: []map[string]any{
+			{"name": "Message-ID", "value": "<self@mail.gmail.com>"},
+			{"name": "To", "value": "a@example.com"},
+			{"name": "Subject", "value": "Hi"},
+		},
+		threads: map[string][]map[string]any{
+			"tSolo": {{
+				"id": "mDraft", "threadId": "tSolo", "internalDate": "1000",
+				"labelIds": []string{"DRAFT"},
+				"payload": map[string]any{"headers": []map[string]any{
+					{"name": "Message-ID", "value": "<self@mail.gmail.com>"},
+				}},
+			}},
+		},
+	}
+	srv := newDraftReplyContextServer(t, cfg)
+
+	if err := runReplyCtxUpdate(t, srv, io.Discard, "d1", "--subject", "Hi", "--body", "Updated"); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	raw := cfg.rawPosted(t)
+	if got := headerLines(raw, "In-Reply-To"); len(got) != 0 {
+		t.Fatalf("non-reply draft gained In-Reply-To %q:\n%s", got, raw)
+	}
+	if got := headerLines(raw, "References"); len(got) != 0 {
+		t.Fatalf("non-reply draft gained References %q:\n%s", got, raw)
+	}
+	if cfg.posted.Message.ThreadId != "tSolo" {
+		t.Fatalf("thread continuity lost: want tSolo, got %q", cfg.posted.Message.ThreadId)
+	}
+	if len(cfg.threadFetches) != 0 {
+		t.Fatalf("update derived reply context from the draft's own thread: fetched %v", cfg.threadFetches)
+	}
+}
+
+// Repeated updates must stay clean and keep the same thread — no chaining onto
+// each successive revision.
+func TestGmailDraftsUpdateCmd_RepeatedUpdatesStayClean(t *testing.T) {
+	for i := range 3 {
+		cfg := &draftReplyContextServer{
+			existingThread: "tSolo",
+			existingHeaders: []map[string]any{
+				// Each round the stored draft is the previous revision, with a
+				// fresh Message-Id, exactly as Gmail rewrites it.
+				{"name": "Message-ID", "value": "<rev" + string(rune('0'+i)) + "@mail.gmail.com>"},
+				{"name": "To", "value": "a@example.com"},
+			},
+			threads: map[string][]map[string]any{},
+		}
+		srv := newDraftReplyContextServer(t, cfg)
+		if err := runReplyCtxUpdate(t, srv, io.Discard, "d1", "--subject", "Hi", "--body", "Updated"); err != nil {
+			t.Fatalf("round %d: execute: %v", i, err)
+		}
+		raw := cfg.rawPosted(t)
+		if got := headerLines(raw, "In-Reply-To"); len(got) != 0 {
+			t.Fatalf("round %d gained In-Reply-To %q", i, got)
+		}
+		if got := headerLines(raw, "References"); len(got) != 0 {
+			t.Fatalf("round %d gained References %q", i, got)
+		}
+		if cfg.posted.Message.ThreadId != "tSolo" {
+			t.Fatalf("round %d thread drifted: %q", i, cfg.posted.Message.ThreadId)
+		}
+	}
+}
+
+// A draft created as a genuine reply keeps that reply context across an update
+// that does not re-specify it — and keeps pointing at the real parent, not the
+// draft's own prior revision.
+func TestGmailDraftsUpdateCmd_GenuineReplyContextPreserved(t *testing.T) {
+	cfg := &draftReplyContextServer{
+		existingThread: "tReal",
+		existingHeaders: []map[string]any{
+			{"name": "Message-ID", "value": "<self@mail.gmail.com>"},
+			{"name": "In-Reply-To", "value": "<orig@example.com>"},
+			{"name": "References", "value": "<orig@example.com>"},
+			{"name": "To", "value": "alice@example.com"},
+		},
+		threads: map[string][]map[string]any{},
+	}
+	srv := newDraftReplyContextServer(t, cfg)
+
+	if err := runReplyCtxUpdate(t, srv, io.Discard, "d1", "--subject", "Re: hi", "--body", "Updated"); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	raw := cfg.rawPosted(t)
+	if got := headerLines(raw, "In-Reply-To"); len(got) != 1 || got[0] != "<orig@example.com>" {
+		t.Fatalf("genuine reply context not preserved: In-Reply-To %q\n%s", got, raw)
+	}
+	if got := headerLines(raw, "References"); len(got) != 1 || got[0] != "<orig@example.com>" {
+		t.Fatalf("References not preserved verbatim: %q\n%s", got, raw)
+	}
+	if strings.Contains(raw, "<self@mail.gmail.com>") {
+		t.Fatalf("draft referenced its own Message-Id:\n%s", raw)
+	}
+}
+
+// Updating a real reply repeatedly must not grow References.
+func TestGmailDraftsUpdateCmd_ReferencesDoNotAccumulate(t *testing.T) {
+	const refs = "<a@example.com> <b@example.com>"
+	for i := range 3 {
+		cfg := &draftReplyContextServer{
+			existingThread: "tReal",
+			existingHeaders: []map[string]any{
+				{"name": "Message-ID", "value": "<rev" + string(rune('0'+i)) + "@mail.gmail.com>"},
+				{"name": "In-Reply-To", "value": "<b@example.com>"},
+				{"name": "References", "value": refs},
+				{"name": "To", "value": "alice@example.com"},
+			},
+			threads: map[string][]map[string]any{},
+		}
+		srv := newDraftReplyContextServer(t, cfg)
+		if err := runReplyCtxUpdate(t, srv, io.Discard, "d1", "--subject", "Re: hi", "--body", "Updated"); err != nil {
+			t.Fatalf("round %d: execute: %v", i, err)
+		}
+		raw := cfg.rawPosted(t)
+		if got := headerLines(raw, "References"); len(got) != 1 || got[0] != refs {
+			t.Fatalf("round %d: References drifted to %q, want %q", i, got, refs)
+		}
+		if got := headerLines(raw, "In-Reply-To"); len(got) != 1 || got[0] != "<b@example.com>" {
+			t.Fatalf("round %d: In-Reply-To drifted to %q", i, got)
+		}
+	}
+}
+
+// --clear-reply-context strips reply headers from an existing draft in place,
+// so recovering a mis-threaded draft does not require delete-and-recreate.
+func TestGmailDraftsUpdateCmd_ClearReplyContext(t *testing.T) {
+	cfg := &draftReplyContextServer{
+		existingThread: "tReal",
+		existingHeaders: []map[string]any{
+			{"name": "Message-ID", "value": "<self@mail.gmail.com>"},
+			{"name": "In-Reply-To", "value": "<orig@example.com>"},
+			{"name": "References", "value": "<orig@example.com>"},
+			{"name": "To", "value": "alice@example.com"},
+		},
+		threads: map[string][]map[string]any{},
+	}
+	srv := newDraftReplyContextServer(t, cfg)
+
+	if err := runReplyCtxUpdate(t, srv, io.Discard,
+		"d1", "--subject", "Standalone", "--body", "Updated", "--clear-reply-context"); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	raw := cfg.rawPosted(t)
+	if got := headerLines(raw, "In-Reply-To"); len(got) != 0 {
+		t.Fatalf("--clear-reply-context left In-Reply-To %q", got)
+	}
+	if got := headerLines(raw, "References"); len(got) != 0 {
+		t.Fatalf("--clear-reply-context left References %q", got)
+	}
+	if cfg.posted.Message.ThreadId != "tReal" {
+		t.Fatalf("--clear-reply-context should keep the thread, got %q", cfg.posted.Message.ThreadId)
+	}
+}
+
+func TestGmailDraftsUpdateCmd_ClearReplyContextConflictsWithReplyTarget(t *testing.T) {
+	for _, target := range [][]string{
+		{"--reply-to-message-id", "m1"},
+		{"--thread-id", "t1"},
+	} {
+		args := append([]string{"d1", "--subject", "S", "--body", "B", "--clear-reply-context"}, target...)
+		flags := &RootFlags{Account: "me@example.com"}
+		ctx := newCmdRuntimeOutputContext(t, io.Discard, io.Discard)
+		err := runKong(t, &GmailDraftsUpdateCmd{}, args, ctx, flags)
+		if err == nil || !strings.Contains(err.Error(), "--clear-reply-context") {
+			t.Fatalf("%v: expected mutual-exclusion error, got %v", target, err)
+		}
+	}
+}
+
+// An explicit --reply-to-message-id pointing at a draft is refused rather than
+// silently producing a reference to an unsent message.
+func TestGmailDraftsUpdateCmd_ReplyToDraftMessageRejected(t *testing.T) {
+	cfg := &draftReplyContextServer{
+		existingThread: "tReal",
+		existingHeaders: []map[string]any{
+			{"name": "Message-ID", "value": "<self@mail.gmail.com>"},
+			{"name": "To", "value": "alice@example.com"},
+		},
+		threads: map[string][]map[string]any{
+			"tOther": {{
+				"id": "mOtherDraft", "threadId": "tOther", "internalDate": "2000",
+				"labelIds": []string{"DRAFT"},
+				"payload": map[string]any{"headers": []map[string]any{
+					{"name": "Message-ID", "value": "<otherdraft@mail.gmail.com>"},
+				}},
+			}},
+		},
+	}
+	srv := newDraftReplyContextServer(t, cfg)
+
+	err := runReplyCtxUpdate(t, srv, io.Discard,
+		"d1", "--subject", "S", "--body", "B", "--reply-to-message-id", "mOtherDraft")
+	if err == nil || !strings.Contains(err.Error(), "draft") {
+		t.Fatalf("expected refusal to reply to a draft, got %v", err)
+	}
+}
+
+// A caller-supplied --thread-id whose newest message is a draft must anchor to
+// the newest real message instead of the draft.
+func TestGmailDraftsUpdateCmd_ThreadIDSkipsDraftMessages(t *testing.T) {
+	cfg := &draftReplyContextServer{
+		existingThread: "tOld",
+		existingHeaders: []map[string]any{
+			{"name": "Message-ID", "value": "<self@mail.gmail.com>"},
+			{"name": "To", "value": "alice@example.com"},
+		},
+		threads: map[string][]map[string]any{
+			"tMixed": {
+				{
+					"id": "mReal", "threadId": "tMixed", "internalDate": "1000",
+					"labelIds": []string{"INBOX"},
+					"payload": map[string]any{"headers": []map[string]any{
+						{"name": "Message-ID", "value": "<real@example.com>"},
+					}},
+				},
+				{
+					"id": "mDraftInThread", "threadId": "tMixed", "internalDate": "9000",
+					"labelIds": []string{"DRAFT"},
+					"payload": map[string]any{"headers": []map[string]any{
+						{"name": "Message-ID", "value": "<threaddraft@mail.gmail.com>"},
+					}},
+				},
+			},
+		},
+	}
+	srv := newDraftReplyContextServer(t, cfg)
+
+	if err := runReplyCtxUpdate(t, srv, io.Discard,
+		"d1", "--subject", "S", "--body", "B", "--thread-id", "tMixed"); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	raw := cfg.rawPosted(t)
+	if got := headerLines(raw, "In-Reply-To"); len(got) != 1 || got[0] != "<real@example.com>" {
+		t.Fatalf("anchored to a draft instead of the newest real message: %q\n%s", got, raw)
+	}
+	if strings.Contains(raw, "<threaddraft@mail.gmail.com>") {
+		t.Fatalf("referenced a draft Message-Id:\n%s", raw)
+	}
+}
+
+// A thread containing nothing but drafts has no valid reply target.
+func TestGmailDraftsUpdateCmd_ThreadIDWithOnlyDraftsRejected(t *testing.T) {
+	cfg := &draftReplyContextServer{
+		existingThread: "tOld",
+		existingHeaders: []map[string]any{
+			{"name": "Message-ID", "value": "<self@mail.gmail.com>"},
+			{"name": "To", "value": "alice@example.com"},
+		},
+		threads: map[string][]map[string]any{
+			"tDraftsOnly": {{
+				"id": "mOnlyDraft", "threadId": "tDraftsOnly", "internalDate": "1000",
+				"labelIds": []string{"DRAFT"},
+				"payload": map[string]any{"headers": []map[string]any{
+					{"name": "Message-ID", "value": "<onlydraft@mail.gmail.com>"},
+				}},
+			}},
+		},
+	}
+	srv := newDraftReplyContextServer(t, cfg)
+
+	err := runReplyCtxUpdate(t, srv, io.Discard,
+		"d1", "--subject", "S", "--body", "B", "--thread-id", "tDraftsOnly")
+	if err == nil || !strings.Contains(err.Error(), "draft") {
+		t.Fatalf("expected refusal on a drafts-only thread, got %v", err)
+	}
+}
+
+// The JSON result reports the effective reply context so a caller can verify
+// threading without re-fetching raw headers.
+func TestGmailDraftsUpdateCmd_ResultReportsReplyContext(t *testing.T) {
+	t.Run("none", func(t *testing.T) {
+		cfg := &draftReplyContextServer{
+			existingThread: "tSolo",
+			existingHeaders: []map[string]any{
+				{"name": "Message-ID", "value": "<self@mail.gmail.com>"},
+				{"name": "To", "value": "a@example.com"},
+			},
+			threads: map[string][]map[string]any{},
+		}
+		srv := newDraftReplyContextServer(t, cfg)
+		var out strings.Builder
+		if err := runReplyCtxUpdate(t, srv, &out, "d1", "--subject", "S", "--body", "B"); err != nil {
+			t.Fatalf("execute: %v", err)
+		}
+		var got map[string]any
+		if err := json.Unmarshal([]byte(out.String()), &got); err != nil {
+			t.Fatalf("decode result %q: %v", out.String(), err)
+		}
+		if v, ok := got["inReplyTo"]; !ok || v != nil {
+			t.Fatalf("want explicit null inReplyTo, got %#v (present=%v)", v, ok)
+		}
+		if v, ok := got["references"]; !ok || v != nil {
+			t.Fatalf("want explicit null references, got %#v (present=%v)", v, ok)
+		}
+		if v, ok := got["replyContextSource"]; !ok || v != nil {
+			t.Fatalf("want explicit null replyContextSource, got %#v (present=%v)", v, ok)
+		}
+	})
+
+	t.Run("carried", func(t *testing.T) {
+		cfg := &draftReplyContextServer{
+			existingThread: "tReal",
+			existingHeaders: []map[string]any{
+				{"name": "Message-ID", "value": "<self@mail.gmail.com>"},
+				{"name": "In-Reply-To", "value": "<orig@example.com>"},
+				{"name": "References", "value": "<orig@example.com>"},
+				{"name": "To", "value": "a@example.com"},
+			},
+			threads: map[string][]map[string]any{},
+		}
+		srv := newDraftReplyContextServer(t, cfg)
+		var out strings.Builder
+		if err := runReplyCtxUpdate(t, srv, &out, "d1", "--subject", "S", "--body", "B"); err != nil {
+			t.Fatalf("execute: %v", err)
+		}
+		var got map[string]any
+		if err := json.Unmarshal([]byte(out.String()), &got); err != nil {
+			t.Fatalf("decode result %q: %v", out.String(), err)
+		}
+		if got["inReplyTo"] != "<orig@example.com>" {
+			t.Fatalf("want carried inReplyTo, got %#v", got["inReplyTo"])
+		}
+		if got["references"] != "<orig@example.com>" {
+			t.Fatalf("want carried references, got %#v", got["references"])
+		}
+		if got["replyContextSource"] != "carried" {
+			t.Fatalf("want replyContextSource carried, got %#v", got["replyContextSource"])
+		}
+	})
+}

--- a/internal/cmd/gmail_drafts_reply_context_test.go
+++ b/internal/cmd/gmail_drafts_reply_context_test.go
@@ -285,6 +285,7 @@ func TestGmailDraftsUpdateCmd_ClearReplyContextConflictsWithReplyTarget(t *testi
 	for _, target := range [][]string{
 		{"--reply-to-message-id", "m1"},
 		{"--thread-id", "t1"},
+		{"--quote"},
 	} {
 		args := append([]string{"d1", "--subject", "S", "--body", "B", "--clear-reply-context"}, target...)
 		flags := &RootFlags{Account: "me@example.com"}

--- a/internal/cmd/gmail_reply.go
+++ b/internal/cmd/gmail_reply.go
@@ -62,6 +62,12 @@ func fetchReplyInfo(ctx context.Context, svc *gmail.Service, replyToMessageID st
 		if err != nil {
 			return nil, err
 		}
+		// A draft has never been delivered, so nothing can thread against its
+		// Message-Id. Refuse rather than emit a reference to a message that
+		// does not exist for any recipient.
+		if msg != nil && hasLabel(msg.LabelIds, "DRAFT") {
+			return nil, fmt.Errorf("reply target message %s is a draft; cannot reply to an unsent message", replyToMessageID)
+		}
 		info := replyInfoFromMessage(msg, includeQuoteBodies)
 		if includeQuoteBodies {
 			info.InlineResources, err = preserveReferencedInlineResources(ctx, svc, msg.Id, msg.Payload, info.BodyHTML)
@@ -83,9 +89,11 @@ func fetchReplyInfo(ctx context.Context, svc *gmail.Service, replyToMessageID st
 		return nil, fmt.Errorf("thread %s has no messages", threadID)
 	}
 
-	msg := selectLatestThreadMessage(thread.Messages)
+	// Only sent or received messages are valid reply parents; a draft in the
+	// thread (including this draft's own previous revision) is not.
+	msg := selectLatestThreadMessage(nonDraftMessages(thread.Messages))
 	if msg == nil {
-		return nil, fmt.Errorf("thread %s has no messages", threadID)
+		return nil, fmt.Errorf("thread %s has no sent or received message to reply to (drafts cannot be reply targets)", threadID)
 	}
 	if includeQuoteBodies && msg.Id != "" {
 		fullMsg, fullErr := fetchMessageForReplyInfo(ctx, svc, msg.Id, true)
@@ -162,6 +170,19 @@ func replyInfoFromMessage(msg *gmail.Message, includeQuoteBodies bool) *replyInf
 		info.References = info.References + " " + messageID
 	}
 	return info
+}
+
+// nonDraftMessages drops draft messages from a thread. Reply headers may only
+// ever point at a message that was actually sent or received.
+func nonDraftMessages(messages []*gmail.Message) []*gmail.Message {
+	out := make([]*gmail.Message, 0, len(messages))
+	for _, msg := range messages {
+		if msg == nil || hasLabel(msg.LabelIds, "DRAFT") {
+			continue
+		}
+		out = append(out, msg)
+	}
+	return out
 }
 
 func selectLatestThreadMessage(messages []*gmail.Message) *gmail.Message {


### PR DESCRIPTION
Fixes #942.

`gmail drafts update` rebuilds the whole message, and it was feeding the draft's own `threadId` back in as a **reply target**:

```go
targetThreadID := existingThreadID          // the draft's OWN thread
...
if strings.TrimSpace(replyToMessageID) == "" {
    replyToThreadID = targetThreadID        // thread continuity used as reply lineage
}
```

That flows to `fetchReplyInfo`, which anchors `In-Reply-To`/`References` to the newest message in the thread. For a draft that is not a reply, the only message in its thread *is* the draft — so every update pointed the draft at its own previous revision, a message that was never sent. A second update chained onto the first.

The two concepts were riding the same wire: `msg.ThreadId` is set from the resolved reply info in `buildGmailMessage`, so simply not passing the thread as a reply target would also have dropped `threadId`. This separates them.

## Changes

- **Reply lineage comes only from caller intent.** Only an explicit `--reply-to-message-id` / `--thread-id` is a reply target. The draft's own thread never is.
- **Thread continuity is carried independently**, via a new `ThreadContinuityID` on `draftComposeInput` applied only when no reply target resolved a thread of its own.
- **Genuine reply context survives an update** by re-applying the draft's own stored `In-Reply-To`/`References` verbatim instead of re-deriving them. Repeated updates are therefore idempotent and `References` does not accumulate.
- **Reply headers never name an unsent message.** `fetchReplyInfo` now filters `DRAFT`-labelled messages out of thread reply-target selection, and an explicit `--reply-to-message-id` pointing at a draft is refused. The draft-safe selector (`selectLatestThreadReplyTarget`) already existed but was wired only into the `--quote` path; the header path was using the unfiltered `selectLatestThreadMessage`.
- **The result reports effective threading.** `drafts create`/`update` now emit `inReplyTo`, `references`, and `replyContextSource` (`caller` / `carried` / null) so a caller can verify without a raw-header fetch. When lineage was carried rather than caller-specified, a warning goes to stderr.
- **`--clear-reply-context`** strips reply headers in place, so repairing a mis-threaded draft no longer requires delete-and-recreate (which loses the draft id).

## Compatibility

`threadId` behaviour is unchanged — a plain update keeps the draft in its thread, and a caller-supplied `--thread-id` still overrides it. The JSON result gains three fields; existing fields are untouched. No existing test needed changing, which is worth noting: nothing in the suite asserted the old self-referencing behaviour.

The `replyContextSource` field reports `null` rather than a `"none"` string when a draft has no reply context, so all three threading fields are null together.

## Testing

`make ci` green. New regression coverage in `internal/cmd/gmail_drafts_reply_context_test.go`:

- non-reply draft update emits no `In-Reply-To`/`References`, keeps `threadId`, and does not fetch its own thread at all
- three successive updates stay clean with a stable thread
- a genuine reply keeps pointing at the real parent across an update that does not re-specify it
- `References` does not drift across repeated updates of a real reply
- `--clear-reply-context` strips the headers and keeps the thread; it conflicts with an explicit reply target
- `--reply-to-message-id` naming a draft is refused
- `--thread-id` whose newest message is a draft anchors to the newest real message; a drafts-only thread is refused
- the JSON result reports effective `inReplyTo`/`references`, null when absent


---

## Review round 2 (updated after ClawSweeper review)

**Dropped the CHANGELOG entry** (`c9836084`) — `AGENTS.md` puts it in the maintainer's landing checklist.

**Added live Gmail proof** for both behaviors flagged as unverified. Detail in [this comment](https://github.com/openclaw/gogcli/pull/944#issuecomment-5135171317); summary:

- **Bug reproduced on current `main`** (`1b261244`): a standalone draft with no reply target gained `In-Reply-To`/`References` after one update, pointing at the revision that update replaced.
- **Standalone draft on this branch**: no reply headers after update, and `threadId` unchanged — thread continuity survives while the self-referential lineage does not.
- **Genuine reply on this branch**: real parent preserved verbatim across four updates, `References` does not accumulate, `replyContextSource` reports `caller` then `carried`.
- **Recovery**: a draft corrupted by `main` keeps its bad headers on this branch (they're indistinguishable from genuine context by inspection); `--clear-reply-context` removes them while keeping `threadId`.

Test drafts were deleted afterward. `make ci` green on `c9836084`.

On the open scope question — whether `--clear-reply-context` and the threading JSON fields should land here or in a follow-up — I've argued the case on #942 and will take whichever split you prefer.
