### PR TITLE
feat(gmail): add offset-bearing internalDateIso to message and thread listings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Gmail: report exact file-input byte counts in compose dry-run output, including forwarded-message notes with trailing newlines. (#936, #937) — thanks @chrischall.
 - Setup: replace obsolete Google Cloud API enablement links with direct API Library URLs while preserving project-scoped recovery hints. (#933) — thanks @LinXunFeng.
 - Docs: `docs write` now rejects an explicitly empty `--tab`/`--tab-id` value instead of silently targeting the whole document.
+- Gmail: add an offset-bearing `dateIso` to message and thread listings, sourced from the API's authoritative `internalDate` rather than the sender's `Date` header, so a JSON consumer is no longer left to guess which zone the naive `date` column is in. (#945)
 
 ## 0.34.1 - 2026-07-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@
 - Gmail: report exact file-input byte counts in compose dry-run output, including forwarded-message notes with trailing newlines. (#936, #937) — thanks @chrischall.
 - Setup: replace obsolete Google Cloud API enablement links with direct API Library URLs while preserving project-scoped recovery hints. (#933) — thanks @LinXunFeng.
 - Docs: `docs write` now rejects an explicitly empty `--tab`/`--tab-id` value instead of silently targeting the whole document.
-- Gmail: add an offset-bearing `dateIso` to message and thread listings, sourced from the API's authoritative `internalDate` rather than the sender's `Date` header, so a JSON consumer is no longer left to guess which zone the naive `date` column is in. (#945, #946)
 
 ## 0.34.1 - 2026-07-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Gmail: report exact file-input byte counts in compose dry-run output, including forwarded-message notes with trailing newlines. (#936, #937) — thanks @chrischall.
 - Setup: replace obsolete Google Cloud API enablement links with direct API Library URLs while preserving project-scoped recovery hints. (#933) — thanks @LinXunFeng.
 - Docs: `docs write` now rejects an explicitly empty `--tab`/`--tab-id` value instead of silently targeting the whole document.
-- Gmail: add an offset-bearing `dateIso` to message and thread listings, sourced from the API's authoritative `internalDate` rather than the sender's `Date` header, so a JSON consumer is no longer left to guess which zone the naive `date` column is in. (#945)
+- Gmail: add an offset-bearing `dateIso` to message and thread listings, sourced from the API's authoritative `internalDate` rather than the sender's `Date` header, so a JSON consumer is no longer left to guess which zone the naive `date` column is in. (#945, #946)
 
 ## 0.34.1 - 2026-07-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.34.2 - 2026-07-27
 
+- Gmail: add source-specific `internalDateIso` timestamps to message and thread listings while preserving the legacy sender-header `date`. (#945, #946) — thanks @chrischall.
 - Gmail: prevent standalone draft updates from acquiring self-referential reply headers, with explicit recovery for affected drafts. (#942, #944) — thanks @chrischall.
 - Security: update gRPC-Go, PostCSS, and Sharp/libvips to patched releases, clearing three high-severity dependency alerts. (#940)
 - Drive: add opt-in `upload --replace --if-version` conflict protection using a fail-closed ETag precondition, without changing unconditional replacement. (#929) — thanks @karstenevers.

--- a/internal/cmd/gmail_date.go
+++ b/internal/cmd/gmail_date.go
@@ -48,9 +48,13 @@ func formatGmailDateInLocation(raw string, loc *time.Location) string {
 //     zone gog was configured for. Get that wrong and the timestamp can land on
 //     the wrong calendar DAY, which is what makes it worse than merely
 //     imprecise.
-//   - internalDate is the Gmail API's own receipt timestamp (epoch
-//     milliseconds, UTC). The Date header is written by the sending client and
-//     varies in format, offset, and honesty; internalDate does not.
+//   - internalDate is Gmail's own internal message timestamp (epoch
+//     milliseconds, UTC), independent of the sender's formatting. For normal
+//     SMTP-received mail it is when Google accepted the message, which Gmail
+//     documents as more reliable than the Date header. It is not universally
+//     independent of that header: for API-migrated mail the importing client
+//     may derive internalDate FROM the Date header, in which case the two
+//     agree by construction rather than by coincidence.
 //
 // Returns "" when internalDate is absent, so the field stays omitempty rather
 // than claiming the Unix epoch.

--- a/internal/cmd/gmail_date.go
+++ b/internal/cmd/gmail_date.go
@@ -39,6 +39,31 @@ func formatGmailDateInLocation(raw string, loc *time.Location) string {
 	return formatMailDateInLocation(raw, loc, listDateLayout)
 }
 
+// formatGmailDateISO renders a message's internalDate as RFC3339 in loc.
+//
+// Two things make this the value a machine consumer should read:
+//
+//   - It carries an explicit offset. listDateLayout ("2006-01-02 15:04") does
+//     not, so a caller that sees "2026-07-28 03:36" has to already know which
+//     zone gog was configured for. Get that wrong and the timestamp can land on
+//     the wrong calendar DAY, which is what makes it worse than merely
+//     imprecise.
+//   - internalDate is the Gmail API's own receipt timestamp (epoch
+//     milliseconds, UTC). The Date header is written by the sending client and
+//     varies in format, offset, and honesty; internalDate does not.
+//
+// Returns "" when internalDate is absent, so the field stays omitempty rather
+// than claiming the Unix epoch.
+func formatGmailDateISO(internalDateMillis int64, loc *time.Location) string {
+	if internalDateMillis <= 0 {
+		return ""
+	}
+	if loc == nil {
+		loc = time.Local
+	}
+	return time.UnixMilli(internalDateMillis).In(loc).Format(time.RFC3339)
+}
+
 // formatQuoteDate renders an original message's Date header in the Gmail-style
 // human form used for quoted replies and forwarded-message headers, converted
 // into loc (matching how Gmail shows the attribution in the reader's timezone).

--- a/internal/cmd/gmail_date.go
+++ b/internal/cmd/gmail_date.go
@@ -65,7 +65,14 @@ func formatGmailDateISO(internalDateMillis int64, loc *time.Location) string {
 	if loc == nil {
 		loc = time.Local
 	}
-	return time.UnixMilli(internalDateMillis).In(loc).Format(time.RFC3339)
+	// internalDate is epoch milliseconds, and time.RFC3339 has no fractional
+	// seconds — formatting a nonzero-millisecond instant with it would truncate
+	// to the preceding whole second. Whole seconds keep the fraction-free form.
+	layout := time.RFC3339
+	if internalDateMillis%1000 != 0 {
+		layout = "2006-01-02T15:04:05.000Z07:00"
+	}
+	return time.UnixMilli(internalDateMillis).In(loc).Format(layout)
 }
 
 // formatQuoteDate renders an original message's Date header in the Gmail-style

--- a/internal/cmd/gmail_date_iso_test.go
+++ b/internal/cmd/gmail_date_iso_test.go
@@ -56,21 +56,52 @@ func TestFormatGmailDateISO_NilLocation(t *testing.T) {
 }
 
 // Whatever the zone, the value round-trips to the same instant — the offset is
-// carried, not dropped.
+// carried, not dropped. internalDate is epoch MILLISECONDS, so this covers both
+// a whole-second instant and one with nonzero milliseconds: the fractional part
+// must survive formatting, not truncate to the preceding whole second.
 func TestFormatGmailDateISO_RoundTripsToSameInstant(t *testing.T) {
-	ms := time.Date(2026, 7, 28, 3, 36, 0, 0, time.UTC).UnixMilli()
+	instants := []int64{
+		time.Date(2026, 7, 28, 3, 36, 0, 0, time.UTC).UnixMilli(),
+		time.Date(2026, 7, 28, 3, 36, 0, 450*int(time.Millisecond), time.UTC).UnixMilli(),
+	}
 	for _, name := range []string{"America/New_York", "UTC", "Asia/Tokyo", "Asia/Kolkata"} {
 		loc, err := time.LoadLocation(name)
 		if err != nil {
 			t.Skipf("tzdata unavailable for %s: %v", name, err)
 		}
-		got := formatGmailDateISO(ms, loc)
-		parsed, parseErr := time.Parse(time.RFC3339, got)
-		if parseErr != nil {
-			t.Fatalf("%s: unparseable %q: %v", name, got, parseErr)
+		for _, ms := range instants {
+			got := formatGmailDateISO(ms, loc)
+			parsed, parseErr := time.Parse(time.RFC3339, got)
+			if parseErr != nil {
+				t.Fatalf("%s: unparseable %q: %v", name, got, parseErr)
+			}
+			if parsed.UnixMilli() != ms {
+				t.Fatalf("%s: %q round-tripped to %d, want %d", name, got, parsed.UnixMilli(), ms)
+			}
 		}
-		if parsed.UnixMilli() != ms {
-			t.Fatalf("%s: %q round-tripped to %d, want %d", name, got, parsed.UnixMilli(), ms)
+	}
+}
+
+// Nonzero milliseconds render as a fixed three-digit fraction; whole seconds
+// keep the fraction-free form the field has emitted since it was introduced.
+func TestFormatGmailDateISO_MillisecondPrecision(t *testing.T) {
+	eastern, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Skipf("tzdata unavailable: %v", err)
+	}
+	base := time.Date(2026, 7, 28, 3, 36, 5, 0, time.UTC).UnixMilli()
+	cases := []struct {
+		ms   int64
+		want string
+	}{
+		{base, "2026-07-27T23:36:05-04:00"},
+		{base + 7, "2026-07-27T23:36:05.007-04:00"},
+		{base + 450, "2026-07-27T23:36:05.450-04:00"},
+		{base + 999, "2026-07-27T23:36:05.999-04:00"},
+	}
+	for _, tc := range cases {
+		if got := formatGmailDateISO(tc.ms, eastern); got != tc.want {
+			t.Fatalf("internalDate %d: got %q, want %q", tc.ms, got, tc.want)
 		}
 	}
 }

--- a/internal/cmd/gmail_date_iso_test.go
+++ b/internal/cmd/gmail_date_iso_test.go
@@ -1,0 +1,76 @@
+package cmd
+
+import (
+	"testing"
+	"time"
+)
+
+// formatGmailDateISO exists because listDateLayout ("2006-01-02 15:04") carries
+// no offset: a caller reading "2026-07-28 03:36" has to already know which zone
+// gog was configured for, and getting that wrong can move the timestamp onto the
+// wrong calendar DAY.
+func TestFormatGmailDateISO(t *testing.T) {
+	eastern, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Skipf("tzdata unavailable: %v", err)
+	}
+
+	// 2026-07-28T03:36:00Z is 11:36 PM Eastern on July 27 — the previous day.
+	// This is the exact shape of the reported failure.
+	julyUTC := time.Date(2026, 7, 28, 3, 36, 0, 0, time.UTC).UnixMilli()
+	got := formatGmailDateISO(julyUTC, eastern)
+	if want := "2026-07-27T23:36:00-04:00"; got != want {
+		t.Fatalf("July: got %q, want %q", got, want)
+	}
+	if legacy := formatGmailDateInLocation("Tue, 28 Jul 2026 03:36:00 +0000", eastern); legacy != "2026-07-27 23:36" {
+		t.Fatalf("legacy layout drifted: %q", legacy)
+	}
+
+	// DST comes from the IANA database, so January is -05:00, not -04:00.
+	jan := time.Date(2026, 1, 15, 17, 0, 0, 0, time.UTC).UnixMilli()
+	if got := formatGmailDateISO(jan, eastern); got != "2026-01-15T12:00:00-05:00" {
+		t.Fatalf("January: got %q, want 2026-01-15T12:00:00-05:00", got)
+	}
+}
+
+// An absent internalDate must yield "" so the field stays omitempty rather than
+// claiming the Unix epoch.
+func TestFormatGmailDateISO_MissingInternalDate(t *testing.T) {
+	for _, ms := range []int64{0, -1} {
+		if got := formatGmailDateISO(ms, time.UTC); got != "" {
+			t.Fatalf("internalDate %d: got %q, want empty", ms, got)
+		}
+	}
+}
+
+// A nil location falls back to time.Local rather than panicking, matching
+// formatMailDateInLocation.
+func TestFormatGmailDateISO_NilLocation(t *testing.T) {
+	got := formatGmailDateISO(time.Date(2026, 7, 28, 3, 36, 0, 0, time.UTC).UnixMilli(), nil)
+	if got == "" {
+		t.Fatal("nil location produced no output")
+	}
+	if _, err := time.Parse(time.RFC3339, got); err != nil {
+		t.Fatalf("nil location produced unparseable RFC3339 %q: %v", got, err)
+	}
+}
+
+// Whatever the zone, the value round-trips to the same instant — the offset is
+// carried, not dropped.
+func TestFormatGmailDateISO_RoundTripsToSameInstant(t *testing.T) {
+	ms := time.Date(2026, 7, 28, 3, 36, 0, 0, time.UTC).UnixMilli()
+	for _, name := range []string{"America/New_York", "UTC", "Asia/Tokyo", "Asia/Kolkata"} {
+		loc, err := time.LoadLocation(name)
+		if err != nil {
+			t.Skipf("tzdata unavailable for %s: %v", name, err)
+		}
+		got := formatGmailDateISO(ms, loc)
+		parsed, parseErr := time.Parse(time.RFC3339, got)
+		if parseErr != nil {
+			t.Fatalf("%s: unparseable %q: %v", name, got, parseErr)
+		}
+		if parsed.UnixMilli() != ms {
+			t.Fatalf("%s: %q round-tripped to %d, want %d", name, got, parsed.UnixMilli(), ms)
+		}
+	}
+}

--- a/internal/cmd/gmail_message_summary_fields_test.go
+++ b/internal/cmd/gmail_message_summary_fields_test.go
@@ -1,0 +1,104 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// A `fields` partial-response mask silently drops anything it does not name.
+// The field arrives zeroed with no API error, so a test that hands the command
+// a fully-populated gmail.Message cannot see the omission — it only shows up
+// against live Gmail, as an absent output field.
+//
+// This stub therefore honors the mask the way Gmail does: internalDate is
+// returned only when the selector asks for it. Drop internalDate from
+// gmailMessageSummaryFields and this test fails.
+func TestGmailMessagesSearch_RequestsInternalDateForISOOutput(t *testing.T) {
+	// Derived, not hand-computed: a hardcoded epoch is one typo away from
+	// silently testing a different calendar day than the one named here.
+	internalDateMillis := strconv.FormatInt(
+		time.Date(2026, 7, 28, 3, 36, 0, 0, time.UTC).UnixMilli(), 10)
+
+	var sawFieldsMask string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+		switch {
+		case strings.Contains(path, "/users/me/messages") && !strings.Contains(path, "/users/me/messages/"):
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"messages": []map[string]any{{"id": "m1", "threadId": "t1"}},
+			})
+			return
+		case strings.Contains(path, "/users/me/messages/m1"):
+			mask := r.URL.Query().Get("fields")
+			sawFieldsMask = mask
+			msg := map[string]any{
+				"id":       "m1",
+				"threadId": "t1",
+				"labelIds": []string{"INBOX"},
+				"payload": map[string]any{
+					"headers": []map[string]any{
+						{"name": "From", "value": "Example <no-reply@example.com>"},
+						{"name": "Subject", "value": "Receipt"},
+						{"name": "Date", "value": "Tue, 28 Jul 2026 03:36:00 +0000"},
+					},
+				},
+			}
+			// Gmail returns internalDate only when the mask names it.
+			if strings.Contains(mask, "internalDate") {
+				msg["internalDate"] = internalDateMillis
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(msg)
+			return
+		case strings.Contains(path, "/users/me/labels"):
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"labels": []map[string]any{{"id": "INBOX", "name": "INBOX", "type": "system"}},
+			})
+			return
+		default:
+			http.NotFound(w, r)
+			return
+		}
+	}))
+	defer srv.Close()
+
+	svc := newGmailServiceFromServer(t, srv)
+	result := executeWithGmailTestService(
+		t,
+		[]string{"--json", "--account", "a@b.com", "gmail", "messages", "search", "from:example.com", "--timezone", "America/New_York"},
+		svc,
+	)
+	if result.err != nil {
+		t.Fatalf("Execute: %v\nstderr=%q", result.err, result.stderr)
+	}
+
+	var parsed struct {
+		Messages []struct {
+			Date            string `json:"date"`
+			InternalDateISO string `json:"internalDateIso"`
+		} `json:"messages"`
+	}
+	if err := json.Unmarshal([]byte(result.stdout), &parsed); err != nil {
+		t.Fatalf("decode search json: %v\nstdout=%q", err, result.stdout)
+	}
+	if len(parsed.Messages) != 1 {
+		t.Fatalf("expected one message, got %#v", parsed.Messages)
+	}
+
+	// The reported shape: 03:36 UTC is 11:36 PM Eastern on the PREVIOUS day.
+	const want = "2026-07-27T23:36:00-04:00"
+	if got := parsed.Messages[0].InternalDateISO; got != want {
+		t.Fatalf("internalDateIso = %q, want %q (fields mask sent: %q)", got, want, sawFieldsMask)
+	}
+	// The legacy human column is unchanged.
+	if got := parsed.Messages[0].Date; got != "2026-07-27 23:36" {
+		t.Fatalf("date = %q, want the existing layout unchanged", got)
+	}
+}

--- a/internal/cmd/gmail_messages.go
+++ b/internal/cmd/gmail_messages.go
@@ -194,15 +194,17 @@ type messageItem struct {
 	ID       string `json:"id"`
 	ThreadID string `json:"threadId,omitempty"`
 	Date     string `json:"date,omitempty"`
-	// DateISO is the same instant as Date but RFC3339 with an explicit offset,
-	// sourced from the API's internalDate rather than the sender's Date header.
+	// InternalDateISO is Gmail's own internalDate — the instant Google accepted
+	// the message — rendered RFC3339 with an explicit offset. It is a DIFFERENT
+	// value from Date, which parses the sender-written Date header: the two
+	// disagree whenever that header is skewed, malformed, or in another zone.
 	// Date stays the compact human column; this is what a parser should read.
-	DateISO     string             `json:"dateIso,omitempty"`
-	From        string             `json:"from,omitempty"`
-	Subject     string             `json:"subject,omitempty"`
-	Labels      []string           `json:"labels,omitempty"`
-	Body        string             `json:"body,omitempty"`
-	Attachments []attachmentOutput `json:"attachments,omitempty"`
+	InternalDateISO string             `json:"internalDateIso,omitempty"`
+	From            string             `json:"from,omitempty"`
+	Subject         string             `json:"subject,omitempty"`
+	Labels          []string           `json:"labels,omitempty"`
+	Body            string             `json:"body,omitempty"`
+	Attachments     []attachmentOutput `json:"attachments,omitempty"`
 }
 
 func fetchMessageDetails(ctx context.Context, svc *gmail.Service, messages []*gmail.Message, idToName map[string]string, loc *time.Location, includeBody bool, bodyFormat string) ([]messageItem, error) {
@@ -246,7 +248,7 @@ func fetchMessageDetails(ctx context.Context, svc *gmail.Service, messages []*gm
 			} else {
 				call = call.Format("metadata").
 					MetadataHeaders(gmailMessageSummaryMetadataHeaders...).
-					Fields("id,threadId,labelIds,payload(headers)")
+					Fields(gmailMessageSummaryFields)
 			}
 			msg, err := call.Context(ctx).Do()
 			if err != nil {
@@ -262,7 +264,7 @@ func fetchMessageDetails(ctx context.Context, svc *gmail.Service, messages []*gm
 			item.From = sanitizeTab(headerValue(msg.Payload, "From"))
 			item.Subject = sanitizeTab(headerValue(msg.Payload, "Subject"))
 			item.Date = formatGmailDateInLocation(headerValue(msg.Payload, "Date"), loc)
-			item.DateISO = formatGmailDateISO(msg.InternalDate, loc)
+			item.InternalDateISO = formatGmailDateISO(msg.InternalDate, loc)
 			if includeBody {
 				if preferHTML {
 					item.Body = gmailcontent.BestBodyHTML(msg.Payload)

--- a/internal/cmd/gmail_messages.go
+++ b/internal/cmd/gmail_messages.go
@@ -194,10 +194,12 @@ type messageItem struct {
 	ID       string `json:"id"`
 	ThreadID string `json:"threadId,omitempty"`
 	Date     string `json:"date,omitempty"`
-	// InternalDateISO is Gmail's own internalDate — the instant Google accepted
-	// the message — rendered RFC3339 with an explicit offset. It is a DIFFERENT
-	// value from Date, which parses the sender-written Date header: the two
-	// disagree whenever that header is skewed, malformed, or in another zone.
+	// InternalDateISO is Gmail's own internalDate rendered RFC3339 with an
+	// explicit offset. It is a SEPARATELY SOURCED value from Date, which parses
+	// the sender-written Date header: for normal SMTP mail internalDate is when
+	// Google accepted the message, so the two can disagree when that header is
+	// skewed, malformed, or in another zone. They are not guaranteed to differ —
+	// API-migrated mail may have internalDate derived from the Date header.
 	// Date stays the compact human column; this is what a parser should read.
 	InternalDateISO string             `json:"internalDateIso,omitempty"`
 	From            string             `json:"from,omitempty"`

--- a/internal/cmd/gmail_messages.go
+++ b/internal/cmd/gmail_messages.go
@@ -191,9 +191,13 @@ func (c *GmailMessagesModifyCmd) Run(ctx context.Context, flags *RootFlags) erro
 }
 
 type messageItem struct {
-	ID          string             `json:"id"`
-	ThreadID    string             `json:"threadId,omitempty"`
-	Date        string             `json:"date,omitempty"`
+	ID       string `json:"id"`
+	ThreadID string `json:"threadId,omitempty"`
+	Date     string `json:"date,omitempty"`
+	// DateISO is the same instant as Date but RFC3339 with an explicit offset,
+	// sourced from the API's internalDate rather than the sender's Date header.
+	// Date stays the compact human column; this is what a parser should read.
+	DateISO     string             `json:"dateIso,omitempty"`
 	From        string             `json:"from,omitempty"`
 	Subject     string             `json:"subject,omitempty"`
 	Labels      []string           `json:"labels,omitempty"`
@@ -258,6 +262,7 @@ func fetchMessageDetails(ctx context.Context, svc *gmail.Service, messages []*gm
 			item.From = sanitizeTab(headerValue(msg.Payload, "From"))
 			item.Subject = sanitizeTab(headerValue(msg.Payload, "Subject"))
 			item.Date = formatGmailDateInLocation(headerValue(msg.Payload, "Date"), loc)
+			item.DateISO = formatGmailDateISO(msg.InternalDate, loc)
 			if includeBody {
 				if preferHTML {
 					item.Body = gmailcontent.BestBodyHTML(msg.Payload)

--- a/internal/cmd/gmail_metadata_headers.go
+++ b/internal/cmd/gmail_metadata_headers.go
@@ -13,6 +13,13 @@ var (
 	gmailMessageSummaryMetadataHeaders = []string{"From", "Subject", "Date"}
 )
 
+// gmailMessageSummaryFields is the partial-response selector for message
+// summary fetches. A `fields` mask silently drops anything it does not name:
+// the field arrives zeroed, with no API error, so the omission surfaces only
+// against live Gmail. Every messageItem field read off the API response must
+// appear here — internalDate backs internalDateIso.
+const gmailMessageSummaryFields = "id,threadId,labelIds,internalDate,payload(headers)"
+
 func defaultGmailGetMetadataHeaders() []string {
 	headers := append([]string{}, gmailBasicMetadataHeaders...)
 	headers = append(headers, "Message-ID", "In-Reply-To", "References", "List-Unsubscribe")

--- a/internal/cmd/gmail_thread_search_helpers.go
+++ b/internal/cmd/gmail_thread_search_helpers.go
@@ -199,8 +199,9 @@ type threadItem struct {
 	ID   string `json:"id"`
 	Date string `json:"date,omitempty"`
 	// InternalDateISO is Gmail's own internalDate for the same message Date is
-	// taken from, rendered RFC3339 with an explicit offset. It is a DIFFERENT
-	// value from Date, which parses the sender-written Date header.
+	// taken from, rendered RFC3339 with an explicit offset. It is a SEPARATELY
+	// SOURCED value from Date, which parses the sender-written Date header; the
+	// two can disagree, and for API-migrated mail can share a source.
 	InternalDateISO string   `json:"internalDateIso,omitempty"`
 	From            string   `json:"from,omitempty"`
 	Subject         string   `json:"subject,omitempty"`

--- a/internal/cmd/gmail_thread_search_helpers.go
+++ b/internal/cmd/gmail_thread_search_helpers.go
@@ -198,13 +198,14 @@ func isUnsubscribeLink(raw string) bool {
 type threadItem struct {
 	ID   string `json:"id"`
 	Date string `json:"date,omitempty"`
-	// DateISO is the same instant as Date but RFC3339 with an explicit offset,
-	// sourced from the API's internalDate rather than the sender's Date header.
-	DateISO      string   `json:"dateIso,omitempty"`
-	From         string   `json:"from,omitempty"`
-	Subject      string   `json:"subject,omitempty"`
-	Labels       []string `json:"labels,omitempty"`
-	MessageCount int      `json:"messageCount,omitempty"`
+	// InternalDateISO is Gmail's own internalDate for the same message Date is
+	// taken from, rendered RFC3339 with an explicit offset. It is a DIFFERENT
+	// value from Date, which parses the sender-written Date header.
+	InternalDateISO string   `json:"internalDateIso,omitempty"`
+	From            string   `json:"from,omitempty"`
+	Subject         string   `json:"subject,omitempty"`
+	Labels          []string `json:"labels,omitempty"`
+	MessageCount    int      `json:"messageCount,omitempty"`
 }
 
 func fetchThreadDetails(ctx context.Context, svc *gmail.Service, threads []*gmail.Thread, idToName map[string]string, oldest bool, loc *time.Location) ([]threadItem, error) {
@@ -274,7 +275,7 @@ func fetchThreadDetails(ctx context.Context, svc *gmail.Service, threads []*gmai
 			}
 			if dateMsg != nil {
 				item.Date = formatGmailDateInLocation(headerValue(dateMsg.Payload, "Date"), loc)
-				item.DateISO = formatGmailDateISO(dateMsg.InternalDate, loc)
+				item.InternalDateISO = formatGmailDateISO(dateMsg.InternalDate, loc)
 			}
 
 			results <- result{index: idx, item: item}

--- a/internal/cmd/gmail_thread_search_helpers.go
+++ b/internal/cmd/gmail_thread_search_helpers.go
@@ -196,8 +196,11 @@ func isUnsubscribeLink(raw string) bool {
 }
 
 type threadItem struct {
-	ID           string   `json:"id"`
-	Date         string   `json:"date,omitempty"`
+	ID   string `json:"id"`
+	Date string `json:"date,omitempty"`
+	// DateISO is the same instant as Date but RFC3339 with an explicit offset,
+	// sourced from the API's internalDate rather than the sender's Date header.
+	DateISO      string   `json:"dateIso,omitempty"`
 	From         string   `json:"from,omitempty"`
 	Subject      string   `json:"subject,omitempty"`
 	Labels       []string `json:"labels,omitempty"`
@@ -271,6 +274,7 @@ func fetchThreadDetails(ctx context.Context, svc *gmail.Service, threads []*gmai
 			}
 			if dateMsg != nil {
 				item.Date = formatGmailDateInLocation(headerValue(dateMsg.Payload, "Date"), loc)
+				item.DateISO = formatGmailDateISO(dateMsg.InternalDate, loc)
 			}
 
 			results <- result{index: idx, item: item}


### PR DESCRIPTION
Fixes #945.

## The problem

Message and thread listings render `date` with `listDateLayout` (`"2006-01-02 15:04"`), which carries **no offset**:

```json
{ "id": "19fa6c3d5a030951", "date": "2026-07-28 03:36", "subject": "…" }
```

A JSON consumer reading that has to already know which zone gog was configured for. Get it wrong and the value moves onto the wrong calendar **day**, not merely the wrong hour — that same instant rendered in Eastern is `2026-07-27 23:36`, a different date. That is the difference between "this went out Tuesday" and "this went out Monday night".

It bites hardest on headless deployments. Mine ran in a container with nothing setting `GOG_TIMEZONE`, so `time.Local` was UTC and the naive value silently meant UTC while every consumer read it as local time.

## The change

Add `internalDateIso` **alongside** `date` rather than reformatting it. `date` is the compact human column in the CLI table, and changing it would regress output for everyone reading it today. This is purely additive.

```json
{
  "id": "19fa6c3d5a030951",
  "date": "2026-07-27 23:36",
  "internalDateIso": "2026-07-27T23:36:00-04:00"
}
```

`internalDateIso` also switches **source**. `formatGmailDateInLocation` parses the `Date:` header written by the sending client, which varies in format and offset and is occasionally just wrong. `internalDateIso` derives from the API's `internalDate` — epoch milliseconds, UTC, Gmail's own internal message timestamp. For normal SMTP-received mail that is when Google accepted the message, which Gmail documents as more reliable than the `Date` header. (It is not universally independent of that header: for API-migrated mail the importing client may derive `internalDate` from it.) It is still rendered in the configured location, so `--timezone` / `GOG_TIMEZONE` / config all continue to apply.

An absent `internalDate` yields `""`, so the field stays `omitempty` rather than claiming the Unix epoch.

Applies to both `messageItem` (`gmail messages`) and `threadItem` (`gmail threads`).

## Compatibility

Nothing that reads `date` changes — same field, same layout, same location. The human table is untouched. No existing test needed modifying.

## Testing

`make ci` green. New `internal/cmd/gmail_date_iso_test.go` covers:

- the reported shape: an instant that is `03:36` UTC renders as `2026-07-27T23:36:00-04:00` in Eastern — the previous day — while the legacy `date` column keeps its existing output
- DST via the IANA database: January is `-05:00`, July `-04:00`
- absent `internalDate` (0 and negative) yields `""`
- a nil location falls back to `time.Local`, matching `formatMailDateInLocation`
- round-trips to the same instant across `America/New_York`, `UTC`, `Asia/Tokyo` and `Asia/Kolkata`, so the offset is carried rather than dropped

Tests `t.Skipf` when tzdata is unavailable rather than failing.

---

## Review round 2 (updated after ClawSweeper review)

**Renamed `dateIso` → `internalDateIso`.** Next to `date`, the old name read as "`date`, in ISO" — a representation change — when it is a different value from a different source. Not `receivedAt`: `internalDate` is the *send* time for messages you sent. See #945 for the full reasoning.

**Fixed a P1 that would have shipped the feature emitting nothing.** The message-summary fetch used a `fields` partial-response mask that never named `internalDate`, so `InternalDate` was always `0` and `omitempty` deleted the output field. A `fields` mask drops what it does not name *silently* — no API error — and unit tests that build `gmail.Message` values directly cannot see it. The selector now names the field and lives next to the metadata headers it travels with, and the new `gmail_message_summary_fields_test.go` uses a stub that honors the mask the way Gmail does. Removing `internalDate` from the selector fails that test with the exact production symptom (`internalDateIso = ""`).

The thread path needed no change — it has no `fields` mask, and `format=metadata` already returns `internalDate`. Live output below confirms it.

**Dropped the CHANGELOG entry** — `AGENTS.md` puts it in the maintainer's landing checklist.

## Real behavior proof

Built from this branch, run against a live Gmail account with `--timezone America/New_York`.

`gog gmail messages search "in:inbox" --max 2 --json` (message path, selector fixed):

```json
{
  "messages": [
    {
      "id": "19fb4605c40146e0",
      "threadId": "19fb4605c40146e0",
      "date": "2026-07-30 14:54",
      "internalDateIso": "2026-07-30T14:54:00-04:00",
      "from": "support@splitwise.com",
      "subject": "An update to the Splitwise API",
      "labels": ["UNREAD", "IMPORTANT", "CATEGORY_UPDATES", "INBOX"]
    }
  ]
}
```

`gog gmail search "in:inbox" --max 2 --json` (thread path, unmodified):

```json
{
  "threads": [
    {
      "id": "19fb44d34ac74f1f",
      "date": "2026-07-30 14:33",
      "internalDateIso": "2026-07-30T14:33:05-04:00",
      "subject": "CMS Inside Connection July 30, 2026",
      "messageCount": 1
    }
  ]
}
```

Note the second: `date` is `14:33`, `internalDateIso` is `14:33:05`. `listDateLayout` has no seconds, so even where the two agree on the instant the legacy column is lossy.

`date` is byte-identical to before on both paths.

**On how often the two sources disagree:** I scanned 60 live messages comparing the `Date` header against `internalDate` — zero disagreed to the minute. Well-behaved senders agree. The case for the new field is the unambiguous offset and the authoritative source, not a divergence I can demonstrate on demand.

## Review round 3

**Qualified the `internalDate` provenance claims (P3).** The finding is right and I'd overstated it. Gmail documents that for **API-migrated mail** the importing client may derive `internalDate` *from* the `Date` header, so my comments claiming the two are always distinct, and that `internalDate` is universally Google's receipt time, were wrong at the edges.

Corrected in all three places (`gmail_date.go`, `messageItem`, `threadItem`) and in this body: `internalDate` is described as Gmail's **internal message timestamp**, equal to Google's acceptance time for normal SMTP mail, with the migrated-mail exception stated explicitly. The field is now "separately sourced" rather than "a different value" — the distinction that actually matters to a consumer is that it doesn't depend on the sender's *formatting*, not that it always disagrees.

This doesn't change the case for the field: the offset is explicit either way, and where the two sources happen to coincide they coincide correctly.


## Review round 4

**Fixed the P2 millisecond truncation.** `internalDate` is epoch milliseconds, but the formatter used `time.RFC3339`, which has no fractional seconds — an instant ending in nonzero milliseconds serialized to a value that parsed back to the preceding whole second. Nonzero-millisecond instants now render with a fixed three-digit fraction (`2026-07-27T23:36:05.450-04:00`); whole-second instants keep the fraction-free form the field has emitted since it was introduced, so the live output shown above is byte-identical.

Coverage added first, red-then-green:

- `TestFormatGmailDateISO_MillisecondPrecision` pins the exact rendering at `.007`, `.450`, and `.999`, and that a whole second stays fraction-free
- `TestFormatGmailDateISO_RoundTripsToSameInstant` now round-trips a nonzero-millisecond instant across all four zones, and failed with the truncation symptom before the fix

`go test ./internal/cmd -run TestFormatGmailDateISO` and `make ci` both green.
