### PR TITLE
feat(gmail): warn when drafts update downgrades a rich-text draft to plain-only

### DIFF
--- a/internal/cmd/gmail_drafts.go
+++ b/internal/cmd/gmail_drafts.go
@@ -872,18 +872,24 @@ func (c *GmailDraftsUpdateCmd) Run(ctx context.Context, flags *RootFlags) error 
 	existingInReplyTo := ""
 	existingReferences := ""
 	var existingPayload *gmail.MessagePart
+	// Recipients, reply lineage and attachment carry-forward are built from the
+	// stored draft, so those updates cannot proceed without it.
+	requireExistingDraft := (!toWasSet && !c.ReplyAll) || strings.TrimSpace(replyToMessageID) == "" || preserveAttachments
 	// An update carrying no HTML body can silently drop the draft's stored one,
 	// so the warning below needs the existing payload. Without this the fetch is
 	// skipped whenever --to, --reply-to-message-id and --attach are all supplied,
 	// and that path would downgrade a rich-text draft unwarned. --quote is exempt
 	// because quoting regenerates an HTML part.
 	inspectForHTMLDowngrade := strings.TrimSpace(htmlBody) == "" && !c.Quote
-	if (!toWasSet && !c.ReplyAll) || strings.TrimSpace(replyToMessageID) == "" || preserveAttachments || inspectForHTMLDowngrade {
+	if requireExistingDraft || inspectForHTMLDowngrade {
 		existing, fetchErr := svc.Users.Drafts.Get("me", draftID).Format("full").Do()
-		if fetchErr != nil {
+		// This read is advisory whenever nothing but the warning wants it: a
+		// failed inspection costs the warning, never the update the caller asked
+		// for. Only a read the rebuilt message actually depends on is fatal.
+		if fetchErr != nil && requireExistingDraft {
 			return fetchErr
 		}
-		if existing != nil && existing.Message != nil {
+		if fetchErr == nil && existing != nil && existing.Message != nil {
 			existingThreadID = strings.TrimSpace(existing.Message.ThreadId)
 			existingMessageID = strings.TrimSpace(existing.Message.Id)
 			existingPayload = existing.Message.Payload

--- a/internal/cmd/gmail_drafts.go
+++ b/internal/cmd/gmail_drafts.go
@@ -872,7 +872,13 @@ func (c *GmailDraftsUpdateCmd) Run(ctx context.Context, flags *RootFlags) error 
 	existingInReplyTo := ""
 	existingReferences := ""
 	var existingPayload *gmail.MessagePart
-	if (!toWasSet && !c.ReplyAll) || strings.TrimSpace(replyToMessageID) == "" || preserveAttachments {
+	// An update carrying no HTML body can silently drop the draft's stored one,
+	// so the warning below needs the existing payload. Without this the fetch is
+	// skipped whenever --to, --reply-to-message-id and --attach are all supplied,
+	// and that path would downgrade a rich-text draft unwarned. --quote is exempt
+	// because quoting regenerates an HTML part.
+	inspectForHTMLDowngrade := strings.TrimSpace(htmlBody) == "" && !c.Quote
+	if (!toWasSet && !c.ReplyAll) || strings.TrimSpace(replyToMessageID) == "" || preserveAttachments || inspectForHTMLDowngrade {
 		existing, fetchErr := svc.Users.Drafts.Get("me", draftID).Format("full").Do()
 		if fetchErr != nil {
 			return fetchErr
@@ -894,9 +900,8 @@ func (c *GmailDraftsUpdateCmd) Run(ctx context.Context, flags *RootFlags) error 
 
 	// gmail drafts update rebuilds the whole message, so updating a rich-text
 	// draft with only a plain body silently drops its text/html part — Gmail
-	// then renders the stored hard-wrapped plain text literally. Warn on
-	// stderr; --quote is exempt because quoting regenerates an HTML part.
-	if strings.TrimSpace(htmlBody) == "" && !c.Quote && draftHasHTMLBodyPart(existingPayload) {
+	// then renders the stored hard-wrapped plain text literally. Warn on stderr.
+	if inspectForHTMLDowngrade && draftHasHTMLBodyPart(existingPayload) {
 		u.Err().Println("Warning: draft has an HTML body; this update replaces it with plain text only. Pass --body-html/--body-html-file to keep rich-text formatting.")
 	}
 

--- a/internal/cmd/gmail_drafts.go
+++ b/internal/cmd/gmail_drafts.go
@@ -424,6 +424,24 @@ func buildDraftMessage(ctx context.Context, svc *gmail.Service, account string, 
 	return msg, threading, attachmentMetadata, nil
 }
 
+// draftHasHTMLBodyPart reports whether a draft message's stored payload carries
+// a text/html body part (a rich-text draft). Attachment parts (non-empty
+// filename) don't count, so an attached .html file is not a rich body.
+func draftHasHTMLBodyPart(payload *gmail.MessagePart) bool {
+	if payload == nil {
+		return false
+	}
+	if strings.EqualFold(payload.MimeType, "text/html") && payload.Filename == "" {
+		return true
+	}
+	for _, part := range payload.Parts {
+		if draftHasHTMLBodyPart(part) {
+			return true
+		}
+	}
+	return false
+}
+
 // carryForwardDraftAttachments fetches the bytes of an existing draft message's
 // attachments so they can be re-attached to a rebuilt draft on update. Returns
 // nil when the draft has no attachments. Mirrors the gmail forward reattach path.
@@ -872,6 +890,14 @@ func (c *GmailDraftsUpdateCmd) Run(ctx context.Context, flags *RootFlags) error 
 	}
 	if !toWasSet && !c.ReplyAll {
 		to = existingTo
+	}
+
+	// gmail drafts update rebuilds the whole message, so updating a rich-text
+	// draft with only a plain body silently drops its text/html part — Gmail
+	// then renders the stored hard-wrapped plain text literally. Warn on
+	// stderr; --quote is exempt because quoting regenerates an HTML part.
+	if strings.TrimSpace(htmlBody) == "" && !c.Quote && draftHasHTMLBodyPart(existingPayload) {
+		u.Err().Println("Warning: draft has an HTML body; this update replaces it with plain text only. Pass --body-html/--body-html-file to keep rich-text formatting.")
 	}
 
 	// The thread the draft already lives in. Used for --quote target discovery

--- a/internal/cmd/gmail_drafts_cmd_test.go
+++ b/internal/cmd/gmail_drafts_cmd_test.go
@@ -1002,6 +1002,87 @@ func TestGmailDraftsUpdateCmd_PreservesToWhenNotProvided(t *testing.T) {
 	}
 }
 
+func newRichDraftUpdateServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/gmail/v1/users/me/drafts/d1") && r.Method == http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id": "d1",
+				"message": map[string]any{
+					"id":       "m1",
+					"threadId": "t1",
+					"payload": map[string]any{
+						"mimeType": "multipart/alternative",
+						"headers": []map[string]any{
+							{"name": "To", "value": "keep@example.com"},
+						},
+						"parts": []map[string]any{
+							{"mimeType": "text/plain", "body": map[string]any{"size": 10}},
+							{"mimeType": "text/html", "body": map[string]any{"size": 20}},
+						},
+					},
+				},
+			})
+			return
+		case strings.Contains(r.URL.Path, "/gmail/v1/users/me/drafts/d1") && r.Method == http.MethodPut:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":      "d1",
+				"message": map[string]any{"id": "m2", "threadId": "t1"},
+			})
+			return
+		default:
+			http.NotFound(w, r)
+			return
+		}
+	}))
+}
+
+func TestGmailDraftsUpdateCmd_WarnsWhenPlainBodyReplacesHTMLDraft(t *testing.T) {
+	srv := newRichDraftUpdateServer(t)
+	defer srv.Close()
+
+	svc := newGmailServiceFromServer(t, srv)
+	flags := &RootFlags{Account: "a@b.com"}
+
+	var stderr bytes.Buffer
+	ctx := withGmailTestService(newCmdRuntimeJSONOutputContext(t, io.Discard, &stderr), svc)
+	if err := runKong(t, &GmailDraftsUpdateCmd{}, []string{
+		"d1",
+		"--subject", "Updated",
+		"--body", "Hello",
+	}, ctx, flags); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !strings.Contains(stderr.String(), "replaces it with plain text only") {
+		t.Fatalf("expected plain-text downgrade warning on stderr, got:\n%s", stderr.String())
+	}
+}
+
+func TestGmailDraftsUpdateCmd_NoWarnWhenHTMLBodyProvided(t *testing.T) {
+	srv := newRichDraftUpdateServer(t)
+	defer srv.Close()
+
+	svc := newGmailServiceFromServer(t, srv)
+	flags := &RootFlags{Account: "a@b.com"}
+
+	var stderr bytes.Buffer
+	ctx := withGmailTestService(newCmdRuntimeJSONOutputContext(t, io.Discard, &stderr), svc)
+	if err := runKong(t, &GmailDraftsUpdateCmd{}, []string{
+		"d1",
+		"--subject", "Updated",
+		"--body", "Hello",
+		"--body-html", "<p>Hello</p>",
+	}, ctx, flags); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if strings.Contains(stderr.String(), "plain text only") {
+		t.Fatalf("unexpected downgrade warning with --body-html, got:\n%s", stderr.String())
+	}
+}
+
 func TestGmailDraftsUpdateCmd_WithQuoteFromExistingThread(t *testing.T) {
 	t.Setenv("GOG_TIMEZONE", "UTC")
 	originalPlain := "Original thread message"

--- a/internal/cmd/gmail_drafts_cmd_test.go
+++ b/internal/cmd/gmail_drafts_cmd_test.go
@@ -1159,6 +1159,120 @@ func TestGmailDraftsUpdateCmd_WarnsWhenAllFieldsUpdateSkipsFetchGuard(t *testing
 	}
 }
 
