### PR TITLE
feat(gmail): auto-select reply From from the addressed send-as alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.34.2 - 2026-07-27
 
+- Gmail: add opt-in reply From alias selection for the verified send-as alias addressed by the original message. (#948) — thanks @ronny-rentner.
 - Gmail: add configurable inline attachment byte limits while retaining the 3 MiB default and path fallback. (#947) — thanks @ronny-rentner.
 - Gmail: preserve single-object result envelopes for attachment-bearing `--results-only` output. (#943) — thanks @hashtag1974.
 - Sheets: keep positional updates within the requested range, preserving comma-bearing single-cell values and accurate named-range dry runs. (#941) — thanks @cathrynlavery.

--- a/docs/commands/gog-gmail-drafts-create.md
+++ b/docs/commands/gog-gmail-drafts-create.md
@@ -21,6 +21,7 @@ gog gmail (mail,email) drafts (draft) create (add,new) [flags]
 | `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email, alias, or auto for authenticated Google API commands |
 | `--attach` | `[]string` |  | Attachment file path (repeatable) |
+| `--auto-from-addressed-alias` | `bool` |  | When --from is omitted, reply from the verified send-as alias addressed by the original message |
 | `--bcc` | `string` |  | BCC recipients (comma-separated) |
 | `--body` | `string` |  | Body (plain text; required unless --body-html is set) |
 | `--body-file` | `string` |  | Body file path (plain text; '-' for stdin) |

--- a/docs/commands/gog-gmail-drafts-update.md
+++ b/docs/commands/gog-gmail-drafts-update.md
@@ -21,6 +21,7 @@ gog gmail (mail,email) drafts (draft) update (edit,set) <draftId> [flags]
 | `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email, alias, or auto for authenticated Google API commands |
 | `--attach` | `[]string` |  | Attachment file path (repeatable). Replaces existing attachments; omit to preserve them, or use --clear-attachments to remove all. |
+| `--auto-from-addressed-alias` | `bool` |  | When --from is omitted, reply from the verified send-as alias addressed by the original message |
 | `--bcc` | `string` |  | BCC recipients (comma-separated) |
 | `--body` | `string` |  | Body (plain text; required unless --body-html is set) |
 | `--body-file` | `string` |  | Body file path (plain text; '-' for stdin) |

--- a/docs/commands/gog-gmail-reply-all.md
+++ b/docs/commands/gog-gmail-reply-all.md
@@ -21,6 +21,7 @@ gog gmail (mail,email) reply-all (replyall) <messageId> [flags]
 | `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email, alias, or auto for authenticated Google API commands |
 | `--attach` | `[]string` |  | Attachment file path (repeatable) |
+| `--auto-from-addressed-alias` | `bool` |  | When --from is omitted, reply from the verified send-as alias addressed by the original message |
 | `--bcc` | `[]string` |  | Add or move recipients to Bcc (repeatable) |
 | `--body` | `string` |  | Body (plain text; required unless --body-html is set) |
 | `--body-file` | `string` |  | Body file path (plain text; '-' for stdin) |

--- a/docs/commands/gog-gmail-reply.md
+++ b/docs/commands/gog-gmail-reply.md
@@ -21,6 +21,7 @@ gog gmail (mail,email) reply <messageId> [flags]
 | `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email, alias, or auto for authenticated Google API commands |
 | `--attach` | `[]string` |  | Attachment file path (repeatable) |
+| `--auto-from-addressed-alias` | `bool` |  | When --from is omitted, reply from the verified send-as alias addressed by the original message |
 | `--bcc` | `[]string` |  | Add or move recipients to Bcc (repeatable) |
 | `--body` | `string` |  | Body (plain text; required unless --body-html is set) |
 | `--body-file` | `string` |  | Body file path (plain text; '-' for stdin) |

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -384,8 +384,8 @@ after the bounded retry window, the command exits with retryable code `8`.
 - `gog gmail get <messageId> [--format full|metadata|raw] [--headers ...]`
 - `gog gmail attachment <messageId> <attachmentId> [--out PATH] [--name NAME] [--inline]`
 - `gog gmail url <threadIds...>`
-- `gog gmail reply <messageId> [--body B|--body-file PATH|--body-html HTML|--body-html-file PATH] [--to ...] [--cc ...] [--bcc ...] [--remove ...] [--subject S] [--no-quote] [--from addr] [--signature|--signature-from addr|--signature-file path] [--attach <file>...]`
-- `gog gmail reply-all <messageId> [--body B|--body-file PATH|--body-html HTML|--body-html-file PATH] [--to ...] [--cc ...] [--bcc ...] [--remove ...] [--subject S] [--no-quote] [--from addr] [--signature|--signature-from addr|--signature-file path] [--attach <file>...]`
+- `gog gmail reply <messageId> [--body B|--body-file PATH|--body-html HTML|--body-html-file PATH] [--to ...] [--cc ...] [--bcc ...] [--remove ...] [--subject S] [--no-quote] [--from addr|--auto-from-addressed-alias] [--signature|--signature-from addr|--signature-file path] [--attach <file>...]`
+- `gog gmail reply-all <messageId> [--body B|--body-file PATH|--body-html HTML|--body-html-file PATH] [--to ...] [--cc ...] [--bcc ...] [--remove ...] [--subject S] [--no-quote] [--from addr|--auto-from-addressed-alias] [--signature|--signature-from addr|--signature-file path] [--attach <file>...]`
 - `gog gmail forward <messageId> --to a@b.com [--cc ...] [--bcc ...] [--note TEXT|--note-file PATH] [--from addr] [--skip-attachments]`
 - `gog gmail labels list`
 - `gog gmail labels get <labelIdOrName>`
@@ -395,8 +395,8 @@ after the bounded retry window, the command exits with retryable code `8`.
 - `gog gmail send --to a@b.com [--subject S] [--body B|--body-file PATH] [--body-html H|--body-html-file PATH] [--cc ...] [--bcc ...] [--reply-to-message-id <messageId>] [--reply-to addr] [--from addr] [--signature|--signature-from addr|--signature-file path] [--attach <file>...]`
 - `gog gmail drafts list [--max N] [--page TOKEN]`
 - `gog gmail drafts get <draftId> [--download]`
-- `gog gmail drafts create [--subject S] [--to a@b.com] [--body B] [--body-html H] [--cc ...] [--bcc ...] [--reply-to-message-id <messageId>|--thread-id <threadId>] [--reply-all] [--reply-to addr] [--attach <file>...]`
-- `gog gmail drafts update <draftId> [--subject S] [--to a@b.com] [--body B] [--body-html H] [--cc ...] [--bcc ...] [--reply-to-message-id <messageId>|--thread-id <threadId>] [--reply-all] [--reply-to addr] [--attach <file>...]`
+- `gog gmail drafts create [--subject S] [--to a@b.com] [--body B] [--body-html H] [--cc ...] [--bcc ...] [--reply-to-message-id <messageId>|--thread-id <threadId>] [--reply-all] [--reply-to addr] [--from addr|--auto-from-addressed-alias] [--attach <file>...]`
+- `gog gmail drafts update <draftId> [--subject S] [--to a@b.com] [--body B] [--body-html H] [--cc ...] [--bcc ...] [--reply-to-message-id <messageId>|--thread-id <threadId>] [--reply-all] [--reply-to addr] [--from addr|--auto-from-addressed-alias] [--attach <file>...]`
 - `gog gmail drafts send <draftId>`
 - `gog gmail drafts delete <draftId>`
 - `gog gmail watch start|status|renew|stop|serve`

--- a/internal/cmd/gmail_compose.go
+++ b/internal/cmd/gmail_compose.go
@@ -179,14 +179,26 @@ func prepareComposeReply(ctx context.Context, svc *gmail.Service, replyToMessage
 	if err != nil {
 		return nil, "", "", err
 	}
-	if quote {
-		loc, locErr := mailDateLocation(ctx, stderrWriter(ctx))
-		if locErr != nil {
-			return nil, "", "", locErr
-		}
-		plainBody, htmlBody = applyQuoteToBodies(plainBody, htmlBody, quote, info, loc)
+	plainBody, htmlBody, err = applyReplyQuote(ctx, quote, info, plainBody, htmlBody)
+	if err != nil {
+		return nil, "", "", err
 	}
 	return info, plainBody, htmlBody, nil
+}
+
+// applyReplyQuote appends the quoted original below the reply bodies. Split out
+// so the reply path can pick the From alias and resolve its signature between
+// fetching the original and quoting it, keeping the signature above the quote.
+func applyReplyQuote(ctx context.Context, quote bool, info *replyInfo, plainBody, htmlBody string) (string, string, error) {
+	if !quote {
+		return plainBody, htmlBody, nil
+	}
+	loc, err := mailDateLocation(ctx, stderrWriter(ctx))
+	if err != nil {
+		return "", "", err
+	}
+	plainBody, htmlBody = applyQuoteToBodies(plainBody, htmlBody, quote, info, loc)
+	return plainBody, htmlBody, nil
 }
 
 func buildGmailMessage(ctx context.Context, opts sendMessageOptions, batch sendBatch, allowMissingTo bool) (*gmail.Message, error) {

--- a/internal/cmd/gmail_compose.go
+++ b/internal/cmd/gmail_compose.go
@@ -135,6 +135,18 @@ func resolveComposeFrom(ctx context.Context, svc *gmail.Service, account, from s
 	return result, nil
 }
 
+// pickSendAsFromRecipients returns the first verified send-as alias among the
+// original recipients — To before Cc, first match wins — or "" if none match.
+// This lets a reply go out as the identity the sender actually wrote to.
+func pickSendAsFromRecipients(toAddrs, ccAddrs []string, sendAs []*gmail.SendAs) string {
+	for _, addr := range append(append([]string{}, toAddrs...), ccAddrs...) {
+		if sa := findSendAsByEmail(sendAs, addr); sa != nil && sendAsAllowedForFrom(sa) {
+			return sa.SendAsEmail
+		}
+	}
+	return ""
+}
+
 func primaryDisplayNameFromPeople(ctx context.Context, account string) string {
 	svc, err := peopleContactsService(ctx, account)
 	if err != nil {

--- a/internal/cmd/gmail_drafts.go
+++ b/internal/cmd/gmail_drafts.go
@@ -316,6 +316,16 @@ func buildDraftMessage(ctx context.Context, svc *gmail.Service, account string, 
 	if err != nil {
 		return nil, "", nil, err
 	}
+	// Reply as the alias the original was addressed to, unless --from was explicit. The
+	// alias comes from the verified send-as list, so it can't be a bad From; a lookup
+	// error leaves the account default in place.
+	if strings.TrimSpace(input.From) == "" && sendAsErr == nil {
+		if alias := pickSendAsFromRecipients(info.ToAddrs, info.CcAddrs, sendAs); alias != "" {
+			if picked, pickErr := resolveComposeFrom(ctx, svc, account, alias, sendAs, sendAsErr); pickErr == nil {
+				from = picked
+			}
+		}
+	}
 	threadID := info.ThreadID
 	atts := attachmentsFromPaths(input.Attach)
 	atts = append(atts, input.PrebuiltAttachments...)

--- a/internal/cmd/gmail_drafts.go
+++ b/internal/cmd/gmail_drafts.go
@@ -252,21 +252,22 @@ func (c *GmailDraftsSendCmd) Run(ctx context.Context, flags *RootFlags) error {
 }
 
 type GmailDraftsCreateCmd struct {
-	To               string   `name:"to" help:"Recipients (comma-separated)"`
-	Cc               string   `name:"cc" help:"CC recipients (comma-separated)"`
-	Bcc              string   `name:"bcc" help:"BCC recipients (comma-separated)"`
-	Subject          string   `name:"subject" help:"Subject (required)"`
-	Body             string   `name:"body" help:"Body (plain text; required unless --body-html is set)"`
-	BodyFile         string   `name:"body-file" help:"Body file path (plain text; '-' for stdin)"`
-	BodyHTML         string   `name:"body-html" help:"Body (HTML; optional)"`
-	BodyHTMLFile     string   `name:"body-html-file" help:"HTML body file path ('-' for stdin)"`
-	ReplyToMessageID string   `name:"reply-to-message-id" help:"Reply to Gmail message ID (sets In-Reply-To/References and thread)"`
-	ThreadID         string   `name:"thread-id" help:"Reply within a Gmail thread (uses latest message for headers)"`
-	ReplyAll         bool     `name:"reply-all" help:"Auto-populate recipients from original message (requires --reply-to-message-id or --thread-id)"`
-	ReplyTo          string   `name:"reply-to" help:"Reply-To header address"`
-	Quote            bool     `name:"quote" help:"Include quoted original message in reply (requires --reply-to-message-id or --thread-id)"`
-	Attach           []string `name:"attach" help:"Attachment file path (repeatable)"`
-	From             string   `name:"from" help:"Send from this email address (must be a verified send-as alias)"`
+	To                     string   `name:"to" help:"Recipients (comma-separated)"`
+	Cc                     string   `name:"cc" help:"CC recipients (comma-separated)"`
+	Bcc                    string   `name:"bcc" help:"BCC recipients (comma-separated)"`
+	Subject                string   `name:"subject" help:"Subject (required)"`
+	Body                   string   `name:"body" help:"Body (plain text; required unless --body-html is set)"`
+	BodyFile               string   `name:"body-file" help:"Body file path (plain text; '-' for stdin)"`
+	BodyHTML               string   `name:"body-html" help:"Body (HTML; optional)"`
+	BodyHTMLFile           string   `name:"body-html-file" help:"HTML body file path ('-' for stdin)"`
+	ReplyToMessageID       string   `name:"reply-to-message-id" help:"Reply to Gmail message ID (sets In-Reply-To/References and thread)"`
+	ThreadID               string   `name:"thread-id" help:"Reply within a Gmail thread (uses latest message for headers)"`
+	ReplyAll               bool     `name:"reply-all" help:"Auto-populate recipients from original message (requires --reply-to-message-id or --thread-id)"`
+	ReplyTo                string   `name:"reply-to" help:"Reply-To header address"`
+	Quote                  bool     `name:"quote" help:"Include quoted original message in reply (requires --reply-to-message-id or --thread-id)"`
+	Attach                 []string `name:"attach" help:"Attachment file path (repeatable)"`
+	From                   string   `name:"from" help:"Send from this email address (must be a verified send-as alias)"`
+	AutoFromAddressedAlias bool     `name:"auto-from-addressed-alias" help:"When --from is omitted, reply from the verified send-as alias addressed by the original message"`
 }
 
 type draftComposeInput struct {
@@ -284,8 +285,9 @@ type draftComposeInput struct {
 	Attach           []string
 	// PrebuiltAttachments carry already-resolved attachment bytes (e.g. existing
 	// draft attachments preserved across an update) alongside any --attach paths.
-	PrebuiltAttachments []mailmime.Attachment
-	From                string
+	PrebuiltAttachments    []mailmime.Attachment
+	From                   string
+	AutoFromAddressedAlias bool
 }
 
 func (c draftComposeInput) validate() error {
@@ -316,10 +318,8 @@ func buildDraftMessage(ctx context.Context, svc *gmail.Service, account string, 
 	if err != nil {
 		return nil, "", nil, err
 	}
-	// Reply as the alias the original was addressed to, unless --from was explicit. The
-	// alias comes from the verified send-as list, so it can't be a bad From; a lookup
-	// error leaves the account default in place.
-	if strings.TrimSpace(input.From) == "" && sendAsErr == nil {
+	// When requested, reply as the verified alias the original was addressed to.
+	if input.AutoFromAddressedAlias && strings.TrimSpace(input.From) == "" && sendAsErr == nil {
 		if alias := pickSendAsFromRecipients(info.ToAddrs, info.CcAddrs, sendAs); alias != "" {
 			if picked, pickErr := resolveComposeFrom(ctx, svc, account, alias, sendAs, sendAsErr); pickErr == nil {
 				from = picked
@@ -597,19 +597,20 @@ func (c *GmailDraftsCreateCmd) Run(ctx context.Context, flags *RootFlags) error 
 	}
 
 	input := draftComposeInput{
-		To:               c.To,
-		Cc:               c.Cc,
-		Bcc:              c.Bcc,
-		Subject:          c.Subject,
-		Body:             body,
-		BodyHTML:         htmlBody,
-		ReplyToMessageID: replyToMessageID,
-		ReplyToThreadID:  threadID,
-		ReplyAll:         c.ReplyAll,
-		ReplyTo:          c.ReplyTo,
-		Quote:            c.Quote,
-		Attach:           attachPaths,
-		From:             c.From,
+		To:                     c.To,
+		Cc:                     c.Cc,
+		Bcc:                    c.Bcc,
+		Subject:                c.Subject,
+		Body:                   body,
+		BodyHTML:               htmlBody,
+		ReplyToMessageID:       replyToMessageID,
+		ReplyToThreadID:        threadID,
+		ReplyAll:               c.ReplyAll,
+		ReplyTo:                c.ReplyTo,
+		Quote:                  c.Quote,
+		Attach:                 attachPaths,
+		From:                   c.From,
+		AutoFromAddressedAlias: c.AutoFromAddressedAlias,
 	}
 	if validateErr := input.validate(); validateErr != nil {
 		return validateErr
@@ -619,19 +620,20 @@ func (c *GmailDraftsCreateCmd) Run(ctx context.Context, flags *RootFlags) error 
 	}
 
 	if dryRunErr := dryRunExit(ctx, flags, "gmail.drafts.create", map[string]any{
-		"to":                  splitCSV(input.To),
-		"cc":                  splitCSV(input.Cc),
-		"bcc":                 splitCSV(input.Bcc),
-		"subject":             strings.TrimSpace(input.Subject),
-		"body_len":            len(input.Body),
-		"body_html_len":       len(input.BodyHTML),
-		"reply_to_message_id": strings.TrimSpace(input.ReplyToMessageID),
-		"thread_id":           strings.TrimSpace(input.ReplyToThreadID),
-		"reply_all":           input.ReplyAll,
-		"reply_to":            strings.TrimSpace(input.ReplyTo),
-		"quote":               input.Quote,
-		"from":                strings.TrimSpace(input.From),
-		"attachments":         attachPaths,
+		"to":                        splitCSV(input.To),
+		"cc":                        splitCSV(input.Cc),
+		"bcc":                       splitCSV(input.Bcc),
+		"subject":                   strings.TrimSpace(input.Subject),
+		"body_len":                  len(input.Body),
+		"body_html_len":             len(input.BodyHTML),
+		"reply_to_message_id":       strings.TrimSpace(input.ReplyToMessageID),
+		"thread_id":                 strings.TrimSpace(input.ReplyToThreadID),
+		"reply_all":                 input.ReplyAll,
+		"reply_to":                  strings.TrimSpace(input.ReplyTo),
+		"quote":                     input.Quote,
+		"from":                      strings.TrimSpace(input.From),
+		"auto_from_addressed_alias": input.AutoFromAddressedAlias,
+		"attachments":               attachPaths,
 	}); dryRunErr != nil {
 		return dryRunErr
 	}
@@ -654,23 +656,24 @@ func (c *GmailDraftsCreateCmd) Run(ctx context.Context, flags *RootFlags) error 
 }
 
 type GmailDraftsUpdateCmd struct {
-	DraftID          string   `arg:"" name:"draftId" help:"Draft ID"`
-	To               *string  `name:"to" help:"Recipients (comma-separated; omit to keep existing)"`
-	Cc               string   `name:"cc" help:"CC recipients (comma-separated)"`
-	Bcc              string   `name:"bcc" help:"BCC recipients (comma-separated)"`
-	Subject          string   `name:"subject" help:"Subject (required)"`
-	Body             string   `name:"body" help:"Body (plain text; required unless --body-html is set)"`
-	BodyFile         string   `name:"body-file" help:"Body file path (plain text; '-' for stdin)"`
-	BodyHTML         string   `name:"body-html" help:"Body (HTML; optional)"`
-	BodyHTMLFile     string   `name:"body-html-file" help:"HTML body file path ('-' for stdin)"`
-	ReplyToMessageID string   `name:"reply-to-message-id" help:"Reply to Gmail message ID (sets In-Reply-To/References and thread)"`
-	ThreadID         string   `name:"thread-id" help:"Reply within a Gmail thread (uses latest message for headers); overrides the draft's existing thread"`
-	ReplyAll         bool     `name:"reply-all" help:"Auto-populate recipients from original message (requires --reply-to-message-id or --thread-id)"`
-	ReplyTo          string   `name:"reply-to" help:"Reply-To header address"`
-	Quote            bool     `name:"quote" help:"Include quoted original message in reply"`
-	Attach           []string `name:"attach" help:"Attachment file path (repeatable). Replaces existing attachments; omit to preserve them, or use --clear-attachments to remove all."`
-	ClearAttachments bool     `name:"clear-attachments" help:"Remove all attachments from the draft. By default, omitting --attach preserves the draft's existing attachments."`
-	From             string   `name:"from" help:"Send from this email address (must be a verified send-as alias)"`
+	DraftID                string   `arg:"" name:"draftId" help:"Draft ID"`
+	To                     *string  `name:"to" help:"Recipients (comma-separated; omit to keep existing)"`
+	Cc                     string   `name:"cc" help:"CC recipients (comma-separated)"`
+	Bcc                    string   `name:"bcc" help:"BCC recipients (comma-separated)"`
+	Subject                string   `name:"subject" help:"Subject (required)"`
+	Body                   string   `name:"body" help:"Body (plain text; required unless --body-html is set)"`
+	BodyFile               string   `name:"body-file" help:"Body file path (plain text; '-' for stdin)"`
+	BodyHTML               string   `name:"body-html" help:"Body (HTML; optional)"`
+	BodyHTMLFile           string   `name:"body-html-file" help:"HTML body file path ('-' for stdin)"`
+	ReplyToMessageID       string   `name:"reply-to-message-id" help:"Reply to Gmail message ID (sets In-Reply-To/References and thread)"`
+	ThreadID               string   `name:"thread-id" help:"Reply within a Gmail thread (uses latest message for headers); overrides the draft's existing thread"`
+	ReplyAll               bool     `name:"reply-all" help:"Auto-populate recipients from original message (requires --reply-to-message-id or --thread-id)"`
+	ReplyTo                string   `name:"reply-to" help:"Reply-To header address"`
+	Quote                  bool     `name:"quote" help:"Include quoted original message in reply"`
+	Attach                 []string `name:"attach" help:"Attachment file path (repeatable). Replaces existing attachments; omit to preserve them, or use --clear-attachments to remove all."`
+	ClearAttachments       bool     `name:"clear-attachments" help:"Remove all attachments from the draft. By default, omitting --attach preserves the draft's existing attachments."`
+	From                   string   `name:"from" help:"Send from this email address (must be a verified send-as alias)"`
+	AutoFromAddressedAlias bool     `name:"auto-from-addressed-alias" help:"When --from is omitted, reply from the verified send-as alias addressed by the original message"`
 }
 
 func (c *GmailDraftsUpdateCmd) Run(ctx context.Context, flags *RootFlags) error {
@@ -710,19 +713,20 @@ func (c *GmailDraftsUpdateCmd) Run(ctx context.Context, flags *RootFlags) error 
 	preserveAttachments := len(attachPaths) == 0 && !c.ClearAttachments
 
 	input := draftComposeInput{
-		To:               to,
-		Cc:               c.Cc,
-		Bcc:              c.Bcc,
-		Subject:          c.Subject,
-		Body:             body,
-		BodyHTML:         htmlBody,
-		ReplyToMessageID: replyToMessageID,
-		ReplyToThreadID:  threadID,
-		ReplyAll:         c.ReplyAll,
-		ReplyTo:          c.ReplyTo,
-		Quote:            c.Quote,
-		Attach:           attachPaths,
-		From:             c.From,
+		To:                     to,
+		Cc:                     c.Cc,
+		Bcc:                    c.Bcc,
+		Subject:                c.Subject,
+		Body:                   body,
+		BodyHTML:               htmlBody,
+		ReplyToMessageID:       replyToMessageID,
+		ReplyToThreadID:        threadID,
+		ReplyAll:               c.ReplyAll,
+		ReplyTo:                c.ReplyTo,
+		Quote:                  c.Quote,
+		Attach:                 attachPaths,
+		From:                   c.From,
+		AutoFromAddressedAlias: c.AutoFromAddressedAlias,
 	}
 	if validateErr := input.validate(); validateErr != nil {
 		return validateErr
@@ -732,23 +736,24 @@ func (c *GmailDraftsUpdateCmd) Run(ctx context.Context, flags *RootFlags) error 
 	}
 
 	if dryRunErr := dryRunExit(ctx, flags, "gmail.drafts.update", map[string]any{
-		"draft_id":             draftID,
-		"to_keep_existing":     !toWasSet && !input.ReplyAll,
-		"to":                   splitCSV(input.To),
-		"cc":                   splitCSV(input.Cc),
-		"bcc":                  splitCSV(input.Bcc),
-		"subject":              strings.TrimSpace(input.Subject),
-		"body_len":             len(input.Body),
-		"body_html_len":        len(input.BodyHTML),
-		"reply_to_message_id":  strings.TrimSpace(input.ReplyToMessageID),
-		"reply_all":            input.ReplyAll,
-		"reply_to":             strings.TrimSpace(input.ReplyTo),
-		"quote":                input.Quote,
-		"from":                 strings.TrimSpace(input.From),
-		"attachments":          attachPaths,
-		"clear_attachments":    c.ClearAttachments,
-		"preserve_attachments": preserveAttachments,
-		"thread_id":            strings.TrimSpace(threadID),
+		"draft_id":                  draftID,
+		"to_keep_existing":          !toWasSet && !input.ReplyAll,
+		"to":                        splitCSV(input.To),
+		"cc":                        splitCSV(input.Cc),
+		"bcc":                       splitCSV(input.Bcc),
+		"subject":                   strings.TrimSpace(input.Subject),
+		"body_len":                  len(input.Body),
+		"body_html_len":             len(input.BodyHTML),
+		"reply_to_message_id":       strings.TrimSpace(input.ReplyToMessageID),
+		"reply_all":                 input.ReplyAll,
+		"reply_to":                  strings.TrimSpace(input.ReplyTo),
+		"quote":                     input.Quote,
+		"from":                      strings.TrimSpace(input.From),
+		"auto_from_addressed_alias": input.AutoFromAddressedAlias,
+		"attachments":               attachPaths,
+		"clear_attachments":         c.ClearAttachments,
+		"preserve_attachments":      preserveAttachments,
+		"thread_id":                 strings.TrimSpace(threadID),
 	}); dryRunErr != nil {
 		return dryRunErr
 	}

--- a/internal/cmd/gmail_drafts_cmd_test.go
+++ b/internal/cmd/gmail_drafts_cmd_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"io"
@@ -1485,6 +1486,62 @@ func TestGmailDraftsCreateCmd_ReplyAllWithReplyToMessageID(t *testing.T) {
 		if strings.Contains(s, excluded) {
 			t.Fatalf("reply-all draft included self address %q:\n%s", excluded, s)
 		}
+	}
+}
+
+func TestBuildDraftMessageAutoSelectsFromAddressedAliasOnlyWhenRequested(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/gmail/v1/users/me/settings/sendAs" && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"sendAs": []map[string]any{
+					{"sendAsEmail": "me@example.com", "displayName": "Me Person", "isPrimary": true, "verificationStatus": "accepted"},
+					{"sendAsEmail": "alias@example.com", "displayName": "Alias", "verificationStatus": "accepted"},
+				},
+			})
+		case r.URL.Path == "/gmail/v1/users/me/messages/m1" && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id": "m1", "threadId": "t1",
+				"payload": map[string]any{"headers": []map[string]any{
+					{"name": "Message-ID", "value": "<m1@example.com>"},
+					{"name": "From", "value": "sender@example.com"},
+					{"name": "To", "value": "alias@example.com"},
+					{"name": "Subject", "value": "Original"},
+				}},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	svc := newGmailServiceFromServer(t, srv)
+	for _, tc := range []struct {
+		name       string
+		autoSelect bool
+		wantFrom   string
+	}{
+		{name: "default", wantFrom: "me@example.com"},
+		{name: "opt in", autoSelect: true, wantFrom: "alias@example.com"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			msg, _, _, err := buildDraftMessage(context.Background(), svc, "me@example.com", draftComposeInput{
+				Body:                   "Thanks",
+				ReplyToMessageID:       "m1",
+				AutoFromAddressedAlias: tc.autoSelect,
+			})
+			if err != nil {
+				t.Fatalf("buildDraftMessage: %v", err)
+			}
+			raw, err := base64.RawURLEncoding.DecodeString(msg.Raw)
+			if err != nil {
+				t.Fatalf("decode raw: %v", err)
+			}
+			if !strings.Contains(string(raw), tc.wantFrom) {
+				t.Fatalf("message missing From %q:\n%s", tc.wantFrom, raw)
+			}
+		})
 	}
 }
 

--- a/internal/cmd/gmail_from_autoselect_test.go
+++ b/internal/cmd/gmail_from_autoselect_test.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	"testing"
+
+	"google.golang.org/api/gmail/v1"
+)
+
+func verifiedSendAs(email string) *gmail.SendAs {
+	return &gmail.SendAs{SendAsEmail: email, VerificationStatus: gmailVerificationAccepted}
+}
+
+func TestPickSendAsFromRecipients(t *testing.T) {
+	sendAs := []*gmail.SendAs{
+		verifiedSendAs("mail@kamuko.de"),
+		verifiedSendAs("sales@kamuko.de"),
+		{SendAsEmail: "pending@kamuko.de", VerificationStatus: "pending"},
+	}
+
+	cases := []struct {
+		name string
+		to   []string
+		cc   []string
+		want string
+	}{
+		{"to match wins", []string{"sales@kamuko.de"}, nil, "sales@kamuko.de"},
+		{"cc used when to has no alias", []string{"someone@else.com"}, []string{"mail@kamuko.de"}, "mail@kamuko.de"},
+		{"to beats cc", []string{"sales@kamuko.de"}, []string{"mail@kamuko.de"}, "sales@kamuko.de"},
+		{"first to match wins", []string{"someone@else.com", "mail@kamuko.de", "sales@kamuko.de"}, nil, "mail@kamuko.de"},
+		{"case-insensitive", []string{"Sales@Kamuko.de"}, nil, "sales@kamuko.de"},
+		{"no match falls back to empty", []string{"someone@else.com"}, []string{"other@else.com"}, ""},
+		{"unverified alias is skipped", []string{"pending@kamuko.de"}, nil, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := pickSendAsFromRecipients(tc.to, tc.cc, sendAs); got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/cmd/gmail_reply_commands.go
+++ b/internal/cmd/gmail_reply_commands.go
@@ -116,6 +116,21 @@ func (c *GmailReplyOptions) run(ctx context.Context, flags *RootFlags, messageID
 	if err != nil {
 		return err
 	}
+	info, err := fetchReplyInfo(ctx, svc, messageID, "", !c.NoQuote)
+	if err != nil {
+		return err
+	}
+	// Reply as the alias the original was addressed to, unless --from was explicit. The
+	// alias comes from the verified send-as list, so it can't be a bad From; a lookup
+	// error leaves the account default in place. Done before signature resolution so the
+	// signature matches the identity actually sending.
+	if strings.TrimSpace(c.From) == "" && sendAsErr == nil {
+		if alias := pickSendAsFromRecipients(info.ToAddrs, info.CcAddrs, sendAs); alias != "" {
+			if picked, pickErr := resolveComposeFrom(ctx, svc, account, alias, sendAs, sendAsErr); pickErr == nil {
+				from = picked
+			}
+		}
+	}
 	if signatureCmd.signatureRequested() {
 		signature, source, sigErr := signatureCmd.resolveComposeSignature(ctx, svc, from.sendingEmail)
 		if sigErr != nil {
@@ -127,20 +142,9 @@ func (c *GmailReplyOptions) run(ctx context.Context, flags *RootFlags, messageID
 			body, htmlBody = appendComposeSignature(body, htmlBody, signature)
 		}
 	}
-
-	info, body, htmlBody, err := prepareComposeReply(ctx, svc, messageID, "", !c.NoQuote, body, htmlBody)
+	body, htmlBody, err = applyReplyQuote(ctx, !c.NoQuote, info, body, htmlBody)
 	if err != nil {
 		return err
-	}
-	// Reply as the alias the original was addressed to, unless --from was explicit. The
-	// alias comes from the verified send-as list, so it can't be a bad From; a lookup
-	// error leaves the account default in place.
-	if strings.TrimSpace(c.From) == "" && sendAsErr == nil {
-		if alias := pickSendAsFromRecipients(info.ToAddrs, info.CcAddrs, sendAs); alias != "" {
-			if picked, pickErr := resolveComposeFrom(ctx, svc, account, alias, sendAs, sendAsErr); pickErr == nil {
-				from = picked
-			}
-		}
 	}
 	recipients, err := buildReplyRecipients(
 		info,

--- a/internal/cmd/gmail_reply_commands.go
+++ b/internal/cmd/gmail_reply_commands.go
@@ -132,6 +132,16 @@ func (c *GmailReplyOptions) run(ctx context.Context, flags *RootFlags, messageID
 	if err != nil {
 		return err
 	}
+	// Reply as the alias the original was addressed to, unless --from was explicit. The
+	// alias comes from the verified send-as list, so it can't be a bad From; a lookup
+	// error leaves the account default in place.
+	if strings.TrimSpace(c.From) == "" && sendAsErr == nil {
+		if alias := pickSendAsFromRecipients(info.ToAddrs, info.CcAddrs, sendAs); alias != "" {
+			if picked, pickErr := resolveComposeFrom(ctx, svc, account, alias, sendAs, sendAsErr); pickErr == nil {
+				from = picked
+			}
+		}
+	}
 	recipients, err := buildReplyRecipients(
 		info,
 		selfEmailsForReply(account, from.sendingEmail, sendAs),

--- a/internal/cmd/gmail_reply_commands.go
+++ b/internal/cmd/gmail_reply_commands.go
@@ -21,21 +21,22 @@ type GmailReplyAllCmd struct {
 }
 
 type GmailReplyOptions struct {
-	To            []string `name:"to" sep:"none" help:"Add or move recipients to To (repeatable)"`
-	Cc            []string `name:"cc" sep:"none" help:"Add or move recipients to Cc (repeatable)"`
-	Bcc           []string `name:"bcc" sep:"none" help:"Add or move recipients to Bcc (repeatable)"`
-	Remove        []string `name:"remove" sep:"none" help:"Remove recipients from all fields (repeatable)"`
-	Subject       string   `name:"subject" help:"Override reply subject (a changed subject starts a new Gmail thread)"`
-	Body          string   `name:"body" help:"Body (plain text; required unless --body-html is set)"`
-	BodyFile      string   `name:"body-file" help:"Body file path (plain text; '-' for stdin)"`
-	BodyHTML      string   `name:"body-html" help:"Body (HTML; optional)"`
-	BodyHTMLFile  string   `name:"body-html-file" help:"HTML body file path ('-' for stdin)"`
-	NoQuote       bool     `name:"no-quote" help:"Do not include the original message below the reply"`
-	Attach        []string `name:"attach" sep:"none" help:"Attachment file path (repeatable)"`
-	From          string   `name:"from" help:"Send from this email address (must be a verified send-as alias)"`
-	Signature     bool     `name:"signature" help:"Append the Gmail signature from the active send-as address"`
-	SignatureFrom string   `name:"signature-from" help:"Append the Gmail signature from this send-as email address"`
-	SignatureFile string   `name:"signature-file" help:"Append a local signature file (plain text or HTML)"`
+	To                     []string `name:"to" sep:"none" help:"Add or move recipients to To (repeatable)"`
+	Cc                     []string `name:"cc" sep:"none" help:"Add or move recipients to Cc (repeatable)"`
+	Bcc                    []string `name:"bcc" sep:"none" help:"Add or move recipients to Bcc (repeatable)"`
+	Remove                 []string `name:"remove" sep:"none" help:"Remove recipients from all fields (repeatable)"`
+	Subject                string   `name:"subject" help:"Override reply subject (a changed subject starts a new Gmail thread)"`
+	Body                   string   `name:"body" help:"Body (plain text; required unless --body-html is set)"`
+	BodyFile               string   `name:"body-file" help:"Body file path (plain text; '-' for stdin)"`
+	BodyHTML               string   `name:"body-html" help:"Body (HTML; optional)"`
+	BodyHTMLFile           string   `name:"body-html-file" help:"HTML body file path ('-' for stdin)"`
+	NoQuote                bool     `name:"no-quote" help:"Do not include the original message below the reply"`
+	Attach                 []string `name:"attach" sep:"none" help:"Attachment file path (repeatable)"`
+	From                   string   `name:"from" help:"Send from this email address (must be a verified send-as alias)"`
+	AutoFromAddressedAlias bool     `name:"auto-from-addressed-alias" help:"When --from is omitted, reply from the verified send-as alias addressed by the original message"`
+	Signature              bool     `name:"signature" help:"Append the Gmail signature from the active send-as address"`
+	SignatureFrom          string   `name:"signature-from" help:"Append the Gmail signature from this send-as email address"`
+	SignatureFile          string   `name:"signature-file" help:"Append a local signature file (plain text or HTML)"`
 }
 
 func (c *GmailReplyCmd) Run(ctx context.Context, flags *RootFlags) error {
@@ -88,20 +89,21 @@ func (c *GmailReplyOptions) run(ctx context.Context, flags *RootFlags, messageID
 	}
 
 	if dryRunErr := dryRunExit(ctx, flags, "gmail."+replyModeName(replyAll), map[string]any{
-		"message_id":       messageID,
-		"to_add":           c.To,
-		"cc_add":           c.Cc,
-		"bcc_add":          c.Bcc,
-		"remove":           c.Remove,
-		"subject_override": strings.TrimSpace(c.Subject),
-		"quote":            !c.NoQuote,
-		"from":             strings.TrimSpace(c.From),
-		"body_len":         len(body),
-		"body_html_len":    len(htmlBody),
-		"attachments":      attachPaths,
-		"signature":        c.Signature,
-		"signature_from":   strings.TrimSpace(c.SignatureFrom),
-		"signature_file":   strings.TrimSpace(c.SignatureFile),
+		"message_id":                messageID,
+		"to_add":                    c.To,
+		"cc_add":                    c.Cc,
+		"bcc_add":                   c.Bcc,
+		"remove":                    c.Remove,
+		"subject_override":          strings.TrimSpace(c.Subject),
+		"quote":                     !c.NoQuote,
+		"from":                      strings.TrimSpace(c.From),
+		"auto_from_addressed_alias": c.AutoFromAddressedAlias,
+		"body_len":                  len(body),
+		"body_html_len":             len(htmlBody),
+		"attachments":               attachPaths,
+		"signature":                 c.Signature,
+		"signature_from":            strings.TrimSpace(c.SignatureFrom),
+		"signature_file":            strings.TrimSpace(c.SignatureFile),
 	}); dryRunErr != nil {
 		return dryRunErr
 	}
@@ -120,11 +122,9 @@ func (c *GmailReplyOptions) run(ctx context.Context, flags *RootFlags, messageID
 	if err != nil {
 		return err
 	}
-	// Reply as the alias the original was addressed to, unless --from was explicit. The
-	// alias comes from the verified send-as list, so it can't be a bad From; a lookup
-	// error leaves the account default in place. Done before signature resolution so the
-	// signature matches the identity actually sending.
-	if strings.TrimSpace(c.From) == "" && sendAsErr == nil {
+	// When requested, reply as the verified alias the original was addressed to. Do this
+	// before signature resolution so the signature matches the identity actually sending.
+	if c.AutoFromAddressedAlias && strings.TrimSpace(c.From) == "" && sendAsErr == nil {
 		if alias := pickSendAsFromRecipients(info.ToAddrs, info.CcAddrs, sendAs); alias != "" {
 			if picked, pickErr := resolveComposeFrom(ctx, svc, account, alias, sendAs, sendAsErr); pickErr == nil {
 				from = picked

--- a/internal/cmd/gmail_reply_commands_test.go
+++ b/internal/cmd/gmail_reply_commands_test.go
@@ -235,7 +235,7 @@ func TestExecuteGmailReplyAllDefaultsAndInlineImages(t *testing.T) {
 }
 
 func TestExecuteGmailReplyAutoSelectsFromAddressedAlias(t *testing.T) {
-	sendReply := func(t *testing.T, originalTo string, extraArgs ...string) string {
+	sendReply := func(t *testing.T, originalTo string, autoSelect bool, extraArgs ...string) string {
 		t.Helper()
 		var sentRaw string
 		svc, cleanup := newGmailServiceForTest(t, func(w http.ResponseWriter, r *http.Request) {
@@ -269,7 +269,11 @@ func TestExecuteGmailReplyAutoSelectsFromAddressedAlias(t *testing.T) {
 		})
 		defer cleanup()
 
-		args := append([]string{"--json", "--account", "me@example.com", "gmail", "reply", "msg-1", "--body", "ok", "--no-quote"}, extraArgs...)
+		args := []string{"--json", "--account", "me@example.com", "gmail", "reply", "msg-1", "--body", "ok", "--no-quote"}
+		if autoSelect {
+			args = append(args, "--auto-from-addressed-alias")
+		}
+		args = append(args, extraArgs...)
 		result := executeWithGmailTestService(t, args, svc)
 		if result.err != nil {
 			t.Fatalf("Execute: %v", result.err)
@@ -287,18 +291,23 @@ func TestExecuteGmailReplyAutoSelectsFromAddressedAlias(t *testing.T) {
 	}
 
 	t.Run("addressed to alias uses it as From", func(t *testing.T) {
-		if from := fromAddr(sendReply(t, "alias@example.com")); !strings.Contains(from, "alias@example.com") {
+		if from := fromAddr(sendReply(t, "alias@example.com", true)); !strings.Contains(from, "alias@example.com") {
 			t.Fatalf("From is not the addressed alias: %q", from)
 		}
 	})
 	t.Run("no alias match falls back to account default", func(t *testing.T) {
-		if from := fromAddr(sendReply(t, "someone@else.com")); !strings.Contains(from, "me@example.com") {
+		if from := fromAddr(sendReply(t, "someone@else.com", true)); !strings.Contains(from, "me@example.com") {
 			t.Fatalf("From is not the account default: %q", from)
 		}
 	})
 	t.Run("explicit --from overrides auto-select", func(t *testing.T) {
-		if from := fromAddr(sendReply(t, "alias@example.com", "--from", "me@example.com")); !strings.Contains(from, "me@example.com") {
+		if from := fromAddr(sendReply(t, "alias@example.com", true, "--from", "me@example.com")); !strings.Contains(from, "me@example.com") {
 			t.Fatalf("explicit --from not honored: %q", from)
+		}
+	})
+	t.Run("omitted flag keeps account default", func(t *testing.T) {
+		if from := fromAddr(sendReply(t, "alias@example.com", false)); !strings.Contains(from, "me@example.com") {
+			t.Fatalf("From is not the account default: %q", from)
 		}
 	})
 }
@@ -343,7 +352,7 @@ func TestExecuteGmailReplySignatureFollowsAutoSelectedAlias(t *testing.T) {
 	defer cleanup()
 
 	result := executeWithGmailTestService(t, []string{
-		"--json", "--account", "me@example.com", "gmail", "reply", "msg-1", "--body", "ok", "--no-quote", "--signature",
+		"--json", "--account", "me@example.com", "gmail", "reply", "msg-1", "--body", "ok", "--no-quote", "--signature", "--auto-from-addressed-alias",
 	}, svc)
 	if result.err != nil {
 		t.Fatalf("Execute: %v", result.err)

--- a/internal/cmd/gmail_reply_commands_test.go
+++ b/internal/cmd/gmail_reply_commands_test.go
@@ -234,6 +234,75 @@ func TestExecuteGmailReplyAllDefaultsAndInlineImages(t *testing.T) {
 	}
 }
 
+func TestExecuteGmailReplyAutoSelectsFromAddressedAlias(t *testing.T) {
+	sendReply := func(t *testing.T, originalTo string, extraArgs ...string) string {
+		t.Helper()
+		var sentRaw string
+		svc, cleanup := newGmailServiceForTest(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			switch {
+			case r.Method == http.MethodGet && r.URL.Path == "/gmail/v1/users/me/settings/sendAs":
+				_ = json.NewEncoder(w).Encode(map[string]any{"sendAs": []map[string]any{
+					{"sendAsEmail": "me@example.com", "displayName": "Me Person", "isPrimary": true, "verificationStatus": "accepted"},
+					{"sendAsEmail": "alias@example.com", "displayName": "Alias", "verificationStatus": "accepted"},
+				}})
+			case r.Method == http.MethodGet && r.URL.Path == "/gmail/v1/users/me/messages/msg-1":
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"id": "msg-1", "threadId": "thread-1",
+					"payload": map[string]any{"headers": []map[string]any{
+						{"name": "Message-ID", "value": "<original@example.com>"},
+						{"name": "From", "value": "alice@example.com"},
+						{"name": "To", "value": originalTo},
+						{"name": "Subject", "value": "Hi"},
+					}},
+				})
+			case r.Method == http.MethodPost && r.URL.Path == "/gmail/v1/users/me/messages/send":
+				body, _ := io.ReadAll(r.Body)
+				var msg gmail.Message
+				_ = json.Unmarshal(body, &msg)
+				raw, _ := base64.RawURLEncoding.DecodeString(msg.Raw)
+				sentRaw = string(raw)
+				_ = json.NewEncoder(w).Encode(map[string]any{"id": "sent-1", "threadId": "thread-1"})
+			default:
+				http.NotFound(w, r)
+			}
+		})
+		defer cleanup()
+
+		args := append([]string{"--json", "--account", "me@example.com", "gmail", "reply", "msg-1", "--body", "ok", "--no-quote"}, extraArgs...)
+		result := executeWithGmailTestService(t, args, svc)
+		if result.err != nil {
+			t.Fatalf("Execute: %v", result.err)
+		}
+		return sentRaw
+	}
+
+	fromAddr := func(raw string) string {
+		for _, line := range strings.Split(raw, "\n") {
+			if strings.HasPrefix(line, "From:") {
+				return line
+			}
+		}
+		return ""
+	}
+
+	t.Run("addressed to alias uses it as From", func(t *testing.T) {
+		if from := fromAddr(sendReply(t, "alias@example.com")); !strings.Contains(from, "alias@example.com") {
+			t.Fatalf("From is not the addressed alias: %q", from)
+		}
+	})
+	t.Run("no alias match falls back to account default", func(t *testing.T) {
+		if from := fromAddr(sendReply(t, "someone@else.com")); !strings.Contains(from, "me@example.com") {
+			t.Fatalf("From is not the account default: %q", from)
+		}
+	})
+	t.Run("explicit --from overrides auto-select", func(t *testing.T) {
+		if from := fromAddr(sendReply(t, "alias@example.com", "--from", "me@example.com")); !strings.Contains(from, "me@example.com") {
+			t.Fatalf("explicit --from not honored: %q", from)
+		}
+	})
+}
+
 func TestExecuteGmailReplyEditedSubjectStartsNewThread(t *testing.T) {
 	var sentThreadID string
 	svc, cleanup := newGmailServiceForTest(t, func(w http.ResponseWriter, r *http.Request) {

--- a/internal/cmd/gmail_reply_commands_test.go
+++ b/internal/cmd/gmail_reply_commands_test.go
@@ -303,6 +303,59 @@ func TestExecuteGmailReplyAutoSelectsFromAddressedAlias(t *testing.T) {
 	})
 }
 
+// TestExecuteGmailReplySignatureFollowsAutoSelectedAlias proves the signature is
+// resolved for the auto-selected alias, not the account default: the alias must be
+// chosen before the signature is fetched.
+func TestExecuteGmailReplySignatureFollowsAutoSelectedAlias(t *testing.T) {
+	var sigEmail, sentRaw string
+	svc, cleanup := newGmailServiceForTest(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/gmail/v1/users/me/settings/sendAs":
+			_ = json.NewEncoder(w).Encode(map[string]any{"sendAs": []map[string]any{
+				{"sendAsEmail": "me@example.com", "displayName": "Me Person", "isPrimary": true, "verificationStatus": "accepted"},
+				{"sendAsEmail": "alias@example.com", "displayName": "Alias", "verificationStatus": "accepted"},
+			}})
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/gmail/v1/users/me/settings/sendAs/"):
+			sigEmail = strings.TrimPrefix(r.URL.Path, "/gmail/v1/users/me/settings/sendAs/")
+			_ = json.NewEncoder(w).Encode(map[string]any{"sendAsEmail": sigEmail, "signature": "<div>sig for " + sigEmail + "</div>"})
+		case r.Method == http.MethodGet && r.URL.Path == "/gmail/v1/users/me/messages/msg-1":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id": "msg-1", "threadId": "thread-1",
+				"payload": map[string]any{"headers": []map[string]any{
+					{"name": "Message-ID", "value": "<original@example.com>"},
+					{"name": "From", "value": "alice@example.com"},
+					{"name": "To", "value": "alias@example.com"},
+					{"name": "Subject", "value": "Hi"},
+				}},
+			})
+		case r.Method == http.MethodPost && r.URL.Path == "/gmail/v1/users/me/messages/send":
+			body, _ := io.ReadAll(r.Body)
+			var msg gmail.Message
+			_ = json.Unmarshal(body, &msg)
+			raw, _ := base64.RawURLEncoding.DecodeString(msg.Raw)
+			sentRaw = string(raw)
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": "sent-1", "threadId": "thread-1"})
+		default:
+			http.NotFound(w, r)
+		}
+	})
+	defer cleanup()
+
+	result := executeWithGmailTestService(t, []string{
+		"--json", "--account", "me@example.com", "gmail", "reply", "msg-1", "--body", "ok", "--no-quote", "--signature",
+	}, svc)
+	if result.err != nil {
+		t.Fatalf("Execute: %v", result.err)
+	}
+	if sigEmail != "alias@example.com" {
+		t.Fatalf("signature fetched for %q, want alias@example.com", sigEmail)
+	}
+	if !strings.Contains(sentRaw, "sig for alias@example.com") {
+		t.Fatalf("sent body missing alias signature:\n%s", sentRaw)
+	}
+}
+
 func TestExecuteGmailReplyEditedSubjectStartsNewThread(t *testing.T) {
 	var sentThreadID string
 	svc, cleanup := newGmailServiceForTest(t, func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

When replying without an explicit `--from`, this selects the send-as alias the original message was addressed to as the reply's From identity, instead of always sending from the account default.

Precedence:

1. explicit `--from` (unchanged — always wins)
2. the send-as alias the original was addressed to (To before Cc, first verified match)
3. the account default (unchanged fallback)

Only verified send-as aliases are eligible, and the alias is resolved through the existing `resolveComposeFrom` path, so it can never produce an invalid From. If the send-as lookup fails, the account default stays in place.

Applies to both `gmail reply` / `gmail reply-all` and reply drafts.

## Motivation

On an account with multiple verified send-as aliases, a reply currently always goes out as the account default — even when the original was addressed to a specific alias. Someone who writes to `alias@example.com` then gets a reply from `primary@example.com`. This keeps the reply on the identity the sender actually wrote to, which is what most people expect a "reply" to do.

## Note on default behavior

This changes default reply behavior (no new flag required to trigger it). I think matching the addressed alias is the least-surprising default, but if you'd rather gate it behind an opt-in flag or a config setting, I'm happy to adjust — flagging it here since it's a behavior change rather than a purely additive one.

## Testing

- Unit test for the picker (`pickSendAsFromRecipients`): To-wins, Cc-used, To-beats-Cc, first-match, case-insensitive match, no-match → empty, unverified alias skipped.
- End-to-end reply test: addressed-to-alias → alias used as From; no matching alias → account default; explicit `--from` → override honored.
- `go test ./internal/cmd/`, `make lint` — 0 issues.
