### PR TITLE
test: isolate tests from ambient XDG and GOG_* path variables

### DIFF
--- a/internal/cmd/testmain_test.go
+++ b/internal/cmd/testmain_test.go
@@ -26,6 +26,23 @@ func TestMain(m *testing.M) {
 	_ = os.Setenv("HOME", home)
 	_ = os.Setenv("XDG_CONFIG_HOME", xdg)
 
+	// Ambient GOG_* path overrides and XDG data/state/cache directories escape
+	// this sandbox entirely: the layout resolver (internal/config/layout.go)
+	// honors them ahead of the HOME- and XDG_CONFIG_HOME-derived defaults set
+	// above, pointing tests at shared real directories. Unset rather than
+	// redirect: a single shared override directory still cross-contaminates
+	// tests. Per-test t.Setenv values are unaffected.
+	oldPathEnv := map[string]string{}
+	for _, name := range []string{
+		"GOG_HOME", "GOG_CONFIG_DIR", "GOG_DATA_DIR", "GOG_STATE_DIR", "GOG_CACHE_DIR",
+		"XDG_DATA_HOME", "XDG_STATE_HOME", "XDG_CACHE_HOME",
+	} {
+		if value, ok := os.LookupEnv(name); ok {
+			oldPathEnv[name] = value
+		}
+		_ = os.Unsetenv(name)
+	}
+
 	code := m.Run()
 
 	if oldHome == "" {
@@ -37,6 +54,10 @@ func TestMain(m *testing.M) {
 		_ = os.Unsetenv("XDG_CONFIG_HOME")
 	} else {
 		_ = os.Setenv("XDG_CONFIG_HOME", oldXDG)
+	}
+
+	for name, value := range oldPathEnv {
+		_ = os.Setenv(name, value)
 	}
 	_ = os.RemoveAll(root)
 	os.Exit(code)

--- a/internal/config/testmain_test.go
+++ b/internal/config/testmain_test.go
@@ -1,0 +1,24 @@
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	// Tests isolate storage via per-test temp directories (HOME by default),
+	// but the layout resolver (internal/config/layout.go) honors ambient GOG_*
+	// path overrides and XDG base directories ahead of HOME-derived defaults,
+	// leaking state across tests and into the developer's real gogcli
+	// directories. Unset rather than redirect: a single shared override
+	// directory still cross-contaminates tests. Per-test t.Setenv values are
+	// unaffected.
+	for _, name := range []string{
+		"GOG_HOME", "GOG_CONFIG_DIR", "GOG_DATA_DIR", "GOG_STATE_DIR", "GOG_CACHE_DIR",
+		"XDG_CONFIG_HOME", "XDG_DATA_HOME", "XDG_STATE_HOME", "XDG_CACHE_HOME",
+	} {
+		_ = os.Unsetenv(name)
+	}
+
+	os.Exit(m.Run())
+}

--- a/internal/googleapi/service_account_test.go
+++ b/internal/googleapi/service_account_test.go
@@ -43,6 +43,13 @@ func TestTokenSourceForServiceAccountScopesUsesInjectedStore(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(ambientHome, "xdg-config"))
 	t.Setenv("XDG_DATA_HOME", filepath.Join(ambientHome, "xdg-data"))
 
+	// GOG_* path overrides outrank HOME and XDG in the layout resolver; clear
+	// them so the ambient file below lands in this test's sandbox rather than
+	// a real gogcli data directory.
+	for _, name := range []string{"GOG_HOME", "GOG_CONFIG_DIR", "GOG_DATA_DIR", "GOG_STATE_DIR", "GOG_CACHE_DIR"} {
+		t.Setenv(name, "")
+	}
+
 	ambientLayout, err := config.NewSystemResolver("").Resolve(config.PathKindData)
 	if err != nil {
 		t.Fatalf("resolve ambient layout: %v", err)

--- a/internal/secrets/testmain_test.go
+++ b/internal/secrets/testmain_test.go
@@ -1,0 +1,24 @@
+package secrets
+
+import (
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	// Tests isolate storage via per-test temp directories (HOME by default),
+	// but the layout resolver (internal/config/layout.go) honors ambient GOG_*
+	// path overrides and XDG base directories ahead of HOME-derived defaults,
+	// leaking state across tests and into the developer's real gogcli
+	// directories. Unset rather than redirect: a single shared override
+	// directory still cross-contaminates tests. Per-test t.Setenv values are
+	// unaffected.
+	for _, name := range []string{
+		"GOG_HOME", "GOG_CONFIG_DIR", "GOG_DATA_DIR", "GOG_STATE_DIR", "GOG_CACHE_DIR",
+		"XDG_CONFIG_HOME", "XDG_DATA_HOME", "XDG_STATE_HOME", "XDG_CACHE_HOME",
+	} {
+		_ = os.Unsetenv(name)
+	}
+
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
## What

Makes the test suite immune to ambient path-environment variables. The layout resolver (`internal/config/layout.go`) honors `GOG_HOME`, `GOG_{CONFIG,DATA,STATE,CACHE}_DIR`, and the XDG base directories ahead of HOME-derived defaults, but tests isolate themselves with per-test `t.Setenv("HOME", t.TempDir())` sandboxes. On any machine that exports one of these documented variables, `go test ./...` today both fails (cross-test contamination through the shared real directory) and writes test fixtures into the developer's **real** gogcli data — including live file-keyring entries, `tracking.json`, and gmail-watch state.

Four test-only changes, no runtime code touched:

- `internal/cmd/testmain_test.go` — the existing `TestMain` (which already redirects `HOME` and `XDG_CONFIG_HOME` to a temp root, from 2ca93e9a) now also unsets the five `GOG_*` path overrides plus `XDG_DATA_HOME`/`XDG_STATE_HOME`/`XDG_CACHE_HOME`, restoring saved values afterward.
- `internal/config/testmain_test.go`, `internal/secrets/testmain_test.go` (new) — minimal `TestMain`s unsetting all nine path variables; these packages' tests were exposed the same way.
- `internal/googleapi/service_account_test.go` — `TestTokenSourceForServiceAccountScopesUsesInjectedStore` deliberately writes an "ambient" fixture through the real resolver to prove the injected store wins. It already pins `HOME`/`XDG_CONFIG_HOME`/`XDG_DATA_HOME` per test but not `GOG_*`, so with `GOG_HOME` exported it wrote `<GOG_HOME>/data/sa-YUBiLmNvbQ.json` (contents: `ambient`) into the real directory **while reporting `ok`** — silently clobbering any real stored service-account key for that address. It now clears the `GOG_*` overrides too.

Unsetting rather than redirecting is deliberate: we tried redirecting the variables at a single shared package-level directory, and tests still cross-contaminate through it — the failures need no preexisting content, because writer tests fill the shared directory mid-run and reader tests then see their state (preexisting junk only changes which package the failures land in). That is also the precise reason CI has never seen this: GitHub runners export none of these variables, so every test falls back to its own `t.Setenv("HOME", …)` sandbox — had a runner exported `XDG_DATA_HOME`, even a pristine one, the same failures would appear. Unsetting reproduces that environment everywhere. Per-test `t.Setenv` of any of these variables keeps working (`TestMain` runs before `m.Run`), and the build-tagged integration suites that intentionally target the real layout are untouched.

## Why

Measured at current main (45b5d766), on macOS (the resolver branches involved are not platform-gated, so Linux with the same variables exported is equally exposed):

- `XDG_DATA_HOME`/`XDG_STATE_HOME` exported → **19 failing tests** across `internal/cmd`, `internal/config`, `internal/secrets` (the split varies with what's already in the shared directory), plus service-account stubs, a file keyring, `tracking.json`, and gmail-watch state written into the real `$XDG_DATA_HOME/gogcli` and `$XDG_STATE_HOME/gogcli`.
- `GOG_HOME` exported → **77 failing tests**, same mechanism, higher resolver precedence — and `GOG_HOME` is gogcli's own documented relocation knob, so the population most at risk is gogcli developers who also use gogcli.
- Worst case, no failure at all: the `internal/googleapi` leak above stays green while overwriting real data.

This came out of a real diagnosis: on a Nix-managed dev machine (XDG variables exported globally), 19 tests failed on a clean checkout of main, and the real `~/.local/share/gogcli` / `~/.local/state/gogcli` had been silently accumulating test fixtures since June. VISION.md counts reliability improvements around keyring and credentials as wanted work; this protects contributors' actual credentials/state from `go test`.

## Behavior changes (complete ledger)

- None at runtime. The diff touches only `_test.go` files.
- Test processes for the four packages no longer see ambient `GOG_HOME`, `GOG_{CONFIG,DATA,STATE,CACHE}_DIR`, `XDG_DATA_HOME`, `XDG_STATE_HOME`, `XDG_CACHE_HOME` (and, in `internal/config`/`internal/secrets`, `XDG_CONFIG_HOME`). Tests that set these per test are unaffected.
- One incidental effect: with `XDG_CACHE_HOME` unset, the `go build` subprocess in `internal/cmd`'s slides-assets test derives its build cache under the sandboxed HOME on Linux (cold cache per run). No measurable runtime change on darwin; the unset is still wanted because gogcli genuinely resolves the cache path (`internal/cmd/backup_gmail.go`).

## Proof

Self-contained TAP script, no credentials required — it runs the matrix against whatever checkout it's started from, so the same script demonstrates the bug on main and its absence here. It pins `GOFLAGS` and starts each scenario from all nine path variables unset (setting only that scenario's), so ambient environment on the machine running it cannot skew or vacuously pass the checks.

<details>
<summary><code>proof-isolation.sh</code> (bash, stdlib only)</summary>

```bash
#!/usr/bin/env bash
# proof-isolation.sh - run from a gogcli checkout root (no credentials needed).
# TAP output. For the four packages that resolve the system path layout,
# verifies `go test` neither fails nor leaves filesystem entries outside its
# sandboxes when the documented path variables are exported, and that behavior
# with none of them set (the environment CI provides) is unchanged.
set -u
PKGS=(./internal/cmd/ ./internal/config/ ./internal/secrets/ ./internal/googleapi/)
PATHVARS=(GOG_HOME GOG_CONFIG_DIR GOG_DATA_DIR GOG_STATE_DIR GOG_CACHE_DIR
  XDG_CONFIG_HOME XDG_DATA_HOME XDG_STATE_HOME XDG_CACHE_HOME)
UNSET=(); for v in "${PATHVARS[@]}"; do UNSET+=(-u "$v"); done
export GOFLAGS= # an inherited -run/-exec/-short would make green runs vacuous
S=$(mktemp -d /tmp/gog-proof-XXXXXX) || exit 1
echo "# head=$(git rev-parse --short HEAD) $(go version | cut -d' ' -f3-4)"
n=0 status=0

check() { # check <pass:0|nonzero> <description>
  n=$((n + 1))
  if [ "$1" -eq 0 ]; then echo "ok $n - $2"; else echo "not ok $n - $2"; status=1; fi
}

# gotest <logname> [VAR=value]... - go test with ONLY the given path vars set
gotest() {
  log=$1
  shift
  env "${UNSET[@]}" "$@" go test -count=1 "${PKGS[@]}" >"$S/$log.log" 2>&1
}

# leakcheck <description> <dir>... - fail on any entry under the dirs, or on find error
leakcheck() {
  desc=$1
  shift
  files=$(find "$@" -mindepth 1 -print 2>&1)
  frc=$?
  rc=0
  [ "$frc" -ne 0 ] && rc=1
  [ -n "$files" ] && rc=1
  check "$rc" "$desc"
  [ -n "$files" ] && printf '%s\n' "$files" | sed "s|^$S/|# leaked: |; s|^[^#]|# find: &|"
}

# 1-2: XDG data/state exported (the report that started this)
mkdir -p "$S/xdg-data" "$S/xdg-state"
gotest xdg XDG_DATA_HOME="$S/xdg-data" XDG_STATE_HOME="$S/xdg-state"
check $? "tests pass with XDG_DATA_HOME/XDG_STATE_HOME exported (others unset)"
leakcheck "no filesystem entries under the exported XDG dirs" "$S/xdg-data" "$S/xdg-state"

# 3-4: GOG_HOME exported (higher precedence than XDG in the resolver)
mkdir -p "$S/goghome"
gotest gog GOG_HOME="$S/goghome"
check $? "tests pass with GOG_HOME exported (others unset)"
leakcheck "no filesystem entries under the exported GOG_HOME" "$S/goghome"

# 5: all nine path variables unset - must pass before and after (CI runs this way)
gotest bare
check $? "tests pass with no path variables set"

echo "1..$n"
for f in xdg gog; do
  if grep -q '^--- FAIL' "$S/$f.log"; then
    echo "# $f run: $(grep -c '^--- FAIL' "$S/$f.log") failing tests, e.g.:"
    grep '^--- FAIL' "$S/$f.log" | head -3 | sed 's/^/#   /'
  fi
done
exit $status
```

</details>

**At current main (45b5d766):**

```
# head=45b5d766 go1.26.6 darwin/arm64
not ok 1 - tests pass with XDG_DATA_HOME/XDG_STATE_HOME exported (others unset)
not ok 2 - no filesystem entries under the exported XDG dirs
# leaked: xdg-data/gogcli
# leaked: xdg-data/gogcli/keep-sa-dXNlckBleGFtcGxlLmNvbQ.json
# leaked: xdg-data/gogcli/sa-c3RkaW5AZXhhbXBsZS5jb20.json
# leaked: xdg-data/gogcli/keep-sa-YUBiLmNvbQ.json
# leaked: xdg-data/gogcli/keyring
# leaked: xdg-data/gogcli/keyring/_gogcli_key_v1_c2hhcmVkL3NlY3JldA
# leaked: xdg-data/gogcli/keyring/.lock
# leaked: xdg-data/gogcli/keyring/_gogcli_key_v1_dG9rZW4tc3ViOmRlZmF1bHQ6c3ViamVjdC0wNg
# leaked: xdg-data/gogcli/keyring/_gogcli_key_v1_dHJhY2tpbmcvYUBiLmNvbS90cmFja2luZ19rZXk
# leaked: xdg-data/gogcli/keyring/_gogcli_key_v1_dHJhY2tpbmcvYUBiLmNvbS90cmFja2luZ19rZXlfdjI
# leaked: xdg-data/gogcli/keyring/_gogcli_key_v1_dG9rZW46ZGVmYXVsdDp1c2VyQGV4YW1wbGUuY29t
# leaked: xdg-data/gogcli/keyring/_gogcli_key_v1_dGVzdC9rZXk
# leaked: xdg-data/gogcli/keyring/_gogcli_key_v1_dHJhY2tpbmcvYUBiLmNvbS90cmFja2luZ19rZXlfdjM
# leaked: xdg-data/gogcli/keyring/_gogcli_key_v1_dHJhY2tpbmcvYUBiLmNvbS9hZG1pbl9rZXk
# leaked: xdg-data/gogcli/keyring/_gogcli_key_v1_dG9rZW46dXNlckBleGFtcGxlLmNvbQ
# leaked: xdg-data/gogcli/keyring/_gogcli_key_v1_dHJhY2tpbmcvYUBiLmNvbS90cmFja2luZ19rZXlfdjE
# leaked: xdg-data/gogcli/sa-ZW52QGV4YW1wbGUuY29t.json
# leaked: xdg-data/gogcli/sa-YUBiLmNvbQ.json
# leaked: xdg-data/gogcli/sa-dXNlckBleGFtcGxlLmNvbQ.json
# leaked: xdg-state/gogcli
# leaked: xdg-state/gogcli/tracking.lock
# leaked: xdg-state/gogcli/tracking.json
# leaked: xdg-state/gogcli/gmail-watch
# leaked: xdg-state/gogcli/gmail-watch/.lock
# leaked: xdg-state/gogcli/gmail-watch/user_x_example_com.json
# leaked: xdg-state/gogcli/gmail-watch/me_example_com.json
# leaked: xdg-state/gogcli/gmail-watch/a_b_com.json
not ok 3 - tests pass with GOG_HOME exported (others unset)
not ok 4 - no filesystem entries under the exported GOG_HOME
# leaked: goghome/config
# leaked: goghome/config/keep-sa-dXNlckBleGFtcGxlLmNvbQ.json
# leaked: goghome/config/keep-sa-a@b.com.json
# leaked: goghome/config/credentials-example.com.json
# leaked: goghome/config/config.json
# leaked: goghome/config/sa-bGVnYWN5QGV4YW1wbGUuY29t.json
# leaked: goghome/config/keep-sa-victim@example.com.json
# leaked: goghome/config/keep-sa-User@Example.com.json
# leaked: goghome/config/credentials.json
# leaked: goghome/config/gmail-attachments
# leaked: goghome/config/gmail-attachments/m-draft-1_a-draft-_a.txt
# leaked: goghome/config/gmail-attachments/m1_a1_a.txt
# leaked: goghome/config/keep-sa-Other@Example.com.json
# leaked: goghome/config/sa-dXNlckBleGFtcGxlLmNvbQ.json
# leaked: goghome/config/credentials-work.json
# leaked: goghome/config/credentials-bad!.json
# leaked: goghome/state
# leaked: goghome/state/tracking.lock
# leaked: goghome/state/tracking.json
# leaked: goghome/state/gmail-watch
# leaked: goghome/state/gmail-watch/.lock
# leaked: goghome/state/gmail-watch/user_x_example_com.json
# leaked: goghome/state/gmail-watch/me_example_com.json
# leaked: goghome/state/gmail-watch/a_b_com.json
# leaked: goghome/data
# leaked: goghome/data/keep-sa-dXNlckBleGFtcGxlLmNvbQ.json
# leaked: goghome/data/sa-c3RkaW5AZXhhbXBsZS5jb20.json
# leaked: goghome/data/keep-sa-YUBiLmNvbQ.json
# leaked: goghome/data/keyring
# leaked: goghome/data/keyring/_gogcli_key_v1_c2hhcmVkL3NlY3JldA
# leaked: goghome/data/keyring/.lock
# leaked: goghome/data/keyring/_gogcli_key_v1_dG9rZW4tc3ViOmRlZmF1bHQ6c3ViamVjdC0wMA
# leaked: goghome/data/keyring/_gogcli_key_v1_dHJhY2tpbmcvYUBiLmNvbS90cmFja2luZ19rZXk
# leaked: goghome/data/keyring/_gogcli_key_v1_dHJhY2tpbmcvYUBiLmNvbS90cmFja2luZ19rZXlfdjI
# leaked: goghome/data/keyring/_gogcli_key_v1_dG9rZW46ZGVmYXVsdDp1c2VyQGV4YW1wbGUuY29t
# leaked: goghome/data/keyring/_gogcli_key_v1_dGVzdC9rZXk
# leaked: goghome/data/keyring/_gogcli_key_v1_dHJhY2tpbmcvYUBiLmNvbS90cmFja2luZ19rZXlfdjM
# leaked: goghome/data/keyring/_gogcli_key_v1_dHJhY2tpbmcvYUBiLmNvbS9hZG1pbl9rZXk
# leaked: goghome/data/keyring/_gogcli_key_v1_dG9rZW46dXNlckBleGFtcGxlLmNvbQ
# leaked: goghome/data/keyring/_gogcli_key_v1_dHJhY2tpbmcvYUBiLmNvbS90cmFja2luZ19rZXlfdjE
# leaked: goghome/data/sa-ZW52QGV4YW1wbGUuY29t.json
# leaked: goghome/data/sa-YUBiLmNvbQ.json
# leaked: goghome/data/sa-dXNlckBleGFtcGxlLmNvbQ.json
ok 5 - tests pass with no path variables set
1..5
# xdg run: 19 failing tests, e.g.:
#   --- FAIL: TestAuthList_JSON_ReportsUnreadableToken (0.05s)
#   --- FAIL: TestAuthListRemoveTokensListDelete_JSON (0.03s)
#   --- FAIL: TestAuthServiceAccountStatus_MissingTextHasHint (0.03s)
# gog run: 77 failing tests, e.g.:
#   --- FAIL: TestAuthList_JSON_ReportsUnreadableToken (0.03s)
#   --- FAIL: TestAuthListRemoveTokensListDelete_JSON (0.03s)
#   --- FAIL: TestAuthStatusCmd_JSONReportsLegacyCredentialsPath (0.00s)
```

The silent case in isolation, at main — the package reports `ok` while writing through the real resolver (`sa-YUBiLmNvbQ.json` is the service-account stub for `a@b.com`, base64url-encoded):

```
$ G=$(mktemp -d); GOG_HOME=$G go test ./internal/googleapi/
ok  	github.com/openclaw/gogcli/internal/googleapi	3.374s
$ find "$G" -type f | sed "s|$G/||"
data/sa-YUBiLmNvbQ.json
$ cat "$G/data/sa-YUBiLmNvbQ.json"; echo
ambient
```

**On this branch:**

```
# head=7d71fa55 go1.26.6 darwin/arm64
ok 1 - tests pass with XDG_DATA_HOME/XDG_STATE_HOME exported (others unset)
ok 2 - no filesystem entries under the exported XDG dirs
ok 3 - tests pass with GOG_HOME exported (others unset)
ok 4 - no filesystem entries under the exported GOG_HOME
ok 5 - tests pass with no path variables set
1..5
```

Scope notes: the proof exercises the four affected packages; a full `go test ./...` under each of the three environments also passes on this branch (that is how the affected set was established — no other package resolves the system layout outside build-tagged integration tests, which intentionally use the real one). Windows CI runs with none of these variables set, so it sees pure CI-parity behavior. One adjacent observation, deliberately out of scope for this PR: CI cannot detect removal of these `TestMain`s (runners never export the variables), so the isolation is convention-guarded only. (The keyring-selection variables — `GOG_KEYRING_BACKEND` and friends — were audited separately and need no scrubbing here: every test that opens a secrets store already pins the backend to `file` per test, on main and on this branch alike.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
