### PR TITLE
fix(gmail): avoid duplicate sanitized content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Gmail: emit sanitized message headers and bodies once in `gmail get --json --sanitize-content`, while retaining the `message` envelope and `--results-only` unwrapping. (#986) — thanks @ronny-rentner.
 - Sheets: add read-only Connected Sheets discovery, full data-source descriptions and execution status, plus bounded reads for anchored data-source tables (extracts) behind an explicitly opted-in BigQuery scope. (#938) — thanks @ryo-touch.
 
 ## v0.36.0 - 2026-08-13

--- a/docs/gmail-workflows.md
+++ b/docs/gmail-workflows.md
@@ -23,7 +23,9 @@ gog gmail thread get <threadId> --sanitize-content --json
 ```
 
 `--sanitize-content` strips unsafe/raw payload details while keeping useful
-message text for automation.
+message text for automation. Message JSON remains under the `message` key;
+add `--results-only` to emit that sanitized message directly. Both shapes emit
+the message headers and body once.
 
 ## Filters
 

--- a/internal/cmd/gmail_get.go
+++ b/internal/cmd/gmail_get.go
@@ -74,14 +74,7 @@ func (c *GmailGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 	if outfmt.IsJSON(ctx) {
 		if c.SanitizeContent {
 			output := sanitizedGmailMessage(msg, format == gmailFormatFull, c.UseIndexedAttachmentIDs)
-			payload := map[string]any{
-				"message": output,
-				"headers": output.Headers,
-			}
-			if format == gmailFormatFull && output.Body != "" {
-				payload["body"] = output.Body
-			}
-			return outfmt.WriteJSON(ctx, stdoutWriter(ctx), payload)
+			return outfmt.WriteJSON(ctx, stdoutWriter(ctx), map[string]any{"message": output})
 		}
 		// Include a flattened headers map for easier querying
 		// (e.g., jq '.headers.to' instead of complex nested queries)

--- a/internal/cmd/gmail_sanitize_test.go
+++ b/internal/cmd/gmail_sanitize_test.go
@@ -97,21 +97,43 @@ func TestGmailGetCmd_SanitizeContent_JSONUsesSafeEnvelope(t *testing.T) {
 	if strings.Contains(result.stdout, "payload") || strings.Contains(result.stdout, "unsubscribe") {
 		t.Fatalf("sanitized JSON should not expose raw Gmail payload/unsubscribe: %s", result.stdout)
 	}
-	var parsed struct {
-		Body    string `json:"body"`
-		Message struct {
-			ID      string            `json:"id"`
-			Headers map[string]string `json:"headers"`
-		} `json:"message"`
+	var envelope map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(result.stdout), &envelope); err != nil {
+		t.Fatalf("decode JSON envelope: %v", err)
 	}
-	if err := json.Unmarshal([]byte(result.stdout), &parsed); err != nil {
-		t.Fatalf("decode JSON: %v", err)
+	if len(envelope) != 1 || envelope["message"] == nil {
+		t.Fatalf("sanitized JSON should contain the message once, got: %s", result.stdout)
+	}
+
+	var parsed struct {
+		ID      string            `json:"id"`
+		Headers map[string]string `json:"headers"`
+		Body    string            `json:"body"`
+	}
+	if err := json.Unmarshal(envelope["message"], &parsed); err != nil {
+		t.Fatalf("decode sanitized message: %v", err)
 	}
 	if parsed.Body != "Hello [url removed]" {
 		t.Fatalf("unexpected body: %q", parsed.Body)
 	}
-	if parsed.Message.Headers["subject"] != "Visit [url removed] now" {
-		t.Fatalf("unexpected sanitized subject: %#v", parsed.Message.Headers)
+	if parsed.Headers["subject"] != "Visit [url removed] now" {
+		t.Fatalf("unexpected sanitized subject: %#v", parsed.Headers)
+	}
+
+	result = executeWithGmailTestService(
+		t,
+		[]string{"--json", "--results-only", "--account", "a@b.com", "gmail", "get", "m1", "--sanitize-content"},
+		newGmailServiceFromServer(t, srv),
+	)
+	if result.err != nil {
+		t.Fatalf("Execute with --results-only: %v\nstderr=%q", result.err, result.stderr)
+	}
+	var direct gmailSanitizedMessageOutput
+	if err := json.Unmarshal([]byte(result.stdout), &direct); err != nil {
+		t.Fatalf("decode direct sanitized message: %v", err)
+	}
+	if direct.ID != parsed.ID || direct.Body != parsed.Body || direct.Headers["subject"] != parsed.Headers["subject"] {
+		t.Fatalf("--results-only did not unwrap the sanitized message: %s", result.stdout)
 	}
 }
 


### PR DESCRIPTION
## Summary

- stop copying sanitized Gmail headers and bodies beside the existing `message` result
- preserve the default `message` envelope while allowing `--results-only` to unwrap it
- document the JSON shape and add fixture-backed regression coverage

Reporter credit is recorded in the changelog. Thanks @ronny-rentner.

## Verification

- `go test ./internal/cmd -run '^(TestGmailGetCmd_SanitizeContent_JSONUsesSafeEnvelope|TestGmailGetCmd_JSON_ResultsOnlyPreservesCompleteAttachmentResult|TestGmailThreadGet_SanitizeContent_JSONUsesSafeEnvelope)$' -count=1`
- `make ci`
- built Linux CLI exercised against a local TLS Gmail fixture, with no live mailbox access:
  - default sanitized JSON: top-level keys `message`; no URL or raw payload
  - `--results-only`: direct sanitized message; no wrapper, URL, or raw payload
- autoreview clean with no accepted/actionable findings

Closes #986