+// When --to, --reply-to-message-id and --attach are all supplied the existing
+// draft is read only to decide whether to warn. That read is advisory, so a
+// failure must not abort the update the caller asked for.
+func TestGmailDraftsUpdateCmd_AdvisoryFetchFailureStillUpdates(t *testing.T) {
+	var draftGets, draftPuts int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/gmail/v1/users/me/drafts/d1") && r.Method == http.MethodGet:
+			draftGets++
+			http.Error(w, "transient draft read failure", http.StatusServiceUnavailable)
+			return
+		case strings.Contains(r.URL.Path, "/gmail/v1/users/me/messages/m9") && r.Method == http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":       "m9",
+				"threadId": "t1",
+				"payload": map[string]any{
+					"headers": []map[string]any{
+						{"name": "Message-ID", "value": "<m9@example.com>"},
+						{"name": "From", "value": "orig@example.com"},
+						{"name": "Subject", "value": "Original"},
+					},
+				},
+			})
+			return
+		case strings.Contains(r.URL.Path, "/gmail/v1/users/me/drafts/d1") && r.Method == http.MethodPut:
+			draftPuts++
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":      "d1",
+				"message": map[string]any{"id": "m2", "threadId": "t1"},
+			})
+			return
+		default:
+			http.NotFound(w, r)
+			return
+		}
+	}))
+	defer srv.Close()
+
+	attachment := filepath.Join(t.TempDir(), "note.txt")
+	if err := os.WriteFile(attachment, []byte("hi"), 0o600); err != nil {
+		t.Fatalf("write attachment: %v", err)
+	}
+
+	svc := newGmailServiceFromServer(t, srv)
+	flags := &RootFlags{Account: "a@b.com"}
+
+	var stderr bytes.Buffer
+	ctx := withGmailTestService(newCmdRuntimeJSONOutputContext(t, io.Discard, &stderr), svc)
+	if err := runKong(t, &GmailDraftsUpdateCmd{}, []string{
+		"d1",
+		"--to", "someone@example.com",
+		"--reply-to-message-id", "m9",
+		"--attach", attachment,
+		"--subject", "Updated",
+		"--body", "Hello",
+	}, ctx, flags); err != nil {
+		t.Fatalf("advisory draft read failure must not abort the update: %v", err)
+	}
+	if draftGets == 0 {
+		t.Fatalf("expected the advisory draft read to be attempted")
+	}
+	if draftPuts != 1 {
+		t.Fatalf("expected the draft update to still be sent, got %d PUTs", draftPuts)
+	}
+	if strings.Contains(stderr.String(), "plain text only") {
+		t.Fatalf("no downgrade warning is possible when the inspection read failed, got:\n%s", stderr.String())
+	}
+}
+
+// A read the rebuilt message actually depends on stays fatal: without --to the
+// update needs the stored recipients, so a failed read must not silently drop
+// them.
+func TestGmailDraftsUpdateCmd_RequiredFetchFailureAborts(t *testing.T) {
+	var draftPuts int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/gmail/v1/users/me/drafts/d1") && r.Method == http.MethodGet:
+			http.Error(w, "transient draft read failure", http.StatusServiceUnavailable)
+			return
+		case strings.Contains(r.URL.Path, "/gmail/v1/users/me/drafts/d1") && r.Method == http.MethodPut:
+			draftPuts++
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":      "d1",
+				"message": map[string]any{"id": "m2", "threadId": "t1"},
+			})
+			return
+		default:
+			http.NotFound(w, r)
+			return
+		}
+	}))
+	defer srv.Close()
+
+	svc := newGmailServiceFromServer(t, srv)
+	flags := &RootFlags{Account: "a@b.com"}
+
+	var stderr bytes.Buffer
+	ctx := withGmailTestService(newCmdRuntimeJSONOutputContext(t, io.Discard, &stderr), svc)
+	err := runKong(t, &GmailDraftsUpdateCmd{}, []string{
+		"d1",
+		"--subject", "Updated",
+		"--body", "Hello",
+	}, ctx, flags)
+	if err == nil {
+		t.Fatalf("expected the required draft read failure to abort the update")
+	}
+	if draftPuts != 0 {
+		t.Fatalf("expected no draft update after a required read failure, got %d PUTs", draftPuts)
+	}
+}
+
 func TestGmailDraftsUpdateCmd_WithQuoteFromExistingThread(t *testing.T) {
 	t.Setenv("GOG_TIMEZONE", "UTC")
 	originalPlain := "Original thread message"

--- a/internal/cmd/gmail_drafts_cmd_test.go
+++ b/internal/cmd/gmail_drafts_cmd_test.go
@@ -1083,6 +1083,82 @@ func TestGmailDraftsUpdateCmd_NoWarnWhenHTMLBodyProvided(t *testing.T) {
 	}
 }
 
