### PR TITLE
feat(gmail): make inline attachment size limit configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.34.2 - 2026-07-27
 
+- Gmail: add configurable inline attachment byte limits while retaining the 3 MiB default and path fallback. (#947) — thanks @ronny-rentner.
 - Gmail: preserve single-object result envelopes for attachment-bearing `--results-only` output. (#943) — thanks @hashtag1974.
 - Sheets: keep positional updates within the requested range, preserving comma-bearing single-cell values and accurate named-range dry runs. (#941) — thanks @cathrynlavery.
 - Gmail: add source-specific `internalDateIso` timestamps to message and thread listings while preserving the legacy sender-header `date`. (#945, #946) — thanks @chrischall.

--- a/docs/commands/gog-gmail-attachment.md
+++ b/docs/commands/gog-gmail-attachment.md
@@ -31,6 +31,7 @@ gog gmail (mail,email) attachment <messageId> <attachmentId> [flags]
 | `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
 | `--inline` | `bool` |  | Also return the attachment content base64-encoded (contentBase64) in the response; attachments over the inline size limit fall back to the file path with an explanatory reason |
+| `--inline-max-bytes` | `int` | 3145728 | Maximum attachment size --inline embeds (bytes) |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
 | `--name` | `string` |  | Filename (used when --out is empty or points to a directory) |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -382,7 +382,7 @@ after the bounded retry window, the command exits with retryable code `8`.
 - `gog gmail thread get <threadId> [--download]`
 - `gog gmail thread modify <threadId> [--add ...] [--remove ...]`
 - `gog gmail get <messageId> [--format full|metadata|raw] [--headers ...]`
-- `gog gmail attachment <messageId> <attachmentId> [--out PATH] [--name NAME] [--inline]`
+- `gog gmail attachment <messageId> <attachmentId> [--out PATH] [--name NAME] [--inline] [--inline-max-bytes BYTES]`
 - `gog gmail url <threadIds...>`
 - `gog gmail reply <messageId> [--body B|--body-file PATH|--body-html HTML|--body-html-file PATH] [--to ...] [--cc ...] [--bcc ...] [--remove ...] [--subject S] [--no-quote] [--from addr] [--signature|--signature-from addr|--signature-file path] [--attach <file>...]`
 - `gog gmail reply-all <messageId> [--body B|--body-file PATH|--body-html HTML|--body-html-file PATH] [--to ...] [--cc ...] [--bcc ...] [--remove ...] [--subject S] [--no-quote] [--from addr] [--signature|--signature-from addr|--signature-file path] [--attach <file>...]`

--- a/internal/cmd/execute_gmail_attachment_inline_test.go
+++ b/internal/cmd/execute_gmail_attachment_inline_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -96,14 +97,17 @@ func TestExecute_GmailAttachment_Inline_SmallAttachment_ReturnsBase64(t *testing
 }
 
 func TestExecute_GmailAttachment_Inline_Oversized_FallsBackToPathWithReason(t *testing.T) {
-	data := bytes.Repeat([]byte("x"), maxInlineAttachmentBytes+1)
+	// The limit is configured artificially low; the property under test is only
+	// the boundary crossing (payload = limit+1), not any realistic size.
+	const inlineLimit = 8
+	data := bytes.Repeat([]byte("x"), inlineLimit+1)
 	svc := newGmailAttachmentTestService(t, data, "big.bin", "application/octet-stream")
 	outPath := tempFilePath(t, "big.bin")
 
 	parsed := executeGmailAttachmentJSON(t, svc,
 		"--json", "--account", "a@b.com",
 		"gmail", "attachment", "m1", "a1",
-		"--out", outPath, "--inline",
+		"--out", outPath, "--inline", "--inline-max-bytes", strconv.Itoa(inlineLimit),
 	)
 
 	if _, ok := parsed["contentBase64"]; ok {

--- a/internal/cmd/execute_gmail_attachment_inline_test.go
+++ b/internal/cmd/execute_gmail_attachment_inline_test.go
@@ -126,6 +126,20 @@ func TestExecute_GmailAttachment_Inline_Oversized_FallsBackToPathWithReason(t *t
 	}
 }
 
+func TestExecute_GmailAttachment_Inline_NegativeLimitRejected(t *testing.T) {
+	result := executeWithTestRuntime(t, []string{
+		"--json", "--account", "a@b.com",
+		"gmail", "attachment", "m1", "a1",
+		"--out", tempFilePath(t, "a.txt"), "--inline", "--inline-max-bytes=-1",
+	}, nil)
+	if result.err == nil {
+		t.Fatalf("negative --inline-max-bytes must error, got stdout=%q", result.stdout)
+	}
+	if !strings.Contains(result.err.Error(), "--inline-max-bytes must be non-negative") {
+		t.Fatalf("err=%v", result.err)
+	}
+}
+
 func TestExecute_GmailAttachment_Default_OutputUnchanged(t *testing.T) {
 	data := []byte("plain old download")
 	svc := newGmailAttachmentTestService(t, data, "a.txt", "text/plain")

--- a/internal/cmd/execute_gmail_attachment_inline_test.go
+++ b/internal/cmd/execute_gmail_attachment_inline_test.go
@@ -205,7 +205,7 @@ func TestExecute_GmailAttachment_Inline_DryRunReportsMode(t *testing.T) {
 	result := executeWithTestRuntime(t, []string{
 		"--json", "--dry-run", "--account", "a@b.com",
 		"gmail", "attachment", "m1", "a1",
-		"--out", tempFilePath(t, "a.txt"), "--inline",
+		"--out", tempFilePath(t, "a.txt"), "--inline", "--inline-max-bytes", "42",
 	}, nil)
 	if result.err != nil {
 		t.Fatalf("Execute: %v\nstderr=%q", result.err, result.stderr)
@@ -217,7 +217,7 @@ func TestExecute_GmailAttachment_Inline_DryRunReportsMode(t *testing.T) {
 	if err := json.Unmarshal([]byte(result.stdout), &parsed); err != nil {
 		t.Fatalf("Unmarshal: %v\nstdout=%q", err, result.stdout)
 	}
-	if !parsed.DryRun || parsed.Request["inline"] != true {
+	if !parsed.DryRun || parsed.Request["inline"] != true || parsed.Request["inline_max_bytes"] != float64(42) {
 		t.Fatalf("unexpected dry-run output: %#v", parsed)
 	}
 }

--- a/internal/cmd/gmail_attachment.go
+++ b/internal/cmd/gmail_attachment.go
@@ -19,17 +19,15 @@ import (
 )
 
 type GmailAttachmentCmd struct {
-	MessageID    string         `arg:"" name:"messageId" help:"Message ID"`
-	AttachmentID string         `arg:"" name:"attachmentId" help:"Attachment ID"`
-	Output       OutputPathFlag `embed:""`
-	Name         string         `name:"name" help:"Filename (used when --out is empty or points to a directory)"`
-	Inline       bool           `name:"inline" help:"Also return the attachment content base64-encoded (contentBase64) in the response; attachments over the inline size limit fall back to the file path with an explanatory reason"`
+	MessageID      string         `arg:"" name:"messageId" help:"Message ID"`
+	AttachmentID   string         `arg:"" name:"attachmentId" help:"Attachment ID"`
+	Output         OutputPathFlag `embed:""`
+	Name           string         `name:"name" help:"Filename (used when --out is empty or points to a directory)"`
+	Inline         bool           `name:"inline" help:"Also return the attachment content base64-encoded (contentBase64) in the response; attachments over the inline size limit fall back to the file path with an explanatory reason"`
+	InlineMaxBytes int            `name:"inline-max-bytes" default:"3145728" help:"Maximum attachment size --inline embeds (bytes)" env:"GOG_GMAIL_INLINE_MAX_BYTES"`
 }
 
 const defaultGmailAttachmentFilename = "attachment.bin"
-
-// maxInlineAttachmentBytes caps how much raw attachment content --inline embeds.
-const maxInlineAttachmentBytes = 3 << 20
 
 func printAttachmentDownloadResult(ctx context.Context, u *ui.UI, payload map[string]any) error {
 	if outfmt.IsJSON(ctx) {
@@ -126,16 +124,16 @@ func (c *GmailAttachmentCmd) Run(ctx context.Context, flags *RootFlags) error {
 		}
 	}
 	if c.Inline {
-		addInlineContent(payload, data)
+		addInlineContent(payload, data, c.InlineMaxBytes)
 	}
 	return printAttachmentDownloadResult(ctx, u, payload)
 }
 
 // addInlineContent embeds the fetched bytes, avoiding a second read of the
 // caller-controlled destination path.
-func addInlineContent(payload map[string]any, data []byte) {
-	if len(data) > maxInlineAttachmentBytes {
-		payload["reason"] = fmt.Sprintf("attachment size %d bytes exceeds inline size limit (%d bytes); content written to path only", len(data), maxInlineAttachmentBytes)
+func addInlineContent(payload map[string]any, data []byte, maxBytes int) {
+	if len(data) > maxBytes {
+		payload["reason"] = fmt.Sprintf("attachment size %d bytes exceeds inline size limit (%d bytes); content written to path only", len(data), maxBytes)
 		return
 	}
 	payload["contentBase64"] = base64.StdEncoding.EncodeToString(data)

--- a/internal/cmd/gmail_attachment.go
+++ b/internal/cmd/gmail_attachment.go
@@ -77,10 +77,11 @@ func (c *GmailAttachmentCmd) Run(ctx context.Context, flags *RootFlags) error {
 
 	// Avoid touching auth/keyring and avoid writing files in dry-run mode.
 	if dryRunErr := dryRunExit(ctx, flags, "gmail.attachment.download", map[string]any{
-		"message_id":    messageID,
-		"attachment_id": attachmentID,
-		"path":          dest,
-		"inline":        c.Inline,
+		"message_id":       messageID,
+		"attachment_id":    attachmentID,
+		"path":             dest,
+		"inline":           c.Inline,
+		"inline_max_bytes": c.InlineMaxBytes,
 	}); dryRunErr != nil {
 		return dryRunErr
 	}

--- a/internal/cmd/gmail_attachment.go
+++ b/internal/cmd/gmail_attachment.go
@@ -59,6 +59,9 @@ func (c *GmailAttachmentCmd) Run(ctx context.Context, flags *RootFlags) error {
 	if messageID == "" || attachmentID == "" {
 		return usage("messageId/attachmentId required")
 	}
+	if c.InlineMaxBytes < 0 {
+		return usage("--inline-max-bytes must be non-negative")
+	}
 	defaultDir := ""
 	if strings.TrimSpace(c.Output.Path) == "" {
 		layout, err := commandLayout(ctx, config.PathKindConfig)


### PR DESCRIPTION
## Summary

`gmail attachment --inline` embeds the attachment content as base64 (`contentBase64`) in the response, but the size it will embed is capped at a hardcoded 3 MiB. This makes that cap configurable while keeping the current default, so nothing changes unless you ask for it.

- New flag `--inline-max-bytes` on `gmail attachment` (default `3145728`, i.e. the current 3 MiB).
- Also settable via `GOG_GMAIL_INLINE_MAX_BYTES`.
- Attachments larger than the limit keep the existing behavior: they fall back to the file path with the same explanatory `reason`.

## Motivation

Automation that consumes attachments *only* through `--inline` — for example a confined agent that cannot read gog's `0600` output files directly — needs to pull attachments larger than 3 MiB without a separate file read. A fixed 3 MiB cap forces those callers to give up on anything bigger.

## User-facing changes

- New flag: `--inline-max-bytes <bytes>` on `gmail attachment`.
- New env var: `GOG_GMAIL_INLINE_MAX_BYTES`.
- Default is unchanged (3 MiB), so existing behavior is preserved unless the limit is raised.

## Testing

- `go test ./internal/cmd/` — the oversized-fallback test now drives the boundary crossing through the flag (`--inline-max-bytes`) rather than a hardcoded constant.
- `make lint` — 0 issues.
