### PR TITLE
docs: note the interim go install path after the module rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,15 @@ go install github.com/openclaw/gogcli/cmd/gog@latest
 gog --version
 ```
 
+The module path moved from `github.com/steipete/gogcli` to
+`github.com/openclaw/gogcli`. Until the first release tagged after that move is
+published, `@latest` still selects an older tag that declares the previous path
+and fails; install a specific version from the old path in the meantime:
+
+```bash
+go install github.com/steipete/gogcli/cmd/gog@v0.34.2
+```
+
 Docker images, Windows archives, raw macOS/Linux binaries, and source builds
 are covered in the [install guide](docs/install.md).
 


### PR DESCRIPTION
The module rename landed in #970, but `go install github.com/openclaw/gogcli/cmd/gog@latest` fails today: `@latest` still resolves v0.34.2, which declares the old module path.

Verified locally:

- `@latest` (new path) → `module declares its path as: github.com/steipete/gogcli`
- `@main` via the public proxy → same error from a stale cached pseudo-version
- `@main` with `GOPROXY=direct` → resolves `v0.34.3-0.20260809060808-342ffd1f8be9` and runs
- `go install github.com/steipete/gogcli/cmd/gog@v0.34.2` → works, reports v0.34.2

This documents the working pinned command until the first post-rename tag ships, so the README does not carry an instruction that fails. The `@latest` line stays as the steady-state form.