### PR TITLE
feat(gmail): warn on rich draft downgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Gmail: warn before a draft update replaces an existing rich-text body with plain text only, while keeping JSON stdout clean. (#955) — thanks @mcinteerj.
 - Dependencies: update the Go developer tools, pnpm, and email-tracking worker transitive pins to their latest releases.
 - Docs: rewrite the README as a concise front door and move task examples into a dedicated guide.
 

--- a/internal/cmd/gmail_drafts.go
+++ b/internal/cmd/gmail_drafts.go
@@ -424,6 +424,29 @@ func buildDraftMessage(ctx context.Context, svc *gmail.Service, account string, 
 	return msg, threading, attachmentMetadata, nil
 }
 
+// draftHasHTMLBodyPart reports whether a draft message's stored payload carries
+// a text/html body part (a rich-text draft). Attachment parts (non-empty
+// filename) don't count, so an attached .html file is not a rich body.
+func draftHasHTMLBodyPart(payload *gmail.MessagePart) bool {
+	if payload == nil {
+		return false
+	}
+	// A named MIME subtree is an attachment, including an attached message whose
+	// nested body may itself contain text/html.
+	if strings.TrimSpace(payload.Filename) != "" {
+		return false
+	}
+	if strings.EqualFold(payload.MimeType, "text/html") {
+		return true
+	}
+	for _, part := range payload.Parts {
+		if draftHasHTMLBodyPart(part) {
+			return true
+		}
+	}
+	return false
+}
+
 // carryForwardDraftAttachments fetches the bytes of an existing draft message's
 // attachments so they can be re-attached to a rebuilt draft on update. Returns
 // nil when the draft has no attachments. Mirrors the gmail forward reattach path.
@@ -854,12 +877,24 @@ func (c *GmailDraftsUpdateCmd) Run(ctx context.Context, flags *RootFlags) error 
 	existingInReplyTo := ""
 	existingReferences := ""
 	var existingPayload *gmail.MessagePart
-	if (!toWasSet && !c.ReplyAll) || strings.TrimSpace(replyToMessageID) == "" || preserveAttachments {
+	// Recipients, reply lineage and attachment carry-forward are built from the
+	// stored draft, so those updates cannot proceed without it.
+	requireExistingDraft := (!toWasSet && !c.ReplyAll) || strings.TrimSpace(replyToMessageID) == "" || preserveAttachments
+	// An update carrying no HTML body can silently drop the draft's stored one,
+	// so the warning below needs the existing payload. Without this the fetch is
+	// skipped whenever --to, --reply-to-message-id and --attach are all supplied,
+	// and that path would downgrade a rich-text draft unwarned. --quote is exempt
+	// because quoting regenerates an HTML part.
+	inspectForHTMLDowngrade := strings.TrimSpace(htmlBody) == "" && !c.Quote
+	if requireExistingDraft || inspectForHTMLDowngrade {
 		existing, fetchErr := svc.Users.Drafts.Get("me", draftID).Format("full").Do()
-		if fetchErr != nil {
+		// This read is advisory whenever nothing but the warning wants it: a
+		// failed inspection costs the warning, never the update the caller asked
+		// for. Only a read the rebuilt message actually depends on is fatal.
+		if fetchErr != nil && requireExistingDraft {
 			return fetchErr
 		}
-		if existing != nil && existing.Message != nil {
+		if fetchErr == nil && existing != nil && existing.Message != nil {
 			existingThreadID = strings.TrimSpace(existing.Message.ThreadId)
 			existingMessageID = strings.TrimSpace(existing.Message.Id)
 			existingPayload = existing.Message.Payload
@@ -872,6 +907,13 @@ func (c *GmailDraftsUpdateCmd) Run(ctx context.Context, flags *RootFlags) error 
 	}
 	if !toWasSet && !c.ReplyAll {
 		to = existingTo
+	}
+
+	// gmail drafts update rebuilds the whole message, so updating a rich-text
+	// draft with only a plain body silently drops its text/html part — Gmail
+	// then renders the stored hard-wrapped plain text literally. Warn on stderr.
+	if inspectForHTMLDowngrade && draftHasHTMLBodyPart(existingPayload) {
+		u.Err().Println("Warning: draft has an HTML body; this update replaces it with plain text only. Pass --body-html/--body-html-file to keep rich-text formatting.")
 	}
 
 	// The thread the draft already lives in. Used for --quote target discovery

--- a/internal/cmd/gmail_drafts_cmd_test.go
+++ b/internal/cmd/gmail_drafts_cmd_test.go
@@ -1002,6 +1002,297 @@ func TestGmailDraftsUpdateCmd_PreservesToWhenNotProvided(t *testing.T) {
 	}
 }
 
+func newRichDraftUpdateServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/gmail/v1/users/me/drafts/d1") && r.Method == http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id": "d1",
+				"message": map[string]any{
+					"id":       "m1",
+					"threadId": "t1",
+					"payload": map[string]any{
+						"mimeType": "multipart/alternative",
+						"headers": []map[string]any{
+							{"name": "To", "value": "keep@example.com"},
+						},
+						"parts": []map[string]any{
+							{"mimeType": "text/plain", "body": map[string]any{"size": 10}},
+							{"mimeType": "text/html", "body": map[string]any{"size": 20}},
+						},
+					},
+				},
+			})
+			return
+		case strings.Contains(r.URL.Path, "/gmail/v1/users/me/drafts/d1") && r.Method == http.MethodPut:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":      "d1",
+				"message": map[string]any{"id": "m2", "threadId": "t1"},
+			})
+			return
+		default:
+			http.NotFound(w, r)
+			return
+		}
+	}))
+}
+
+func TestDraftHasHTMLBodyPart_IgnoresAttachmentSubtrees(t *testing.T) {
+	payload := &gmail.MessagePart{
+		MimeType: "multipart/mixed",
+		Parts: []*gmail.MessagePart{
+			{MimeType: "text/plain"},
+			{
+				MimeType: "message/rfc822",
+				Filename: "attached.eml",
+				Parts: []*gmail.MessagePart{
+					{MimeType: "text/html"},
+				},
+			},
+		},
+	}
+
+	if draftHasHTMLBodyPart(payload) {
+		t.Fatal("HTML nested inside an attached message must not count as the draft body")
+	}
+}
+
+func TestGmailDraftsUpdateCmd_WarnsWhenPlainBodyReplacesHTMLDraft(t *testing.T) {
+	srv := newRichDraftUpdateServer(t)
+	defer srv.Close()
+
+	svc := newGmailServiceFromServer(t, srv)
+	flags := &RootFlags{Account: "a@b.com"}
+
+	var stderr bytes.Buffer
+	ctx := withGmailTestService(newCmdRuntimeJSONOutputContext(t, io.Discard, &stderr), svc)
+	if err := runKong(t, &GmailDraftsUpdateCmd{}, []string{
+		"d1",
+		"--subject", "Updated",
+		"--body", "Hello",
+	}, ctx, flags); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !strings.Contains(stderr.String(), "replaces it with plain text only") {
+		t.Fatalf("expected plain-text downgrade warning on stderr, got:\n%s", stderr.String())
+	}
+}
+
+func TestGmailDraftsUpdateCmd_NoWarnWhenHTMLBodyProvided(t *testing.T) {
+	srv := newRichDraftUpdateServer(t)
+	defer srv.Close()
+
+	svc := newGmailServiceFromServer(t, srv)
+	flags := &RootFlags{Account: "a@b.com"}
+
+	var stderr bytes.Buffer
+	ctx := withGmailTestService(newCmdRuntimeJSONOutputContext(t, io.Discard, &stderr), svc)
+	if err := runKong(t, &GmailDraftsUpdateCmd{}, []string{
+		"d1",
+		"--subject", "Updated",
+		"--body", "Hello",
+		"--body-html", "<p>Hello</p>",
+	}, ctx, flags); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if strings.Contains(stderr.String(), "plain text only") {
+		t.Fatalf("unexpected downgrade warning with --body-html, got:\n%s", stderr.String())
+	}
+}
+
+// The fetch of the existing draft is skipped when --to, --reply-to-message-id
+// and --attach are all supplied. That path still replaces the body, so the
+// downgrade warning must still reach it.
+func TestGmailDraftsUpdateCmd_WarnsWhenAllFieldsUpdateSkipsFetchGuard(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/gmail/v1/users/me/drafts/d1") && r.Method == http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id": "d1",
+				"message": map[string]any{
+					"id":       "m1",
+					"threadId": "t1",
+					"payload": map[string]any{
+						"mimeType": "multipart/alternative",
+						"parts": []map[string]any{
+							{"mimeType": "text/plain", "body": map[string]any{"size": 10}},
+							{"mimeType": "text/html", "body": map[string]any{"size": 20}},
+						},
+					},
+				},
+			})
+			return
+		case strings.Contains(r.URL.Path, "/gmail/v1/users/me/messages/m9") && r.Method == http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":       "m9",
+				"threadId": "t1",
+				"payload": map[string]any{
+					"headers": []map[string]any{
+						{"name": "Message-ID", "value": "<m9@example.com>"},
+						{"name": "From", "value": "orig@example.com"},
+						{"name": "Subject", "value": "Original"},
+					},
+				},
+			})
+			return
+		case strings.Contains(r.URL.Path, "/gmail/v1/users/me/drafts/d1") && r.Method == http.MethodPut:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":      "d1",
+				"message": map[string]any{"id": "m2", "threadId": "t1"},
+			})
+			return
+		default:
+			http.NotFound(w, r)
+			return
+		}
+	}))
+	defer srv.Close()
+
+	attachment := filepath.Join(t.TempDir(), "note.txt")
+	if err := os.WriteFile(attachment, []byte("hi"), 0o600); err != nil {
+		t.Fatalf("write attachment: %v", err)
+	}
+
+	svc := newGmailServiceFromServer(t, srv)
+	flags := &RootFlags{Account: "a@b.com"}
+
+	var stderr bytes.Buffer
+	ctx := withGmailTestService(newCmdRuntimeJSONOutputContext(t, io.Discard, &stderr), svc)
+	if err := runKong(t, &GmailDraftsUpdateCmd{}, []string{
+		"d1",
+		"--to", "someone@example.com",
+		"--reply-to-message-id", "m9",
+		"--attach", attachment,
+		"--subject", "Updated",
+		"--body", "Hello",
+	}, ctx, flags); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !strings.Contains(stderr.String(), "replaces it with plain text only") {
+		t.Fatalf("expected downgrade warning on the all-fields update path, got:\n%s", stderr.String())
+	}
+}
+
+// When --to, --reply-to-message-id and --attach are all supplied the existing
+// draft is read only to decide whether to warn. That read is advisory, so a
+// failure must not abort the update the caller asked for.
+func TestGmailDraftsUpdateCmd_AdvisoryFetchFailureStillUpdates(t *testing.T) {
+	var draftGets, draftPuts int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/gmail/v1/users/me/drafts/d1") && r.Method == http.MethodGet:
+			draftGets++
+			http.Error(w, "transient draft read failure", http.StatusServiceUnavailable)
+			return
+		case strings.Contains(r.URL.Path, "/gmail/v1/users/me/messages/m9") && r.Method == http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":       "m9",
+				"threadId": "t1",
+				"payload": map[string]any{
+					"headers": []map[string]any{
+						{"name": "Message-ID", "value": "<m9@example.com>"},
+						{"name": "From", "value": "orig@example.com"},
+						{"name": "Subject", "value": "Original"},
+					},
+				},
+			})
+			return
+		case strings.Contains(r.URL.Path, "/gmail/v1/users/me/drafts/d1") && r.Method == http.MethodPut:
+			draftPuts++
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":      "d1",
+				"message": map[string]any{"id": "m2", "threadId": "t1"},
+			})
+			return
+		default:
+			http.NotFound(w, r)
+			return
+		}
+	}))
+	defer srv.Close()
+
+	attachment := filepath.Join(t.TempDir(), "note.txt")
+	if err := os.WriteFile(attachment, []byte("hi"), 0o600); err != nil {
+		t.Fatalf("write attachment: %v", err)
+	}
+
+	svc := newGmailServiceFromServer(t, srv)
+	flags := &RootFlags{Account: "a@b.com"}
+
+	var stderr bytes.Buffer
+	ctx := withGmailTestService(newCmdRuntimeJSONOutputContext(t, io.Discard, &stderr), svc)
+	if err := runKong(t, &GmailDraftsUpdateCmd{}, []string{
+		"d1",
+		"--to", "someone@example.com",
+		"--reply-to-message-id", "m9",
+		"--attach", attachment,
+		"--subject", "Updated",
+		"--body", "Hello",
+	}, ctx, flags); err != nil {
+		t.Fatalf("advisory draft read failure must not abort the update: %v", err)
+	}
+	if draftGets == 0 {
+		t.Fatalf("expected the advisory draft read to be attempted")
+	}
+	if draftPuts != 1 {
+		t.Fatalf("expected the draft update to still be sent, got %d PUTs", draftPuts)
+	}
+	if strings.Contains(stderr.String(), "plain text only") {
+		t.Fatalf("no downgrade warning is possible when the inspection read failed, got:\n%s", stderr.String())
+	}
+}
+
+// A read the rebuilt message actually depends on stays fatal: without --to the
+// update needs the stored recipients, so a failed read must not silently drop
+// them.
+func TestGmailDraftsUpdateCmd_RequiredFetchFailureAborts(t *testing.T) {
+	var draftPuts int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/gmail/v1/users/me/drafts/d1") && r.Method == http.MethodGet:
+			http.Error(w, "transient draft read failure", http.StatusServiceUnavailable)
+			return
+		case strings.Contains(r.URL.Path, "/gmail/v1/users/me/drafts/d1") && r.Method == http.MethodPut:
+			draftPuts++
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":      "d1",
+				"message": map[string]any{"id": "m2", "threadId": "t1"},
+			})
+			return
+		default:
+			http.NotFound(w, r)
+			return
+		}
+	}))
+	defer srv.Close()
+
+	svc := newGmailServiceFromServer(t, srv)
+	flags := &RootFlags{Account: "a@b.com"}
+
+	var stderr bytes.Buffer
+	ctx := withGmailTestService(newCmdRuntimeJSONOutputContext(t, io.Discard, &stderr), svc)
+	err := runKong(t, &GmailDraftsUpdateCmd{}, []string{
+		"d1",
+		"--subject", "Updated",
+		"--body", "Hello",
+	}, ctx, flags)
+	if err == nil {
+		t.Fatalf("expected the required draft read failure to abort the update")
+	}
+	if draftPuts != 0 {
+		t.Fatalf("expected no draft update after a required read failure, got %d PUTs", draftPuts)
+	}
+}
+
 func TestGmailDraftsUpdateCmd_WithQuoteFromExistingThread(t *testing.T) {
 	t.Setenv("GOG_TIMEZONE", "UTC")
 	originalPlain := "Original thread message"


### PR DESCRIPTION
## Summary

- land the contributor work from #955 as one maintainer-reviewed commit
- warn on stderr before a plain-only draft update removes an existing rich-text body
- keep JSON stdout clean and keep advisory MIME inspection failures non-fatal
- ignore HTML nested below an attachment boundary
- add the Unreleased changelog credit for @mcinteerj

## Proof

- `make ci`
- focused draft-update regression suite, including advisory/required read failures and attached-message HTML
- contributor-provided exact-head live Gmail proof on #955: warning emitted for a real multipart draft downgrade, valid JSON remained on stdout, and supplying HTML preserved `multipart/alternative`

Autoreview: clean, no accepted/actionable findings.

Co-authored-by: Jake <mcinteerj@gmail.com>