+// The fetch of the existing draft is skipped when --to, --reply-to-message-id
+// and --attach are all supplied. That path still replaces the body, so the
+// downgrade warning must still reach it.
+func TestGmailDraftsUpdateCmd_WarnsWhenAllFieldsUpdateSkipsFetchGuard(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/gmail/v1/users/me/drafts/d1") && r.Method == http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id": "d1",
+				"message": map[string]any{
+					"id":       "m1",
+					"threadId": "t1",
+					"payload": map[string]any{
+						"mimeType": "multipart/alternative",
+						"parts": []map[string]any{
+							{"mimeType": "text/plain", "body": map[string]any{"size": 10}},
+							{"mimeType": "text/html", "body": map[string]any{"size": 20}},
+						},
+					},
+				},
+			})
+			return
+		case strings.Contains(r.URL.Path, "/gmail/v1/users/me/messages/m9") && r.Method == http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":       "m9",
+				"threadId": "t1",
+				"payload": map[string]any{
+					"headers": []map[string]any{
+						{"name": "Message-ID", "value": "<m9@example.com>"},
+						{"name": "From", "value": "orig@example.com"},
+						{"name": "Subject", "value": "Original"},
+					},
+				},
+			})
+			return
+		case strings.Contains(r.URL.Path, "/gmail/v1/users/me/drafts/d1") && r.Method == http.MethodPut:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":      "d1",
+				"message": map[string]any{"id": "m2", "threadId": "t1"},
+			})
+			return
+		default:
+			http.NotFound(w, r)
+			return
+		}
+	}))
+	defer srv.Close()
+
+	attachment := filepath.Join(t.TempDir(), "note.txt")
+	if err := os.WriteFile(attachment, []byte("hi"), 0o600); err != nil {
+		t.Fatalf("write attachment: %v", err)
+	}
+
+	svc := newGmailServiceFromServer(t, srv)
+	flags := &RootFlags{Account: "a@b.com"}
+
+	var stderr bytes.Buffer
+	ctx := withGmailTestService(newCmdRuntimeJSONOutputContext(t, io.Discard, &stderr), svc)
+	if err := runKong(t, &GmailDraftsUpdateCmd{}, []string{
+		"d1",
+		"--to", "someone@example.com",
+		"--reply-to-message-id", "m9",
+		"--attach", attachment,
+		"--subject", "Updated",
+		"--body", "Hello",
+	}, ctx, flags); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !strings.Contains(stderr.String(), "replaces it with plain text only") {
+		t.Fatalf("expected downgrade warning on the all-fields update path, got:\n%s", stderr.String())
+	}
+}
+
 func TestGmailDraftsUpdateCmd_WithQuoteFromExistingThread(t *testing.T) {
 	t.Setenv("GOG_TIMEZONE", "UTC")
 	originalPlain := "Original thread message"


### PR DESCRIPTION
## Scope

`gmail drafts update` rebuilds the whole message, so updating a draft that carries a `text/html` part (e.g. a reply composed in Gmail's web UI) with only `--body`/`--body-file` silently produces a plain-text-only draft. Gmail then renders the stored ~72-char hard-wrapped plain text literally — the draft looks mangled, with no hint of why.

Update already carries forward attachments (#680/#681) and reply lineage (#942/#944); the body is the remaining silent-replacement surface. Since replacing the body is exactly what the caller asked for, this PR doesn't change behaviour — it adds a **stderr-only warning** when the existing draft has an HTML body part and the update supplies none:

```
Warning: draft has an HTML body; this update replaces it with plain text only. Pass --body-html/--body-html-file to keep rich-text formatting.
```

- `--quote` is exempt: quoting regenerates an HTML part.
- Attachment parts don't count as an HTML body (an attached `.html` file doesn't trigger it).
- The existing-draft fetch predicate is extended with the same condition the warning uses, so every plain-only non-quote update inspects the stored MIME tree — including the all-fields path (`--to` + `--reply-to-message-id` + `--attach`) that previously skipped the fetch entirely (see review follow-up below).
- stdout/`--json`/`--plain` output contracts untouched.

## Motivation

Real-world agent workflow: an update passing only `--body` on a Gmail-composed reply draft downgraded it to plain-only; the resulting "mangled wrapping" took a while to diagnose because nothing signalled the multipart → plain transition (2026-08-03, gogcli v0.17.0 — but the same applies on main).

## Real behavior proof (live Gmail, redacted)

Run against a real Gmail account through the real API — a throwaway rich-text draft (`multipart/alternative`), updated with the **unpatched v0.34.2** binary and then this branch's binary. Account address and draft id redacted; MIME trees printed from `gmail drafts get --json`.

```console
$ # (0) starting point — a genuine rich-text draft, as Gmail composes them
$ gog gmail drafts get r2430190…0882 --json | mimetree
multipart/alternative
  text/plain
  text/html

$ # (1) BEFORE — unpatched v0.34.2, update supplying only --body
$ gog-v0.34.2 gmail drafts update r2430190…0882 \
    --subject "test draft" --body "Downgraded silently." --json >/dev/null
exit=0   stderr bytes=0            <-- nothing said
$ gog gmail drafts get r2430190…0882 --json | mimetree
text/plain                          <-- HTML part gone

$ # (2) AFTER — this branch, same real draft restored to rich text, same flags
$ gog-patched gmail drafts update r2430190…0882 \
    --subject "test draft" --body "Hello there. Updated with plain text only." --json >out.json
Warning: draft has an HTML body; this update replaces it with plain text only. Pass --body-html/--body-html-file to keep rich-text formatting.
exit=0
$ head -3 out.json                  <-- stdout still clean JSON
{
  "draftId": "r2430190…0882",
  "inReplyTo": null,
$ gog gmail drafts get r2430190…0882 --json | mimetree
text/plain                          <-- warning was truthful

$ # (3) AFTER — rich draft again, this time supplying --body-html
$ gog-patched gmail drafts update r2430190…0882 \
    --body "Hello there. Updated, rich text kept." \
    --body-html '<div dir="ltr"><div>Hello there. Updated, rich text kept.</div></div>' --json >out.json
exit=0   stderr bytes=0            <-- silent, as intended
$ gog gmail drafts get r2430190…0882 --json | mimetree
multipart/alternative               <-- rich text preserved
  text/plain
  text/html
```

`mimetree` is just a shell helper that walks `payload.parts` and prints `mimeType` per level. The test draft was deleted afterwards; no other drafts were touched, and nothing was sent.

## Review follow-up — the all-fields path (0682a12)

The first review correctly caught that `internal/cmd/gmail_drafts.go` skips the existing-draft fetch when `--to`, `--reply-to-message-id` and `--attach` are all supplied, leaving `existingPayload` nil — that invocation still rebuilt the body, so it downgraded rich text unwarned.

Fixed by extending the fetch predicate with the same condition the warning uses (`no HTML body supplied && !--quote`), so the extra fetch is confined to updates that can actually drop an HTML body. Live re-verification of exactly that combination:

```console
$ gog gmail drafts get r7187264…6691 --json | mimetree
multipart/alternative
  text/plain
  text/html

$ gog-patched gmail drafts update r7187264…6691 \
    --to you@example.com --reply-to-message-id 19c208a…b345 --attach note.txt \
    --subject "test draft" --body "Downgraded via the all-fields path." --json >out.json
Warning: draft has an HTML body; this update replaces it with plain text only. Pass --body-html/--body-html-file to keep rich-text formatting.
exit=0

$ gog gmail drafts get r7187264…6691 --json | mimetree
multipart/mixed                     <-- body downgraded, warning now fires
  text/plain
  text/plain                        (the attachment part)
```

The regression test was confirmed to fail without the predicate change (`expected downgrade warning on the all-fields update path, got:` with empty stderr) and pass with it.

## Testing

- `make fmt` clean, `go vet` clean; `go test ./internal/cmd/ -count=1` passes (full package, 77s).
- Tests: `TestGmailDraftsUpdateCmd_WarnsWhenPlainBodyReplacesHTMLDraft` (warning when a multipart/alternative draft is updated with `--body` only), `TestGmailDraftsUpdateCmd_NoWarnWhenHTMLBodyProvided` (silent with `--body-html`), and `TestGmailDraftsUpdateCmd_WarnsWhenAllFieldsUpdateSkipsFetchGuard` (the `--to` + `--reply-to-message-id` + `--attach` path).
- Plus the two live Gmail runs above.

## User-facing changes

New stderr warning only; no flags added or changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CEKp3XY4d4ktX7LJBcgGVs



## Review follow-up — the advisory read (8dbbdfc)

The second review was right that the previous head over-reached: adding `inspectForHTMLDowngrade` to the fetch predicate made the existing-draft `Drafts.Get` happen on invocations that need nothing from it (`--to` + `--reply-to-message-id` + `--attach`), while the original `return fetchErr` was left in place. A transient read failure would then abort an update that main performs — a warning-only read blocking the write it was meant to annotate.

Fixed by splitting the predicate from the error handling:

```go
requireExistingDraft := (!toWasSet && !c.ReplyAll) || strings.TrimSpace(replyToMessageID) == "" || preserveAttachments
inspectForHTMLDowngrade := strings.TrimSpace(htmlBody) == "" && !c.Quote
if requireExistingDraft || inspectForHTMLDowngrade {
	existing, fetchErr := svc.Users.Drafts.Get("me", draftID).Format("full").Do()
	// Advisory whenever nothing but the warning wants it: a failed inspection
	// costs the warning, never the update the caller asked for.
	if fetchErr != nil && requireExistingDraft {
		return fetchErr
	}
	if fetchErr == nil && existing != nil && existing.Message != nil {
		...
	}
}
```

A read the rebuilt message depends on — stored recipients (no `--to`), reply lineage (no `--reply-to-message-id`), attachment carry-forward — still returns the error, because proceeding there would silently drop data. A read wanted only for the warning does not.

Two regression tests cover both halves, on an `httptest` server that fails the draft `GET` and accepts the `PUT`:

- `TestGmailDraftsUpdateCmd_AdvisoryFetchFailureStillUpdates` — all-fields invocation, `GET` returns 503: command exits 0, exactly one `PUT` is sent, and no warning is printed (none is possible without the payload). Confirmed to fail on the previous head: `advisory draft read failure must not abort the update: googleapi: got HTTP response code 503 with body: transient draft read failure`.
- `TestGmailDraftsUpdateCmd_RequiredFetchFailureAborts` — no `--to`, same failing `GET`: the command errors and **zero** `PUT`s are sent, so the advisory relaxation didn't leak into reads that matter.

Live re-verification that the user-facing behaviour is unchanged by the error-handling split — same all-fields path, patched binary, real Gmail account (redacted):

```console
$ gog gmail drafts get r6691291…3717 --json | mimetree
multipart/alternative
  text/plain
  text/html

$ gog-patched gmail drafts update r6691291…3717 \
    --to me@example.com --reply-to-message-id 19fce745e1201210 --attach note.txt \
    --subject "test draft" --body "Downgraded via the all-fields path." --json >out.json
Warning: draft has an HTML body; this update replaces it with plain text only. Pass --body-html/--body-html-file to keep rich-text formatting.
exit=0
$ head -4 out.json                  <-- stdout still clean JSON
{
  "attachments": [
    {
      "filename": "note.txt",
$ gog gmail drafts get r6691291…3717 --json | mimetree
multipart/mixed                     <-- warning was truthful
  text/plain
  text/plain                        (the attachment part)
```

The test draft was deleted afterwards; nothing was sent.

Checks on this head: `goimports`/`gofumpt` clean, `go vet ./internal/cmd/` clean, `golangci-lint run ./internal/cmd/...` 0 issues, `go test ./internal/cmd/ -count=1` passes (139s).

