### PR TITLE
feat(gmail): env-configure --auto-from-addressed-alias via GOG_GMAIL_AUTO_FROM_ADDRESSED_ALIAS

### DIFF
--- a/internal/cmd/gmail_auto_from_env_test.go
+++ b/internal/cmd/gmail_auto_from_env_test.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestGmailAutoFromAddressedAliasEnvDefaults(t *testing.T) {
+	t.Setenv("GOG_GMAIL_AUTO_FROM_ADDRESSED_ALIAS", "1")
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "reply", args: []string{"gmail", "reply", "m1", "--body", "hello"}},
+		{name: "reply all", args: []string{"gmail", "reply-all", "m1", "--body", "hello"}},
+		{name: "draft create", args: []string{"gmail", "drafts", "create", "--to", "you@example.com", "--subject", "subject", "--body", "hello"}},
+		{name: "draft update", args: []string{"gmail", "drafts", "update", "d1", "--subject", "subject", "--body", "hello"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			args := append([]string{"--json", "--dry-run"}, tc.args...)
+			result := executeWithTestRuntime(t, args, nil)
+			if result.err != nil {
+				t.Fatalf("Execute: %v\nstderr=%q", result.err, result.stderr)
+			}
+			var output struct {
+				Request struct {
+					AutoFromAddressedAlias bool `json:"auto_from_addressed_alias"`
+				} `json:"request"`
+			}
+			if err := json.Unmarshal([]byte(result.stdout), &output); err != nil {
+				t.Fatalf("decode: %v\nout=%q", err, result.stdout)
+			}
+			if !output.Request.AutoFromAddressedAlias {
+				t.Fatalf("environment default was not applied: %s", result.stdout)
+			}
+		})
+	}
+}

--- a/internal/cmd/gmail_drafts.go
+++ b/internal/cmd/gmail_drafts.go
@@ -267,7 +267,7 @@ type GmailDraftsCreateCmd struct {
 	Quote                  bool     `name:"quote" help:"Include quoted original message in reply (requires --reply-to-message-id or --thread-id)"`
 	Attach                 []string `name:"attach" help:"Attachment file path (repeatable)"`
 	From                   string   `name:"from" help:"Send from this email address (must be a verified send-as alias)"`
-	AutoFromAddressedAlias bool     `name:"auto-from-addressed-alias" help:"When --from is omitted, reply from the verified send-as alias addressed by the original message"`
+	AutoFromAddressedAlias bool     `name:"auto-from-addressed-alias" help:"When --from is omitted, reply from the verified send-as alias addressed by the original message" env:"GOG_GMAIL_AUTO_FROM_ADDRESSED_ALIAS"`
 }
 
 type draftComposeInput struct {
@@ -777,7 +777,7 @@ type GmailDraftsUpdateCmd struct {
 	//nolint:lll // flag help text
 	ClearReplyContext      bool   `name:"clear-reply-context" help:"Strip In-Reply-To/References from the draft, making it a standalone message. By default an update preserves the draft's existing reply headers."`
 	From                   string `name:"from" help:"Send from this email address (must be a verified send-as alias)"`
-	AutoFromAddressedAlias bool   `name:"auto-from-addressed-alias" help:"When --from is omitted, reply from the verified send-as alias addressed by the original message"`
+	AutoFromAddressedAlias bool   `name:"auto-from-addressed-alias" help:"When --from is omitted, reply from the verified send-as alias addressed by the original message" env:"GOG_GMAIL_AUTO_FROM_ADDRESSED_ALIAS"`
 }
 
 func (c *GmailDraftsUpdateCmd) Run(ctx context.Context, flags *RootFlags) error {

--- a/internal/cmd/gmail_reply_commands.go
+++ b/internal/cmd/gmail_reply_commands.go
@@ -33,7 +33,7 @@ type GmailReplyOptions struct {
 	NoQuote                bool     `name:"no-quote" help:"Do not include the original message below the reply"`
 	Attach                 []string `name:"attach" sep:"none" help:"Attachment file path (repeatable)"`
 	From                   string   `name:"from" help:"Send from this email address (must be a verified send-as alias)"`
-	AutoFromAddressedAlias bool     `name:"auto-from-addressed-alias" help:"When --from is omitted, reply from the verified send-as alias addressed by the original message"`
+	AutoFromAddressedAlias bool     `name:"auto-from-addressed-alias" help:"When --from is omitted, reply from the verified send-as alias addressed by the original message" env:"GOG_GMAIL_AUTO_FROM_ADDRESSED_ALIAS"`
 	Signature              bool     `name:"signature" help:"Append the Gmail signature from the active send-as address"`
 	SignatureFrom          string   `name:"signature-from" help:"Append the Gmail signature from this send-as email address"`
 	SignatureFile          string   `name:"signature-file" help:"Append a local signature file (plain text or HTML)"`


### PR DESCRIPTION
## Summary

Adds `GOG_GMAIL_AUTO_FROM_ADDRESSED_ALIAS` as an environment default for the existing `--auto-from-addressed-alias` option, so agents and wrappers can enable the policy without appending a flag to every invocation.

The environment default applies to the four command paths that already own the option and sender-selection behavior:

- `gmail reply`
- `gmail reply-all`
- `gmail drafts create`
- `gmail drafts update`

It does **not** add support to `gmail forward`. No behavior changes when the variable is unset, and an explicit `--from` retains its existing precedence.

## Motivation

A bridge that consistently wants replies to use the verified send-as alias addressed by the original message currently has to pass `--auto-from-addressed-alias` on every supported command. The environment default follows gogcli's existing env-backed Gmail option conventions without creating a new sender-selection path.

## Testing

- Added `TestGmailAutoFromAddressedAliasEnvDefaults`, covering env parsing for all four supported commands.
- Existing sender-selection tests cover addressed-alias selection, account-default fallback, and explicit `--from` precedence.
- `make ci` passes.

## Built-binary proof

The signed current-head binary was exercised source-blind with JSON dry runs:

- Env enabled: all four plans reported `auto_from_addressed_alias: true`.
- Env unset: all four plans reported `false`.
- Env enabled plus explicit `--from`: the plan retained both the enabled option and explicit sender input.
- No Google API call or message send occurred.

Provider-level alias proof is unavailable on the current test host because none of its healthy authenticated Gmail accounts exposes a verified non-primary send-as alias. The provider selection path itself is unchanged from the existing explicit flag.
