### PR TITLE
chore(release): open 0.35.1 Unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.35.1 - Unreleased
+
+- No unreleased changes.
+
 ## 0.35.0 - 2026-08-09
 
 - Install: move the Go module to `github.com/openclaw/gogcli`; new releases install with `go install github.com/openclaw/gogcli/cmd/gog@latest` instead of the former `github.com/steipete/gogcli` path.


### PR DESCRIPTION
v0.35.0 published successfully, but job 8 ("Open next Unreleased PR") was skipped because job 7 (Homebrew handoff) failed on the known TAP_TOKEN 403. This restores the changelog closeout the release process expects.

No functional change.