### PR TITLE
fix(gmail): redact embedded credentials in watch hook URL output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Security: redact credentials embedded in Gmail watch hook URLs, including userinfo, path, query, and fragment components, unless `--show-secrets` is set. (#960) — thanks @bunlongheng.
 - Gmail: add guarded single-message RFC822/EML import from a file or stdin, with labels, internal-date, spam, calendar-processing, and parse-only dry-run controls. (#956) — thanks @holgergruenhagen.
 - Gmail: warn before a draft update replaces an existing rich-text body with plain text only, while keeping JSON stdout clean. (#955) — thanks @mcinteerj.
 - Dependencies: update the Google API and OpenTelemetry stacks, Go developer tools, pnpm, and email-tracking worker toolchain to their latest policy-eligible releases.

--- a/internal/cmd/gmail_watch_cmds.go
+++ b/internal/cmd/gmail_watch_cmds.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"net"
 	"net/http"
-	"net/url"
+	neturl "net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -525,7 +525,7 @@ func redactHookURL(raw string) string {
 	if strings.TrimSpace(raw) == "" {
 		return raw
 	}
-	parsed, err := url.Parse(raw)
+	parsed, err := neturl.Parse(raw)
 	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
 		return "[REDACTED]"
 	}

--- a/internal/cmd/gmail_watch_cmds.go
+++ b/internal/cmd/gmail_watch_cmds.go
@@ -518,42 +518,22 @@ func writeWatchState(ctx context.Context, state gmailWatchState, showSecrets boo
 	return nil
 }
 
-// redactHookURL strips credentials that can be embedded in a webhook URL so the
-// hook URL can be shown in `gmail watch status` output without leaking secrets.
-// It removes userinfo (https://user:pass@host), query values (e.g. ?token=...),
-// and any fragment, while keeping the scheme, host, and path visible so the
-// destination stays recognizable. URLs without embedded credentials are returned
-// unchanged. Mirrors the git remote URL redaction used elsewhere in the CLI.
+// redactHookURL keeps only the origin of a webhook URL. Webhook providers place
+// credentials in userinfo, paths, queries, and fragments, so preserving any of
+// those components would make the default status output unsafe to share.
 func redactHookURL(raw string) string {
+	if strings.TrimSpace(raw) == "" {
+		return raw
+	}
 	parsed, err := url.Parse(raw)
 	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
-		return raw
+		return "[REDACTED]"
 	}
 
-	redacted := false
-	if parsed.User != nil {
-		parsed.User = url.User("redacted")
-		redacted = true
-	}
-	if parsed.RawQuery != "" {
-		query := parsed.Query()
-		for key, values := range query {
-			for i := range values {
-				values[i] = "redacted"
-			}
-			query[key] = values
-		}
-		parsed.RawQuery = query.Encode()
-		redacted = true
-	}
-	if parsed.Fragment != "" {
-		parsed.Fragment = "redacted"
-		redacted = true
-	}
-	if !redacted {
+	if parsed.User == nil && parsed.Path == "" && parsed.RawQuery == "" && parsed.Fragment == "" {
 		return raw
 	}
-	return parsed.String()
+	return parsed.Scheme + "://" + parsed.Host + "/[REDACTED]"
 }
 
 func buildWatchState(account, topic string, labels []string, resp *gmail.WatchResponse, ttl time.Duration, hook *gmailWatchHook) (gmailWatchState, error) {

--- a/internal/cmd/gmail_watch_cmds.go
+++ b/internal/cmd/gmail_watch_cmds.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -436,10 +437,13 @@ func (c *GmailWatchServeCmd) Run(ctx context.Context, kctx *kong.Context, flags 
 
 func writeWatchState(ctx context.Context, state gmailWatchState, showSecrets bool) error {
 	if outfmt.IsJSON(ctx) {
-		if !showSecrets && state.Hook != nil && state.Hook.Token != "" {
+		if !showSecrets && state.Hook != nil {
 			redacted := state
 			h := *state.Hook
-			h.Token = "[REDACTED]"
+			if h.Token != "" {
+				h.Token = "[REDACTED]"
+			}
+			h.URL = redactHookURL(h.URL)
 			redacted.Hook = &h
 			return outfmt.WriteJSON(ctx, stdoutWriter(ctx), map[string]any{"watch": redacted})
 		}
@@ -465,7 +469,11 @@ func writeWatchState(ctx context.Context, state gmailWatchState, showSecrets boo
 		u.Out().Linef("updated_at\t%s", formatUnixMillis(state.UpdatedAtMs))
 	}
 	if state.Hook != nil {
-		u.Out().Linef("hook_url\t%s", state.Hook.URL)
+		hookURL := state.Hook.URL
+		if !showSecrets {
+			hookURL = redactHookURL(hookURL)
+		}
+		u.Out().Linef("hook_url\t%s", hookURL)
 		if state.Hook.IncludeBody {
 			u.Out().Linef("hook_include_body\ttrue")
 		}
@@ -508,6 +516,44 @@ func writeWatchState(ctx context.Context, state gmailWatchState, showSecrets boo
 		u.Out().Linef("auth_failure_reason\t%s", state.AuthFailureReason)
 	}
 	return nil
+}
+
+// redactHookURL strips credentials that can be embedded in a webhook URL so the
+// hook URL can be shown in `gmail watch status` output without leaking secrets.
+// It removes userinfo (https://user:pass@host), query values (e.g. ?token=...),
+// and any fragment, while keeping the scheme, host, and path visible so the
+// destination stays recognizable. URLs without embedded credentials are returned
+// unchanged. Mirrors the git remote URL redaction used elsewhere in the CLI.
+func redactHookURL(raw string) string {
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return raw
+	}
+
+	redacted := false
+	if parsed.User != nil {
+		parsed.User = url.User("redacted")
+		redacted = true
+	}
+	if parsed.RawQuery != "" {
+		query := parsed.Query()
+		for key, values := range query {
+			for i := range values {
+				values[i] = "redacted"
+			}
+			query[key] = values
+		}
+		parsed.RawQuery = query.Encode()
+		redacted = true
+	}
+	if parsed.Fragment != "" {
+		parsed.Fragment = "redacted"
+		redacted = true
+	}
+	if !redacted {
+		return raw
+	}
+	return parsed.String()
 }
 
 func buildWatchState(account, topic string, labels []string, resp *gmail.WatchResponse, ttl time.Duration, hook *gmailWatchHook) (gmailWatchState, error) {

--- a/internal/cmd/gmail_watch_helpers_test.go
+++ b/internal/cmd/gmail_watch_helpers_test.go
@@ -129,7 +129,7 @@ func TestWriteWatchState_TextAndJSON(t *testing.T) {
 	if !strings.Contains(textOut, "account\ta@b.com") {
 		t.Fatalf("expected account output")
 	}
-	if !strings.Contains(textOut, "hook_url\thttp://example.com/hook") {
+	if !strings.Contains(textOut, "hook_url\thttp://example.com/[REDACTED]") {
 		t.Fatalf("expected hook output")
 	}
 
@@ -150,8 +150,8 @@ func TestWriteWatchState_TextAndJSON(t *testing.T) {
 	if err := json.Unmarshal([]byte(jsonOut), &parsed); err != nil {
 		t.Fatalf("json parse: %v", err)
 	}
-	if parsed.Watch.Hook == nil || parsed.Watch.Hook.URL == "" {
-		t.Fatalf("expected hook in json")
+	if parsed.Watch.Hook == nil || parsed.Watch.Hook.URL != "http://example.com/[REDACTED]" {
+		t.Fatalf("expected redacted hook in json")
 	}
 }
 

--- a/internal/cmd/gmail_watch_redact_test.go
+++ b/internal/cmd/gmail_watch_redact_test.go
@@ -123,6 +123,12 @@ func TestWriteWatchState_TokenRedaction(t *testing.T) {
 }
 
 func TestWriteWatchState_HookURLCredentialRedaction(t *testing.T) {
+	password := "example-" + "password"
+	queryToken := "example-" + "query-token"
+	pathToken := "example-" + "path-token"
+	basicAuthURL := "https://alice:" + password + "@example.com/hook"
+	credentialURL := "https://alice:" + password + "@example.com/hooks/" + pathToken + "?token=" + queryToken
+
 	makeState := func(hookURL string) gmailWatchState {
 		return gmailWatchState{
 			Account:   "a@b.com",
@@ -152,39 +158,53 @@ func TestWriteWatchState_HookURLCredentialRedaction(t *testing.T) {
 	}
 
 	t.Run("userinfo password redacted by default", func(t *testing.T) {
-		out := run(t, makeState("https://alice:s3cr3tpass@example.com/hook"), false, false)
-		if strings.Contains(out, "s3cr3tpass") {
+		out := run(t, makeState(basicAuthURL), false, false)
+		if strings.Contains(out, password) {
 			t.Fatalf("basic-auth password leaked in hook URL: %s", out)
 		}
-		if !strings.Contains(out, "example.com/hook") {
-			t.Fatalf("host/path should remain visible, got: %s", out)
+		if !strings.Contains(out, "hook_url\thttps://example.com/[REDACTED]") {
+			t.Fatalf("expected recognizable redacted origin, got: %s", out)
 		}
 	})
 
 	t.Run("query token redacted by default", func(t *testing.T) {
-		out := run(t, makeState("https://example.com/hook?token=supersecretquerytoken"), false, false)
-		if strings.Contains(out, "supersecretquerytoken") {
+		out := run(t, makeState("https://example.com/hook?token="+queryToken), false, false)
+		if strings.Contains(out, queryToken) {
 			t.Fatalf("query token leaked in hook URL: %s", out)
 		}
 	})
 
-	t.Run("credential-free url unchanged", func(t *testing.T) {
-		out := run(t, makeState("https://example.com/hook"), false, false)
-		if !strings.Contains(out, "hook_url\thttps://example.com/hook") {
-			t.Fatalf("plain hook URL should be shown unchanged, got: %s", out)
+	t.Run("path credential redacted by default", func(t *testing.T) {
+		out := run(t, makeState("https://example.com/hooks/"+pathToken), false, false)
+		if strings.Contains(out, pathToken) || strings.Contains(out, "/hooks/") {
+			t.Fatalf("path credential leaked in hook URL: %s", out)
+		}
+	})
+
+	t.Run("origin-only url unchanged", func(t *testing.T) {
+		out := run(t, makeState("https://example.com"), false, false)
+		if !strings.Contains(out, "hook_url\thttps://example.com") {
+			t.Fatalf("origin-only hook URL should be shown unchanged, got: %s", out)
+		}
+	})
+
+	t.Run("malformed url fails closed", func(t *testing.T) {
+		out := run(t, makeState("opaque-secret-without-an-origin"), false, false)
+		if strings.Contains(out, "opaque-secret") || !strings.Contains(out, "hook_url\t[REDACTED]") {
+			t.Fatalf("malformed hook URL was not fully redacted: %s", out)
 		}
 	})
 
 	t.Run("show-secrets reveals full url", func(t *testing.T) {
-		out := run(t, makeState("https://alice:s3cr3tpass@example.com/hook?token=supersecretquerytoken"), true, false)
-		if !strings.Contains(out, "s3cr3tpass") || !strings.Contains(out, "supersecretquerytoken") {
+		out := run(t, makeState(credentialURL), true, false)
+		if !strings.Contains(out, password) || !strings.Contains(out, pathToken) || !strings.Contains(out, queryToken) {
 			t.Fatalf("--show-secrets should reveal full hook URL, got: %s", out)
 		}
 	})
 
 	t.Run("json output redacts url credentials by default", func(t *testing.T) {
-		out := run(t, makeState("https://alice:s3cr3tpass@example.com/hook?token=supersecretquerytoken"), false, true)
-		if strings.Contains(out, "s3cr3tpass") || strings.Contains(out, "supersecretquerytoken") {
+		out := run(t, makeState(credentialURL), false, true)
+		if strings.Contains(out, password) || strings.Contains(out, pathToken) || strings.Contains(out, queryToken) {
 			t.Fatalf("JSON output leaked hook URL credentials: %s", out)
 		}
 		var parsed map[string]json.RawMessage

--- a/internal/cmd/gmail_watch_redact_test.go
+++ b/internal/cmd/gmail_watch_redact_test.go
@@ -121,3 +121,75 @@ func TestWriteWatchState_TokenRedaction(t *testing.T) {
 		}
 	})
 }
+
+func TestWriteWatchState_HookURLCredentialRedaction(t *testing.T) {
+	makeState := func(hookURL string) gmailWatchState {
+		return gmailWatchState{
+			Account:   "a@b.com",
+			Topic:     "projects/p/topics/t",
+			HistoryID: "1",
+			Hook: &gmailWatchHook{
+				URL: hookURL,
+			},
+		}
+	}
+
+	run := func(t *testing.T, state gmailWatchState, showSecrets, jsonOut bool) string {
+		t.Helper()
+		return captureStdout(t, func() {
+			u, err := ui.New(ui.Options{Stdout: os.Stdout, Stderr: io.Discard, Color: "never"})
+			if err != nil {
+				t.Fatalf("ui.New: %v", err)
+			}
+			ctx := ui.WithUI(context.Background(), u)
+			if jsonOut {
+				ctx = outfmt.WithMode(ctx, outfmt.Mode{JSON: true})
+			}
+			if err := writeWatchState(ctx, state, showSecrets); err != nil {
+				t.Fatalf("writeWatchState: %v", err)
+			}
+		})
+	}
+
+	t.Run("userinfo password redacted by default", func(t *testing.T) {
+		out := run(t, makeState("https://alice:s3cr3tpass@example.com/hook"), false, false)
+		if strings.Contains(out, "s3cr3tpass") {
+			t.Fatalf("basic-auth password leaked in hook URL: %s", out)
+		}
+		if !strings.Contains(out, "example.com/hook") {
+			t.Fatalf("host/path should remain visible, got: %s", out)
+		}
+	})
+
+	t.Run("query token redacted by default", func(t *testing.T) {
+		out := run(t, makeState("https://example.com/hook?token=supersecretquerytoken"), false, false)
+		if strings.Contains(out, "supersecretquerytoken") {
+			t.Fatalf("query token leaked in hook URL: %s", out)
+		}
+	})
+
+	t.Run("credential-free url unchanged", func(t *testing.T) {
+		out := run(t, makeState("https://example.com/hook"), false, false)
+		if !strings.Contains(out, "hook_url\thttps://example.com/hook") {
+			t.Fatalf("plain hook URL should be shown unchanged, got: %s", out)
+		}
+	})
+
+	t.Run("show-secrets reveals full url", func(t *testing.T) {
+		out := run(t, makeState("https://alice:s3cr3tpass@example.com/hook?token=supersecretquerytoken"), true, false)
+		if !strings.Contains(out, "s3cr3tpass") || !strings.Contains(out, "supersecretquerytoken") {
+			t.Fatalf("--show-secrets should reveal full hook URL, got: %s", out)
+		}
+	})
+
+	t.Run("json output redacts url credentials by default", func(t *testing.T) {
+		out := run(t, makeState("https://alice:s3cr3tpass@example.com/hook?token=supersecretquerytoken"), false, true)
+		if strings.Contains(out, "s3cr3tpass") || strings.Contains(out, "supersecretquerytoken") {
+			t.Fatalf("JSON output leaked hook URL credentials: %s", out)
+		}
+		var parsed map[string]json.RawMessage
+		if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+			t.Fatalf("json parse: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

`gog gmail watch status` prints the configured webhook **hook URL verbatim** in both text and JSON output. Any credentials embedded in that URL are leaked in plaintext **even without `--show-secrets`**, which defeats the existing hook bearer-token redaction (landed in #136).

Leaked credential classes:
- **Basic-auth userinfo** - `https://user:pass@host/hook` (Go's `http.Client` uses this for `Authorization: Basic`, so it is a real, functional webhook credential).
- **Secret query params** - `https://host/hook?token=SECRET` (Slack-style and many webhook providers put the secret in the query string; the CLI's own `--token` help even documents `?token=`).

This is the same secret-leak class the project already guards against: the hook **bearer token** is redacted here, and git remote URLs are redacted via `redactGitURL` in `internal/backup/git.go`. The hook URL was simply missed.

## Fix

Add `redactHookURL` and apply it in `writeWatchState` (text + JSON paths) unless `--show-secrets` is passed. It strips **userinfo, query values, and fragment** while keeping **scheme/host/path** visible so the destination stays recognizable. Credential-free URLs are returned unchanged. This mirrors the existing `redactGitURL` behavior for consistency.

- Minimal change, no API/flag/schema changes.
- `--show-secrets` still reveals the full URL (unchanged escape hatch).

## Reproduction / Evidence

Test added to the existing `internal/cmd/gmail_watch_redact_test.go`.

**Before the fix** (source reverted to `main`, new test kept) - credentials leak:

```
--- FAIL: TestWriteWatchState_HookURLCredentialRedaction/userinfo_password_redacted_by_default
    gmail_watch_redact_test.go:157: basic-auth password leaked in hook URL
--- FAIL: TestWriteWatchState_HookURLCredentialRedaction/query_token_redacted_by_default
    gmail_watch_redact_test.go:167: query token leaked in hook URL
--- FAIL: TestWriteWatchState_HookURLCredentialRedaction/json_output_redacts_url_credentials_by_default
    gmail_watch_redact_test.go:188: JSON output leaked hook URL credentials
```

**After the fix** - all pass:

```
ok  github.com/steipete/gogcli/internal/cmd
--- PASS: TestWriteWatchState_HookURLCredentialRedaction (userinfo/query/json/plain-url/show-secrets)
--- PASS: TestWriteWatchState_TokenRedaction (existing suite unchanged)
```

## Verification

```
go build ./internal/cmd/    # ok
go vet ./internal/cmd/      # ok
gofmt -l ...                # clean
go test ./internal/cmd/ -run 'TestWriteWatchState|Watch'   # ok
```

## Why it matters

`gogcli` is designed to be driven by agents and scripts; `watch status` output routinely lands in logs, transcripts, and shared terminals. A hook URL with embedded credentials should be treated exactly like the bearer token it sits next to.
