### PR TITLE
fix(lint): satisfy wsl whitespace in OAuth callback server test

### DIFF
--- a/internal/googleauth/oauth_flow_more_test.go
+++ b/internal/googleauth/oauth_flow_more_test.go
@@ -18,12 +18,15 @@ func TestNewOAuthCallbackServer_ReadTimeout(t *testing.T) {
 	if srv.ReadTimeout == 0 {
 		t.Fatal("ReadTimeout must be set")
 	}
+
 	if srv.ReadHeaderTimeout == 0 {
 		t.Fatal("ReadHeaderTimeout must be set")
 	}
+
 	if srv.IdleTimeout == 0 {
 		t.Fatal("IdleTimeout must be set")
 	}
+
 	if srv.MaxHeaderBytes == 0 {
 		t.Fatal("MaxHeaderBytes must be set")
 	}


### PR DESCRIPTION
Main went red on the lint gate right after the robustness-sweep merge; the PR-branch CI does not run this linter. Verified locally: `golangci-lint run` reports 0 issues, build passes.