### PR TITLE
build: move Go floor to 1.26.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # syntax=docker/dockerfile:1.7
 
-ARG GO_VERSION=1.26.5
+ARG GO_VERSION=1.26.6
 ARG ALPINE_VERSION=3.24
 
-FROM golang:${GO_VERSION}-alpine AS build
+FROM golang:${GO_VERSION}-alpine@sha256:af8d6740070b8906d12eae1c3e3ea0957fb63f492051ea05e354c38ef9fe88df AS build
 
 RUN apk add --no-cache ca-certificates git tzdata
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openclaw/gogcli
 
-go 1.26.5
+go 1.26.6
 
 require (
 	cloud.google.com/go/pubsub/v2 v2.6.1

--- a/scripts/release-local
+++ b/scripts/release-local
@@ -295,7 +295,7 @@ prepare_official_go_environment() {
 
   tool_root="$work_dir/pinned-release-tools"
   /bin/mkdir -p "$tool_root/goreleaser"
-  go_archive_name="go1.26.5.darwin-${expected_goarch}.tar.gz"
+  go_archive_name="go1.26.6.darwin-${expected_goarch}.tar.gz"
   goreleaser_archive_name="goreleaser_Darwin_${goreleaser_arch}.tar.gz"
   release_go_archive="$tool_root/$go_archive_name"
   release_goreleaser_archive="$tool_root/$goreleaser_archive_name"
@@ -328,8 +328,8 @@ prepare_official_go_environment() {
   go_version=$(/usr/bin/env -i GOROOT= GO111MODULE=on GOAUTH=off GOCACHEPROG= GOENV=off \
     GOEXPERIMENT= GOFLAGS= GOFIPS140=off GOTOOLCHAIN=local \
     "$release_go_bin" version)
-  [[ "$go_version" == "go version go1.26.5 darwin/$expected_goarch" ]] || {
-    echo "release: official builds require native Go 1.26.5" >&2
+  [[ "$go_version" == "go version go1.26.6 darwin/$expected_goarch" ]] || {
+    echo "release: official builds require native Go 1.26.6" >&2
     exit 1
   }
   goreleaser_version=$(/usr/bin/env -i "$release_goreleaser_bin" --version)

--- a/scripts/test-release-assets.sh
+++ b/scripts/test-release-assets.sh
@@ -287,7 +287,7 @@ cat > "$tmp/bin/go" <<'EOF'
 set -euo pipefail
 test_root=$(cd "$(dirname "$0")/.." && pwd)
 if [[ "${1:-}" == version && "${2:-}" != -m ]]; then
-  printf '%s\n' 'go version go1.26.5 darwin/arm64'
+  printf '%s\n' 'go version go1.26.6 darwin/arm64'
   exit 0
 fi
 if [[ "${1:-}" == build ]]; then
@@ -323,7 +323,7 @@ revision=${MOCK_VCS_REVISION:-2222222222222222222222222222222222222222}
 if [[ "${MOCK_BAD_PLATFORM:-}" == "$goos-$goarch" ]]; then
   revision=3333333333333333333333333333333333333333
 fi
-printf '%s: %s\n' "$binary" "${MOCK_GO_TOOLCHAIN:-go1.26.5}"
+printf '%s: %s\n' "$binary" "${MOCK_GO_TOOLCHAIN:-go1.26.6}"
 printf '\tpath\t%s\n' "${MOCK_MAIN_PACKAGE:-github.com/openclaw/gogcli/cmd/gog}"
 printf '\tbuild\tvcs=%s\n' "${MOCK_VCS:-git}"
 printf '\tbuild\tGOARCH=%s\n' "${MOCK_GOARCH:-$goarch}"

--- a/scripts/test-release-local.sh
+++ b/scripts/test-release-local.sh
@@ -40,7 +40,7 @@ fresh_repo="$tmp/status-fresh-clone"
 "$real_git" init --quiet "$config_repo"
 "$real_git" -C "$config_repo" config user.name release-test
 "$real_git" -C "$config_repo" config user.email release-test@example.com
-printf '%s\n' 'module example.com/release-test' 'go 1.26.5' > "$config_repo/go.mod"
+printf '%s\n' 'module example.com/release-test' 'go 1.26.6' > "$config_repo/go.mod"
 printf '%s\n' 'package main' 'const buildSource = "trusted-commit"' 'func main() {}' > "$config_repo/main.go"
 "$real_git" -C "$config_repo" add go.mod main.go
 "$real_git" -C "$config_repo" -c commit.gpgsign=false commit --quiet -m initial
@@ -117,7 +117,7 @@ EOF
 cat > "$tmp/bin/go" <<'EOF'
 #!/usr/bin/env bash
 [[ "${1:-}" == version ]] || exit 2
-printf '%s\n' 'go version go1.26.5 darwin/arm64'
+printf '%s\n' 'go version go1.26.6 darwin/arm64'
 EOF
 
 cat > "$tmp/bin/git" <<'EOF'
@@ -412,7 +412,7 @@ jq -n \
   --arg replacement "$tmp/overlay/main.go" \
   '{Replace:{($source):$replacement}}' > "$tmp/overlay.json"
 cat > "$tmp/go.work" <<'EOF'
-go 1.26.5
+go 1.26.6
 
 use .
 EOF
@@ -898,7 +898,7 @@ if grep -Fv 'env -u GOTOOLCHAIN ./scripts/test-release-local.sh' <<<"$workflow_r
   echo "workflow invokes the local release test with ambient Go build controls" >&2
   exit 1
 fi
-grep -Fq 'go version go1.26.5 darwin/$expected_goarch' <<<"$prepare_go_function"
+grep -Fq 'go version go1.26.6 darwin/$expected_goarch' <<<"$prepare_go_function"
 grep -Fq 'GoReleaser 2.17.0' <<<"$prepare_go_function"
 grep -Fq 'GO111MODULE' <<<"$prepare_go_function"
 grep -Fq 'GOAUTH' <<<"$prepare_go_function"


### PR DESCRIPTION
## Summary

- move the repository Go floor and release assertions from 1.26.5 to 1.26.6
- pin the Docker builder to the fresh 1.26.6-alpine manifest digest
- clear GO-2026-5026, GO-2026-5972, GO-2026-6090, and GO-2026-6218

## Proof

- `GOTOOLCHAIN=go1.26.6 go build ./...`
- `GOTOOLCHAIN=go1.26.6 go test ./...`
- `GOTOOLCHAIN=go1.26.6 ./scripts/test-release-local.sh`
- `GOTOOLCHAIN=go1.26.6 ./scripts/test-release-assets.sh`
- built `cmd/gog` with Go 1.26.6 and verified `--version` reports v0.36.0
- autoreview clean with no accepted or actionable findings
