### PR TITLE
chore(release): prepare v0.34.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.34.2 - 2026-07-27
+## 0.34.2 - 2026-08-02
 
 - Dependencies: refresh the Google API, gRPC, Markdown, terminal, and email-tracking worker toolchains to their latest compatible releases.
 - Gmail: add opt-in reply From alias selection for the verified send-as alias addressed by the original message. (#948) — thanks @ronny-rentner.


### PR DESCRIPTION
Reconcile the single unpublished 0.34.2 changelog section onto the actual release date, preserving all previously landed entries and the already-correct `v0.34.2` version file.

Proof:
- unique 0.34.2 heading and exact `internal/cmd/VERSION` checks pass
- full `make ci` passes
- `scripts/release-local --check` passes GoReleaser config, signing/notarization, release assets, local release gates, and next-release closeout tests
- built CLI runs at exact review head
- branch autoreview is clean
