### PR TITLE
feat(gmail): import RFC822 messages

### DIFF
--- a/.agents/skills/gog-gmail/SKILL.md
+++ b/.agents/skills/gog-gmail/SKILL.md
@@ -36,6 +36,7 @@ gog --readonly --account user@example.com gmail search 'newer_than:7d' --max 10 
 | `forward` | Forward a message to new recipients |
 | `get` | Get a message (full\|metadata\|raw) |
 | `history` | Gmail history |
+| `import` | Import an RFC822/EML message into Gmail |
 | `labels` | Label operations |
 | `mark-read` | Mark messages as read |
 | `messages` | Message operations |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Gmail: add guarded single-message RFC822/EML import from a file or stdin, with labels, internal-date, spam, calendar-processing, and parse-only dry-run controls. (#956) — thanks @holgergruenhagen.
 - Gmail: warn before a draft update replaces an existing rich-text body with plain text only, while keeping JSON stdout clean. (#955) — thanks @mcinteerj.
 - Dependencies: update the Google API and OpenTelemetry stacks, Go developer tools, pnpm, and email-tracking worker toolchain to their latest policy-eligible releases.
 - Docs: rewrite the README as a concise front door and move task examples into a dedicated guide.

--- a/docs/commands.generated.md
+++ b/docs/commands.generated.md
@@ -410,6 +410,7 @@ Generated from `gog schema --json`.
     - [`gog gmail (mail,email) forward (fwd) --to=STRING <messageId> [flags]`](commands/gog-gmail-forward.md) - Forward a message to new recipients
     - [`gog gmail (mail,email) get (info,show) <messageId> [flags]`](commands/gog-gmail-get.md) - Get a message (full|metadata|raw)
     - [`gog gmail (mail,email) history [flags]`](commands/gog-gmail-history.md) - Gmail history
+    - [`gog gmail (mail,email) import <file> [flags]`](commands/gog-gmail-import.md) - Import an RFC822/EML message into Gmail
     - [`gog gmail (mail,email) labels (label) <command>`](commands/gog-gmail-labels.md) - Label operations
       - [`gog gmail (mail,email) labels (label) create (add,new) <name>`](commands/gog-gmail-labels-create.md) - Create a new label
       - [`gog gmail (mail,email) labels (label) delete (rm,del) <labelIdOrName>`](commands/gog-gmail-labels-delete.md) - Delete a label

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -2,7 +2,7 @@
 
 Every `gog` command has a generated docs page. The source of truth is the live CLI schema; run `make docs-commands` after changing command names, flags, help text, aliases, or arguments.
 
-Generated pages: 708.
+Generated pages: 709.
 
 ## Top-level Commands
 
@@ -463,6 +463,7 @@ Generated pages: 708.
     - [gog gmail forward](gog-gmail-forward.md) - Forward a message to new recipients
     - [gog gmail get](gog-gmail-get.md) - Get a message (full|metadata|raw)
     - [gog gmail history](gog-gmail-history.md) - Gmail history
+    - [gog gmail import](gog-gmail-import.md) - Import an RFC822/EML message into Gmail
     - [gog gmail labels](gog-gmail-labels.md) - Label operations
       - [gog gmail labels create](gog-gmail-labels-create.md) - Create a new label
       - [gog gmail labels delete](gog-gmail-labels-delete.md) - Delete a label

--- a/docs/commands/gog-gmail-import.md
+++ b/docs/commands/gog-gmail-import.md
@@ -1,44 +1,18 @@
-# `gog gmail`
+# `gog gmail import`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Gmail
+Import an RFC822/EML message into Gmail
 
 ## Usage
 
 ```bash
-gog gmail (mail,email) <command> [flags]
+gog gmail (mail,email) import <file> [flags]
 ```
 
 ## Parent
 
-- [gog](gog.md)
-
-## Subcommands
-
-- [gog gmail archive](gog-gmail-archive.md) - Archive messages or explicit threads (remove from inbox)
-- [gog gmail attachment](gog-gmail-attachment.md) - Download a single attachment
-- [gog gmail autoreply](gog-gmail-autoreply.md) - Reply once to matching messages
-- [gog gmail batch](gog-gmail-batch.md) - Batch operations (permanent delete requires broader Gmail scope; use gmail trash for normal trashing)
-- [gog gmail drafts](gog-gmail-drafts.md) - Draft operations
-- [gog gmail forward](gog-gmail-forward.md) - Forward a message to new recipients
-- [gog gmail get](gog-gmail-get.md) - Get a message (full|metadata|raw)
-- [gog gmail history](gog-gmail-history.md) - Gmail history
-- [gog gmail import](gog-gmail-import.md) - Import an RFC822/EML message into Gmail
-- [gog gmail labels](gog-gmail-labels.md) - Label operations
-- [gog gmail mark-read](gog-gmail-mark-read.md) - Mark messages as read
-- [gog gmail messages](gog-gmail-messages.md) - Message operations
-- [gog gmail raw](gog-gmail-raw.md) - Dump raw Gmail API response as JSON (Users.Messages.Get; lossless; for scripting and LLM consumption)
-- [gog gmail reply](gog-gmail-reply.md) - Reply to a message
-- [gog gmail reply-all](gog-gmail-reply-all.md) - Reply to all message participants
-- [gog gmail search](gog-gmail-search.md) - Search threads using Gmail query syntax
-- [gog gmail send](gog-gmail-send.md) - Send an email
-- [gog gmail settings](gog-gmail-settings.md) - Settings and admin
-- [gog gmail thread](gog-gmail-thread.md) - Thread operations (get, modify)
-- [gog gmail track](gog-gmail-track.md) - Email open tracking
-- [gog gmail trash](gog-gmail-trash.md) - Move messages to trash
-- [gog gmail unread](gog-gmail-unread.md) - Mark messages as unread
-- [gog gmail url](gog-gmail-url.md) - Print Gmail web URLs for threads
+- [gog gmail](gog-gmail.md)
 
 ## Flags
 
@@ -56,9 +30,13 @@ gog gmail (mail,email) <command> [flags]
 | `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
 | `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `--internal-date-source` | `string` | dateHeader | Gmail internal date source: dateHeader or receivedTime |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--label` | `[]string` |  | Label ID or name to apply (repeatable) |
+| `--never-mark-spam` | `bool` |  | Never classify the imported message as spam |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
+| `--process-for-calendar` | `bool` |  | Process calendar invitations in the imported message |
 | `--readonly` | `bool` | false | Block mutating API requests at runtime; auth add also requests read-only OAuth scopes |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
@@ -68,5 +46,5 @@ gog gmail (mail,email) <command> [flags]
 
 ## See Also
 
-- [gog](gog.md)
+- [gog gmail](gog-gmail.md)
 - [Command index](README.md)

--- a/docs/gmail-workflows.md
+++ b/docs/gmail-workflows.md
@@ -66,6 +66,27 @@ For account-specific send blocking, use the no-send config commands:
 - [`gog config no-send list`](commands/gog-config-no-send-list.md)
 - [`gog config no-send remove`](commands/gog-config-no-send-remove.md)
 
+## Import an RFC822 Message
+
+Import one existing RFC822/EML message from a file or stdin:
+
+```bash
+gog gmail import message.eml --label Imported --never-mark-spam
+cat message.eml | gog gmail import - --internal-date-source receivedTime
+```
+
+Use `--dry-run` to parse the message and report its source, byte count, key
+headers, labels, and import controls without authenticating or changing the
+mailbox. `--internal-date-source dateHeader` (the default) asks Gmail to use a
+valid `Date` header; `receivedTime` uses the import time. The optional
+`--process-for-calendar` flag lets Gmail process calendar invitations.
+
+This command imports one message through Gmail's normal delivery scanning and
+classification. It does not fetch from IMAP, synchronize mailboxes, or
+orchestrate bulk migrations.
+
+Command page: [`gog gmail import`](commands/gog-gmail-import.md).
+
 ## Reply and Reply All
 
 The Gmail API has no reply method. Clients fetch the original message, build a

--- a/internal/cmd/gmail.go
+++ b/internal/cmd/gmail.go
@@ -18,6 +18,7 @@ type GmailCmd struct {
 	Trash   GmailTrashMsgCmd `cmd:"" name:"trash" group:"Organize" help:"Move messages to trash"`
 
 	Send      GmailSendCmd      `cmd:"" name:"send" group:"Write" help:"Send an email"`
+	Import    GmailImportCmd    `cmd:"" name:"import" group:"Write" help:"Import an RFC822/EML message into Gmail"`
 	Reply     GmailReplyCmd     `cmd:"" name:"reply" group:"Write" help:"Reply to a message"`
 	ReplyAll  GmailReplyAllCmd  `cmd:"" name:"reply-all" aliases:"replyall" group:"Write" help:"Reply to all message participants"`
 	Forward   GmailForwardCmd   `cmd:"" name:"forward" aliases:"fwd" group:"Write" help:"Forward a message to new recipients"`

--- a/internal/cmd/gmail_import.go
+++ b/internal/cmd/gmail_import.go
@@ -1,0 +1,166 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/mail"
+	"os"
+	"strings"
+
+	"google.golang.org/api/gmail/v1"
+	gapi "google.golang.org/api/googleapi"
+
+	"github.com/steipete/gogcli/internal/config"
+	"github.com/steipete/gogcli/internal/googleapi"
+	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+type GmailImportCmd struct {
+	File               string   `arg:"" name:"file" help:"RFC822/EML file path, or '-' for stdin"`
+	Labels             []string `name:"label" help:"Label ID or name to apply (repeatable)"`
+	InternalDateSource string   `name:"internal-date-source" enum:"dateHeader,receivedTime" default:"dateHeader" help:"Gmail internal date source: dateHeader or receivedTime"`
+	NeverMarkSpam      bool     `name:"never-mark-spam" help:"Never classify the imported message as spam"`
+	ProcessForCalendar bool     `name:"process-for-calendar" help:"Process calendar invitations in the imported message"`
+}
+
+type gmailImportPlan struct {
+	Source             string   `json:"source"`
+	Bytes              int      `json:"bytes"`
+	Subject            string   `json:"subject,omitempty"`
+	From               string   `json:"from,omitempty"`
+	To                 string   `json:"to,omitempty"`
+	Date               string   `json:"date,omitempty"`
+	MessageID          string   `json:"message_id,omitempty"`
+	Labels             []string `json:"labels,omitempty"`
+	InternalDateSource string   `json:"internal_date_source"`
+	NeverMarkSpam      bool     `json:"never_mark_spam"`
+	ProcessForCalendar bool     `json:"process_for_calendar"`
+}
+
+func (c *GmailImportCmd) Run(ctx context.Context, flags *RootFlags) error {
+	raw, plan, err := c.readAndPlan(ctx)
+	if err != nil {
+		return err
+	}
+
+	if dryRunErr := dryRunExit(ctx, flags, "gmail.import", plan); dryRunErr != nil {
+		return dryRunErr
+	}
+	if googleapi.ReadOnly(ctx) {
+		return fmt.Errorf("%w: Gmail message import is disabled", googleapi.ErrReadOnly)
+	}
+
+	account, err := requireAccount(flags)
+	if err != nil {
+		return err
+	}
+	svc, err := gmailService(ctx, account)
+	if err != nil {
+		return err
+	}
+
+	labelIDs := []string(nil)
+	if len(c.Labels) > 0 {
+		nameToID, labelsErr := fetchLabelNameToID(svc)
+		if labelsErr != nil {
+			return labelsErr
+		}
+		labelIDs = resolveLabelIDs(c.Labels, nameToID)
+	}
+
+	call := svc.Users.Messages.Import("me", &gmail.Message{LabelIds: labelIDs}).
+		InternalDateSource(c.InternalDateSource).
+		Media(bytes.NewReader(raw), gapi.ContentType("message/rfc822")).
+		Context(ctx)
+	if c.NeverMarkSpam {
+		call = call.NeverMarkSpam(true)
+	}
+	if c.ProcessForCalendar {
+		call = call.ProcessForCalendar(true)
+	}
+
+	message, err := call.Do()
+	if err != nil {
+		return err
+	}
+	return writeGmailImportResult(ctx, message)
+}
+
+func (c *GmailImportCmd) readAndPlan(ctx context.Context) ([]byte, gmailImportPlan, error) {
+	source := strings.TrimSpace(c.File)
+	if source == "" {
+		return nil, gmailImportPlan{}, usage("RFC822/EML file is required")
+	}
+
+	var (
+		raw []byte
+		err error
+	)
+	if source == "-" {
+		raw, err = io.ReadAll(stdinReader(ctx))
+	} else {
+		path, expandErr := config.ExpandPath(source)
+		if expandErr != nil {
+			return nil, gmailImportPlan{}, expandErr
+		}
+		raw, err = os.ReadFile(path) //nolint:gosec // user-provided import path
+	}
+	if err != nil {
+		return nil, gmailImportPlan{}, err
+	}
+	if len(raw) == 0 {
+		return nil, gmailImportPlan{}, usage("RFC822/EML input is empty")
+	}
+
+	message, err := mail.ReadMessage(bytes.NewReader(raw))
+	if err != nil {
+		return nil, gmailImportPlan{}, usagef("invalid RFC822/EML input: %v", err)
+	}
+	plan := gmailImportPlan{
+		Source:             source,
+		Bytes:              len(raw),
+		Subject:            message.Header.Get("Subject"),
+		From:               message.Header.Get("From"),
+		To:                 message.Header.Get("To"),
+		Date:               message.Header.Get("Date"),
+		MessageID:          message.Header.Get("Message-ID"),
+		Labels:             normalizedImportLabels(c.Labels),
+		InternalDateSource: c.InternalDateSource,
+		NeverMarkSpam:      c.NeverMarkSpam,
+		ProcessForCalendar: c.ProcessForCalendar,
+	}
+	return raw, plan, nil
+}
+
+func normalizedImportLabels(labels []string) []string {
+	if len(labels) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(labels))
+	for _, label := range labels {
+		if label = strings.TrimSpace(label); label != "" {
+			out = append(out, label)
+		}
+	}
+	return out
+}
+
+func writeGmailImportResult(ctx context.Context, message *gmail.Message) error {
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(ctx, stdoutWriter(ctx), map[string]any{
+			"messageId":    message.Id,
+			"threadId":     message.ThreadId,
+			"labelIds":     message.LabelIds,
+			"internalDate": message.InternalDate,
+		})
+	}
+	u := ui.FromContext(ctx)
+	u.Out().Linef("message_id\t%s", message.Id)
+	if message.ThreadId != "" {
+		u.Out().Linef("thread_id\t%s", message.ThreadId)
+	}
+	return nil
+}

--- a/internal/cmd/gmail_import_test.go
+++ b/internal/cmd/gmail_import_test.go
@@ -126,8 +126,8 @@ func TestGmailImportUploadsMessageAndOptions(t *testing.T) {
 				return
 			}
 			var metadata gmail.Message
-			if err := json.NewDecoder(metadataPart).Decode(&metadata); err != nil {
-				t.Errorf("decode metadata: %v", err)
+			if decodeErr := json.NewDecoder(metadataPart).Decode(&metadata); decodeErr != nil {
+				t.Errorf("decode metadata: %v", decodeErr)
 				return
 			}
 			if len(metadata.LabelIds) != 1 || metadata.LabelIds[0] != "Label_42" {

--- a/internal/cmd/gmail_import_test.go
+++ b/internal/cmd/gmail_import_test.go
@@ -1,0 +1,207 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/gmail/v1"
+
+	"github.com/steipete/gogcli/internal/app"
+	"github.com/steipete/gogcli/internal/googleapi"
+	"github.com/steipete/gogcli/internal/outfmt"
+)
+
+const testImportEML = "From: Sender <sender@example.com>\r\n" +
+	"To: Receiver <receiver@example.com>\r\n" +
+	"Subject: Import test\r\n" +
+	"Date: Wed, 06 Aug 2026 12:34:56 +0000\r\n" +
+	"Message-ID: <import-test@example.com>\r\n" +
+	"Content-Type: text/plain; charset=utf-8\r\n" +
+	"\r\n" +
+	"synthetic body\r\n"
+
+func TestGmailImportDryRunParsesFileWithoutAuth(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "message.eml")
+	if err := os.WriteFile(path, []byte(testImportEML), 0o600); err != nil {
+		t.Fatalf("write EML: %v", err)
+	}
+
+	result := executeWithTestRuntime(t, []string{
+		"--dry-run", "--json", "gmail", "import", path,
+		"--label", "Inbox/Test", "--internal-date-source", "receivedTime",
+		"--never-mark-spam", "--process-for-calendar",
+	}, &app.Runtime{})
+	if result.err != nil {
+		t.Fatalf("dry-run import: %v\nstderr=%s", result.err, result.stderr)
+	}
+
+	var got struct {
+		DryRun  bool   `json:"dry_run"`
+		Op      string `json:"op"`
+		Request struct {
+			Bytes              int      `json:"bytes"`
+			Subject            string   `json:"subject"`
+			MessageID          string   `json:"message_id"`
+			Labels             []string `json:"labels"`
+			InternalDateSource string   `json:"internal_date_source"`
+			NeverMarkSpam      bool     `json:"never_mark_spam"`
+			ProcessForCalendar bool     `json:"process_for_calendar"`
+		} `json:"request"`
+	}
+	if err := json.Unmarshal([]byte(result.stdout), &got); err != nil {
+		t.Fatalf("decode dry-run: %v\n%s", err, result.stdout)
+	}
+	if !got.DryRun || got.Op != "gmail.import" || got.Request.Bytes != len(testImportEML) {
+		t.Fatalf("unexpected dry-run envelope: %#v", got)
+	}
+	if got.Request.Subject != "Import test" || got.Request.MessageID != "<import-test@example.com>" {
+		t.Fatalf("unexpected parsed headers: %#v", got.Request)
+	}
+	if len(got.Request.Labels) != 1 || got.Request.Labels[0] != "Inbox/Test" || got.Request.InternalDateSource != "receivedTime" || !got.Request.NeverMarkSpam || !got.Request.ProcessForCalendar {
+		t.Fatalf("unexpected options: %#v", got.Request)
+	}
+}
+
+func TestGmailImportDryRunReadsStdin(t *testing.T) {
+	var out bytes.Buffer
+	ctx := newCmdRuntimeIOContext(t, strings.NewReader(testImportEML), &out, io.Discard)
+	ctx = outfmt.WithMode(ctx, outfmt.Mode{JSON: true})
+	err := (&GmailImportCmd{File: "-", InternalDateSource: "dateHeader"}).Run(ctx, &RootFlags{DryRun: true})
+	if ExitCode(err) != 0 {
+		t.Fatalf("stdin dry-run: %v", err)
+	}
+	var got struct {
+		Request struct {
+			Source  string `json:"source"`
+			Subject string `json:"subject"`
+		} `json:"request"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil || got.Request.Source != "-" || got.Request.Subject != "Import test" {
+		t.Fatalf("unexpected stdin dry-run: err=%v value=%#v output=%s", err, got, out.String())
+	}
+}
+
+func TestGmailImportRejectsInvalidRFC822(t *testing.T) {
+	ctx := newCmdRuntimeIOContext(t, strings.NewReader("not a header\r\n\r\nbody"), io.Discard, io.Discard)
+	err := (&GmailImportCmd{File: "-", InternalDateSource: "dateHeader"}).Run(ctx, &RootFlags{DryRun: true})
+	if err == nil || !strings.Contains(err.Error(), "invalid RFC822/EML input") {
+		t.Fatalf("error = %v, want invalid RFC822/EML input", err)
+	}
+}
+
+func TestGmailImportUploadsMessageAndOptions(t *testing.T) {
+	var imported []byte
+	svc, cleanup := newGmailServiceForTest(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/gmail/v1/users/me/labels":
+			_ = json.NewEncoder(w).Encode(map[string]any{"labels": []map[string]string{{"id": "Label_42", "name": "Imported"}}})
+		case r.Method == http.MethodPost && r.URL.Path == "/upload/gmail/v1/users/me/messages/import":
+			if got := r.URL.Query().Get("internalDateSource"); got != "receivedTime" {
+				t.Errorf("internalDateSource = %q", got)
+			}
+			if r.URL.Query().Get("neverMarkSpam") != "true" || r.URL.Query().Get("processForCalendar") != "true" {
+				t.Errorf("missing import boolean options: %s", r.URL.RawQuery)
+			}
+			mediaType, params, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+			if err != nil || mediaType != "multipart/related" {
+				t.Errorf("content type = %q, err=%v", mediaType, err)
+				http.Error(w, "bad multipart", http.StatusBadRequest)
+				return
+			}
+			reader := multipart.NewReader(r.Body, params["boundary"])
+			metadataPart, err := reader.NextPart()
+			if err != nil {
+				t.Errorf("metadata part: %v", err)
+				return
+			}
+			var metadata gmail.Message
+			if err := json.NewDecoder(metadataPart).Decode(&metadata); err != nil {
+				t.Errorf("decode metadata: %v", err)
+				return
+			}
+			if len(metadata.LabelIds) != 1 || metadata.LabelIds[0] != "Label_42" {
+				t.Errorf("label IDs = %v", metadata.LabelIds)
+			}
+			messagePart, err := reader.NextPart()
+			if err != nil {
+				t.Errorf("message part: %v", err)
+				return
+			}
+			imported, err = io.ReadAll(messagePart)
+			if err != nil {
+				t.Errorf("read message part: %v", err)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id": "m-imported", "threadId": "t-imported", "labelIds": []string{"Label_42"}, "internalDate": "1786019696000",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	})
+	defer cleanup()
+
+	var out bytes.Buffer
+	ctx := newCmdRuntimeJSONOutputContext(t, &out, io.Discard)
+	ctx = withGmailTestService(ctx, svc)
+	err := (&GmailImportCmd{
+		File: testWriteImportEML(t), Labels: []string{"Imported"}, InternalDateSource: "receivedTime",
+		NeverMarkSpam: true, ProcessForCalendar: true,
+	}).Run(ctx, &RootFlags{Account: "test@example.com"})
+	if err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if string(imported) != testImportEML {
+		t.Fatalf("imported bytes changed:\n%q", imported)
+	}
+	var got struct {
+		MessageID string `json:"messageId"`
+		ThreadID  string `json:"threadId"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil || got.MessageID != "m-imported" || got.ThreadID != "t-imported" {
+		t.Fatalf("unexpected output: err=%v value=%#v output=%s", err, got, out.String())
+	}
+}
+
+func TestGmailImportReadOnlyBlocksBeforeAuth(t *testing.T) {
+	ctx := googleapi.WithReadOnly(context.Background(), true)
+	err := (&GmailImportCmd{File: testWriteImportEML(t), InternalDateSource: "dateHeader"}).Run(ctx, &RootFlags{Account: "test@example.com"})
+	if !errors.Is(err, googleapi.ErrReadOnly) {
+		t.Fatalf("error = %v, want ErrReadOnly", err)
+	}
+}
+
+func TestGmailImportHonorsExactCommandAllowlist(t *testing.T) {
+	path := testWriteImportEML(t)
+	allowed := executeWithTestRuntime(t, []string{
+		"--enable-commands-exact", "gmail.import", "--dry-run", "gmail", "import", path,
+	}, &app.Runtime{})
+	if allowed.err != nil {
+		t.Fatalf("allowed import: %v", allowed.err)
+	}
+	blocked := executeWithTestRuntime(t, []string{
+		"--enable-commands-exact", "gmail.search", "--dry-run", "gmail", "import", path,
+	}, &app.Runtime{})
+	if blocked.err == nil || !strings.Contains(blocked.err.Error(), "not enabled") {
+		t.Fatalf("blocked import error = %v", blocked.err)
+	}
+}
+
+func testWriteImportEML(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "message.eml")
+	if err := os.WriteFile(path, []byte(testImportEML), 0o600); err != nil {
+		t.Fatalf("write EML: %v", err)
+	}
+	return path
+}

--- a/safety-profiles/agent-safe.yaml
+++ b/safety-profiles/agent-safe.yaml
@@ -31,6 +31,7 @@ gmail:
   unread: true
   trash: false
   send: false
+  import: false
   autoreply: false
   track: false
   drafts:

--- a/safety-profiles/readonly.yaml
+++ b/safety-profiles/readonly.yaml
@@ -33,6 +33,7 @@ gmail:
   unread: false
   trash: false
   send: false
+  import: false
   autoreply: false
   track: false
   drafts:

--- a/scripts/live-tests/gmail.sh
+++ b/scripts/live-tests/gmail.sh
@@ -53,6 +53,27 @@ run_gmail_tests() {
   run_required "gmail" "gmail labels list" gog gmail labels list --json >/dev/null
   run_required "gmail" "gmail labels get" gog gmail labels get INBOX --json >/dev/null
 
+  local import_eml import_subject import_json import_msg_id import_thread_id import_readback
+  import_eml="$LIVE_TMP/gmail-import-$TS.eml"
+  import_subject="gogcli synthetic import $TS"
+  printf 'From: gogcli live test <%s>\r\nTo: %s\r\nSubject: %s\r\nDate: Thu, 06 Aug 2026 12:34:56 +0000\r\nMessage-ID: <gogcli-import-%s@gogcli.test>\r\nMIME-Version: 1.0\r\nContent-Type: text/plain; charset=utf-8\r\n\r\nSynthetic RFC822 import proof.\r\n' \
+    "$ACCOUNT" "$ACCOUNT" "$import_subject" "$TS" >"$import_eml"
+  run_required "gmail-import" "gmail import dry-run" gog --dry-run gmail import "$import_eml" \
+    --label STARRED --internal-date-source dateHeader --never-mark-spam --process-for-calendar --json >/dev/null
+  import_json=$(gog gmail import "$import_eml" --label STARRED \
+    --internal-date-source dateHeader --never-mark-spam --process-for-calendar --json)
+  import_msg_id=$(extract_field "$import_json" messageId)
+  import_thread_id=$(extract_field "$import_json" threadId)
+  [ -n "$import_msg_id" ] || { echo "Failed to parse imported Gmail message id" >&2; exit 1; }
+  [ -n "$import_thread_id" ] || { echo "Failed to parse imported Gmail thread id" >&2; exit 1; }
+  register_gmail_thread_cleanup "$import_thread_id"
+  import_readback=$(gog gmail get "$import_msg_id" --format metadata --json)
+  "$PY" -c 'import json,sys
+obj=json.load(sys.stdin)
+assert obj.get("headers", {}).get("subject") == sys.argv[1]
+assert "STARRED" in obj.get("message", {}).get("labelIds", [])' \
+    "$import_subject" <<<"$import_readback"
+
   if ! skip "gmail-settings"; then
     local sendas_json sendas_email
     echo "==> gmail settings sendas list"


### PR DESCRIPTION
## Summary

- add `gog gmail import <file|->` for one RFC822/EML message
- expose label, internal-date, spam, and calendar-processing controls from Gmail's import API
- parse message headers during dry-run without touching auth, and preserve readonly/command-policy guards
- document the narrow surface and add generated command, unit, safety-profile, and live-harness coverage

This intentionally does not add IMAP fetching, mailbox synchronization, or bulk migration orchestration.

Closes #956.

## Proof

- `go test ./internal/cmd -run 'TestGmailImport' -count=1`
- `make ci`
- source-blind CLI behavior validation for help/docs, file/stdin dry-run, varied input, malformed/empty input, readonly, and exact allowlists
- autoreview clean with no accepted/actionable findings

Live Gmail import/readback remains a pre-merge gate; the execution host currently has no authorized test account.
