### PR TITLE
fix(sheets): correct Connected Sheets sheet identity and SYNC_ALL extract reads

### DIFF
--- a/docs/sheets-connected.md
+++ b/docs/sheets-connected.md
@@ -54,4 +54,6 @@ gog --readonly --account you@example.com \
 
 Table discovery asks `spreadsheets.get` only for anchor definitions and related sheet metadata. `read` then uses the selected table's configured columns and row limit to construct a bounded `spreadsheets.values.get` request. The default is at most 1,000 data rows plus the header; JSON output reports `truncated: true` when the configured extract can contain more rows. Use `--render FORMULA` or `--render UNFORMATTED_VALUE` when formatted display values are not suitable.
 
+An extract that syncs every column keeps its column list on the linked `DATA_SOURCE` sheet rather than on the anchor, and the anchor lookup is range-scoped, so `read` issues one additional `spreadsheets.get` for those column definitions. Add pacing when reading many extracts in a loop; back-to-back reads can reach the Sheets per-minute quota.
+
 These commands do not create, update, refresh, or delete data sources. Connected Sheets refresh remains asynchronous, and `list` or `describe` can be polled until `state` is `SUCCEEDED` or `FAILED`.

--- a/internal/cmd/sheets_datasource.go
+++ b/internal/cmd/sheets_datasource.go
@@ -293,12 +293,12 @@ func (c *SheetsDataSourceTableReadCmd) Run(ctx context.Context, flags *RootFlags
 	if columnCount == 0 {
 		// The ranged lookup above only returns the sheets the anchor intersects,
 		// so a SYNC_ALL table's column list — which lives on its separate
-		// DATA_SOURCE sheet — is missing. Re-read sheet properties unranged.
-		snapshot, snapshotErr := fetchSheetsDataSourceSnapshot(ctx, svc, spreadsheetID)
-		if snapshotErr != nil {
-			return wrapConnectedSheetsReadError(snapshotErr, account)
+		// DATA_SOURCE sheet — is missing. Re-read those columns unranged.
+		allSheets, columnsErr := fetchSheetsDataSourceSheetColumns(ctx, svc, spreadsheetID)
+		if columnsErr != nil {
+			return wrapConnectedSheetsReadError(columnsErr, account)
 		}
-		columnCount = dataSourceColumnCount(snapshot.Sheets, item.DataSourceID)
+		columnCount = dataSourceColumnCount(allSheets, item.DataSourceID)
 	}
 	if columnCount == 0 {
 		return usagef("cannot determine columns for data-source table at %q", anchor)
@@ -365,6 +365,21 @@ func fetchSheetsDataSourceSnapshot(ctx context.Context, svc *sheets.Service, spr
 		Schedules:   resp.DataSourceSchedules,
 		Sheets:      resp.Sheets,
 	}, nil
+}
+
+// fetchSheetsDataSourceSheetColumns reads just the data-source sheet column
+// definitions, which a ranged lookup cannot return. Kept narrower than the full
+// snapshot mask so the extra request stays cheap.
+func fetchSheetsDataSourceSheetColumns(ctx context.Context, svc *sheets.Service, spreadsheetID string) ([]*sheets.Sheet, error) {
+	resp, err := svc.Spreadsheets.Get(spreadsheetID).
+		Fields(googleapi.Field("sheets(properties(sheetId,title,dataSourceSheetProperties(dataSourceId,columns)))")).
+		Context(ctx).
+		Do()
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.Sheets, nil
 }
 
 func fetchSheetsDataSourceTables(ctx context.Context, svc *sheets.Service, spreadsheetID, anchor string) (*sheets.Spreadsheet, error) {

--- a/internal/cmd/sheets_datasource.go
+++ b/internal/cmd/sheets_datasource.go
@@ -291,6 +291,16 @@ func (c *SheetsDataSourceTableReadCmd) Run(ctx context.Context, flags *RootFlags
 		columnCount = dataSourceColumnCount(resp.Sheets, item.DataSourceID)
 	}
 	if columnCount == 0 {
+		// The ranged lookup above only returns the sheets the anchor intersects,
+		// so a SYNC_ALL table's column list — which lives on its separate
+		// DATA_SOURCE sheet — is missing. Re-read sheet properties unranged.
+		snapshot, snapshotErr := fetchSheetsDataSourceSnapshot(ctx, svc, spreadsheetID)
+		if snapshotErr != nil {
+			return wrapConnectedSheetsReadError(snapshotErr, account)
+		}
+		columnCount = dataSourceColumnCount(snapshot.Sheets, item.DataSourceID)
+	}
+	if columnCount == 0 {
 		return usagef("cannot determine columns for data-source table at %q", anchor)
 	}
 

--- a/internal/cmd/sheets_datasource.go
+++ b/internal/cmd/sheets_datasource.go
@@ -396,6 +396,9 @@ func sheetsDataSourceToItem(source *sheets.DataSource, allSheets []*sheets.Sheet
 		}
 	}
 	if sheet := findSheetsDataSourceSheet(allSheets, source); sheet != nil && sheet.Properties != nil {
+		// Spreadsheet.dataSources[].sheetId is absent from live API responses, so
+		// the linked sheet's own properties are the authoritative id.
+		item.SheetID = sheet.Properties.SheetId
 		item.SheetTitle = sheet.Properties.Title
 		status := sheet.Properties.DataSourceSheetProperties
 		if status != nil {
@@ -418,15 +421,26 @@ func findSheetsDataSourceSheet(allSheets []*sheets.Sheet, source *sheets.DataSou
 	if source == nil {
 		return nil
 	}
+	// Match on the data source id first: live responses omit
+	// Spreadsheet.dataSources[].sheetId, and a zero value would otherwise claim
+	// any unrelated sheet that happens to have id 0.
 	for _, sheet := range allSheets {
 		if sheet == nil || sheet.Properties == nil {
 			continue
 		}
 		properties := sheet.Properties
-		if properties.SheetId == source.SheetId {
+		if properties.DataSourceSheetProperties != nil && properties.DataSourceSheetProperties.DataSourceId == source.DataSourceId {
 			return sheet
 		}
-		if properties.DataSourceSheetProperties != nil && properties.DataSourceSheetProperties.DataSourceId == source.DataSourceId {
+	}
+	if source.SheetId == 0 {
+		return nil
+	}
+	for _, sheet := range allSheets {
+		if sheet == nil || sheet.Properties == nil {
+			continue
+		}
+		if sheet.Properties.SheetId == source.SheetId {
 			return sheet
 		}
 	}

--- a/internal/cmd/sheets_datasource_test.go
+++ b/internal/cmd/sheets_datasource_test.go
@@ -7,10 +7,11 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"os"
 	"strings"
 	"testing"
+
+	"google.golang.org/api/sheets/v4"
 )
 
 func TestSheetsDataSourceListAndDescribe(t *testing.T) {
@@ -134,10 +135,32 @@ func TestSheetsDataSourceTableListDescribeAndRead(t *testing.T) {
 	if !strings.Contains(joinedQueries, "includeGridData=true") || !strings.Contains(joinedQueries, "dataSourceTable") {
 		t.Fatalf("table discovery did not request anchor definitions: %s", joinedQueries)
 	}
+	// A SELECTED table lists its own columns, so it must not pay for the
+	// unranged column lookup.
+	if got := countUnrangedColumnLookups(*queries); got != 0 {
+		t.Fatalf("unranged column lookups = %d, want 0: %#v", got, *queries)
+	}
+}
+
+// countUnrangedColumnLookups counts spreadsheets.get calls that carry neither
+// grid data nor value-range parameters, which is the shape of the unranged
+// column lookup used for SYNC_ALL extracts.
+func countUnrangedColumnLookups(queries []string) int {
+	count := 0
+	for _, query := range queries {
+		if strings.Contains(query, "includeGridData") || strings.Contains(query, "majorDimension") {
+			continue
+		}
+		if strings.Contains(query, "dataSourceSheetProperties") {
+			count++
+		}
+	}
+
+	return count
 }
 
 func TestSheetsDataSourceTableReadSyncAllExtract(t *testing.T) {
-	srv, _ := newConnectedSheetsFixtureServer(t)
+	srv, queries := newConnectedSheetsFixtureServer(t)
 	defer srv.Close()
 	svc := newSheetsServiceFromServer(t, srv)
 
@@ -167,6 +190,51 @@ func TestSheetsDataSourceTableReadSyncAllExtract(t *testing.T) {
 	}
 	if read.DataSourceID != "ds-query" || !read.Truncated {
 		t.Fatalf("unexpected SYNC_ALL read identity: %#v", read)
+	}
+	// Exactly one extra lookup: the ranged anchor fetch cannot supply the columns,
+	// and repeating it per read would multiply the request cost.
+	if got := countUnrangedColumnLookups(*queries); got != 1 {
+		t.Fatalf("unranged column lookups = %d, want 1: %#v", got, *queries)
+	}
+}
+
+func TestFindSheetsDataSourceSheet(t *testing.T) {
+	decoy := &sheets.Sheet{Properties: &sheets.SheetProperties{SheetId: 0, Title: "Unrelated First Tab"}}
+	linked := &sheets.Sheet{Properties: &sheets.SheetProperties{
+		SheetId:                   777,
+		Title:                     "Linked",
+		DataSourceSheetProperties: &sheets.DataSourceSheetProperties{DataSourceId: "ds-1"},
+	}}
+	byIDOnly := &sheets.Sheet{Properties: &sheets.SheetProperties{SheetId: 777, Title: "By Sheet Id"}}
+
+	for _, test := range []struct {
+		name      string
+		allSheets []*sheets.Sheet
+		source    *sheets.DataSource
+		want      *sheets.Sheet
+	}{{
+		// Live responses omit dataSources[].sheetId, so the zero value must not
+		// win against a sheet that actually declares the data source.
+		name:      "data source id wins over a sheet with id 0",
+		allSheets: []*sheets.Sheet{decoy, linked},
+		source:    &sheets.DataSource{DataSourceId: "ds-1"},
+		want:      linked,
+	}, {
+		name:      "falls back to a supplied sheet id",
+		allSheets: []*sheets.Sheet{decoy, byIDOnly},
+		source:    &sheets.DataSource{DataSourceId: "ds-1", SheetId: 777},
+		want:      byIDOnly,
+	}, {
+		name:      "no match without a usable sheet id",
+		allSheets: []*sheets.Sheet{decoy, byIDOnly},
+		source:    &sheets.DataSource{DataSourceId: "ds-1"},
+		want:      nil,
+	}} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := findSheetsDataSourceSheet(test.allSheets, test.source); got != test.want {
+				t.Fatalf("findSheetsDataSourceSheet = %#v, want %#v", got, test.want)
+			}
+		})
 	}
 }
 
@@ -224,6 +292,12 @@ func newConnectedSheetsFixtureServer(t *testing.T) (*httptest.Server, *[]string)
 	if err != nil {
 		t.Fatalf("read Connected Sheets fixture: %v", err)
 	}
+	// Decode here rather than per request: an httptest handler runs on its own
+	// goroutine, where t.Fatalf is not allowed.
+	var parsed map[string]any
+	if err := json.Unmarshal(fixture, &parsed); err != nil {
+		t.Fatalf("decode Connected Sheets fixture: %v", err)
+	}
 	queries := make([]string, 0)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		queries = append(queries, r.URL.RawQuery)
@@ -231,12 +305,10 @@ func newConnectedSheetsFixtureServer(t *testing.T) (*httptest.Server, *[]string)
 		path := strings.TrimPrefix(strings.TrimPrefix(r.URL.Path, "/sheets/v4"), "/v4")
 		switch {
 		case strings.Contains(path, "/spreadsheets/connected1/values/") && r.Method == http.MethodGet:
-			requested, err := url.PathUnescape(strings.TrimPrefix(path, "/spreadsheets/connected1/values/"))
-			if err != nil {
-				t.Fatalf("decode values range: %v", err)
-			}
+			// net/http already decoded r.URL.Path, so the trimmed remainder is
+			// the requested A1 range.
 			_ = json.NewEncoder(w).Encode(map[string]any{
-				"range":          requested,
+				"range":          strings.TrimPrefix(path, "/spreadsheets/connected1/values/"),
 				"majorDimension": "ROWS",
 				"values": [][]any{
 					{"word", "word_count"},
@@ -246,7 +318,12 @@ func newConnectedSheetsFixtureServer(t *testing.T) (*httptest.Server, *[]string)
 				},
 			})
 		case strings.HasPrefix(path, "/spreadsheets/connected1") && r.Method == http.MethodGet:
-			_, _ = w.Write(filterConnectedSheetsFixture(t, fixture, r.URL.Query()["ranges"]))
+			body, err := connectedSheetsFixtureForRanges(parsed, fixture, r.URL.Query()["ranges"])
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			_, _ = w.Write(body)
 		default:
 			http.NotFound(w, r)
 		}
@@ -254,13 +331,12 @@ func newConnectedSheetsFixtureServer(t *testing.T) (*httptest.Server, *[]string)
 	return srv, &queries
 }
 
-// filterConnectedSheetsFixture mirrors a live spreadsheets.get: when ranges are
-// supplied the response only carries the sheets those ranges intersect, so a
+// connectedSheetsFixtureForRanges mirrors a live spreadsheets.get: when ranges
+// are supplied the response only carries the sheets those ranges intersect, so a
 // SYNC_ALL extract's column list on the separate DATA_SOURCE sheet disappears.
-func filterConnectedSheetsFixture(t *testing.T, fixture []byte, ranges []string) []byte {
-	t.Helper()
+func connectedSheetsFixtureForRanges(parsed map[string]any, full []byte, ranges []string) ([]byte, error) {
 	if len(ranges) == 0 {
-		return fixture
+		return full, nil
 	}
 	titles := make(map[string]bool, len(ranges))
 	for _, item := range ranges {
@@ -271,11 +347,7 @@ func filterConnectedSheetsFixture(t *testing.T, fixture []byte, ranges []string)
 		titles[strings.Trim(title, "'")] = true
 	}
 
-	var payload map[string]any
-	if err := json.Unmarshal(fixture, &payload); err != nil {
-		t.Fatalf("decode Connected Sheets fixture: %v", err)
-	}
-	sheetsValue, _ := payload["sheets"].([]any)
+	sheetsValue, _ := parsed["sheets"].([]any)
 	kept := make([]any, 0, len(sheetsValue))
 	for _, sheet := range sheetsValue {
 		entry, _ := sheet.(map[string]any)
@@ -285,12 +357,13 @@ func filterConnectedSheetsFixture(t *testing.T, fixture []byte, ranges []string)
 			kept = append(kept, sheet)
 		}
 	}
-	payload["sheets"] = kept
 
-	filtered, err := json.Marshal(payload)
-	if err != nil {
-		t.Fatalf("encode filtered Connected Sheets fixture: %v", err)
+	// Copy rather than mutate: the parsed fixture is shared across requests.
+	filtered := make(map[string]any, len(parsed))
+	for key, value := range parsed {
+		filtered[key] = value
 	}
+	filtered["sheets"] = kept
 
-	return filtered
+	return json.Marshal(filtered)
 }

--- a/internal/cmd/sheets_datasource_test.go
+++ b/internal/cmd/sheets_datasource_test.go
@@ -28,6 +28,8 @@ func TestSheetsDataSourceListAndDescribe(t *testing.T) {
 		SpreadsheetID string `json:"spreadsheetId"`
 		DataSources   []struct {
 			DataSourceID string `json:"dataSourceId"`
+			SheetID      int64  `json:"sheetId"`
+			SheetTitle   string `json:"sheetTitle"`
 			Provider     string `json:"provider"`
 			Source       string `json:"source"`
 			State        string `json:"state"`
@@ -45,6 +47,15 @@ func TestSheetsDataSourceListAndDescribe(t *testing.T) {
 	}
 	if list.DataSources[1].Provider != "BIGQUERY" || list.DataSources[1].Source != "bigquery-public-data.samples.shakespeare" {
 		t.Fatalf("table data source summary = %#v", list.DataSources[1])
+	}
+	// Live responses omit Spreadsheet.dataSources[].sheetId, so both entries must
+	// resolve their linked sheet by data source id rather than latching onto the
+	// unrelated tab that happens to have sheet id 0.
+	if list.DataSources[0].SheetID != 102 || list.DataSources[0].SheetTitle != "Query Preview" {
+		t.Fatalf("query data source sheet identity = %#v", list.DataSources[0])
+	}
+	if list.DataSources[1].SheetID != 101 || list.DataSources[1].SheetTitle != "Shakespeare Preview" {
+		t.Fatalf("table data source sheet identity = %#v", list.DataSources[1])
 	}
 	if strings.Contains(listResult.stdout, "SELECT corpus") {
 		t.Fatalf("list output should not expose raw query text: %s", listResult.stdout)

--- a/internal/cmd/sheets_datasource_test.go
+++ b/internal/cmd/sheets_datasource_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"strings"
 	"testing"
@@ -135,6 +136,40 @@ func TestSheetsDataSourceTableListDescribeAndRead(t *testing.T) {
 	}
 }
 
+func TestSheetsDataSourceTableReadSyncAllExtract(t *testing.T) {
+	srv, _ := newConnectedSheetsFixtureServer(t)
+	defer srv.Close()
+	svc := newSheetsServiceFromServer(t, srv)
+
+	// A SYNC_ALL extract carries no inline column list, and the ranged
+	// spreadsheets.get that locates the anchor omits the DATA_SOURCE sheet that
+	// does, so the column count has to be recovered from an unranged read.
+	readResult := executeWithSheetsTestService(t, []string{
+		"--json", "--account", "services@openclaw.org",
+		"sheets", "datasource", "table", "read", "connected1", "Synced Extract!A1", "--max-rows", "3",
+	}, svc)
+	if readResult.err != nil {
+		t.Fatalf("read SYNC_ALL data-source table: %v", readResult.err)
+	}
+	var read struct {
+		Anchor       string `json:"anchor"`
+		Range        string `json:"range"`
+		DataSourceID string `json:"dataSourceId"`
+		Truncated    bool   `json:"truncated"`
+	}
+	if err := json.Unmarshal([]byte(readResult.stdout), &read); err != nil {
+		t.Fatalf("decode read JSON: %v\n%s", err, readResult.stdout)
+	}
+	// ds-query exposes two columns on its DATA_SOURCE sheet, so three data rows
+	// plus the header span A1:B4.
+	if read.Anchor != "'Synced Extract'!A1" || read.Range != "'Synced Extract'!A1:B4" {
+		t.Fatalf("unexpected SYNC_ALL read bounds: %#v", read)
+	}
+	if read.DataSourceID != "ds-query" || !read.Truncated {
+		t.Fatalf("unexpected SYNC_ALL read identity: %#v", read)
+	}
+}
+
 func TestSheetsDataSourceTableValidation(t *testing.T) {
 	for _, test := range []struct {
 		name   string
@@ -196,8 +231,12 @@ func newConnectedSheetsFixtureServer(t *testing.T) (*httptest.Server, *[]string)
 		path := strings.TrimPrefix(strings.TrimPrefix(r.URL.Path, "/sheets/v4"), "/v4")
 		switch {
 		case strings.Contains(path, "/spreadsheets/connected1/values/") && r.Method == http.MethodGet:
+			requested, err := url.PathUnescape(strings.TrimPrefix(path, "/spreadsheets/connected1/values/"))
+			if err != nil {
+				t.Fatalf("decode values range: %v", err)
+			}
 			_ = json.NewEncoder(w).Encode(map[string]any{
-				"range":          "Extracts!B3:C6",
+				"range":          requested,
 				"majorDimension": "ROWS",
 				"values": [][]any{
 					{"word", "word_count"},
@@ -207,10 +246,51 @@ func newConnectedSheetsFixtureServer(t *testing.T) (*httptest.Server, *[]string)
 				},
 			})
 		case strings.HasPrefix(path, "/spreadsheets/connected1") && r.Method == http.MethodGet:
-			_, _ = w.Write(fixture)
+			_, _ = w.Write(filterConnectedSheetsFixture(t, fixture, r.URL.Query()["ranges"]))
 		default:
 			http.NotFound(w, r)
 		}
 	}))
 	return srv, &queries
+}
+
+// filterConnectedSheetsFixture mirrors a live spreadsheets.get: when ranges are
+// supplied the response only carries the sheets those ranges intersect, so a
+// SYNC_ALL extract's column list on the separate DATA_SOURCE sheet disappears.
+func filterConnectedSheetsFixture(t *testing.T, fixture []byte, ranges []string) []byte {
+	t.Helper()
+	if len(ranges) == 0 {
+		return fixture
+	}
+	titles := make(map[string]bool, len(ranges))
+	for _, item := range ranges {
+		title := item
+		if idx := strings.LastIndex(item, "!"); idx >= 0 {
+			title = item[:idx]
+		}
+		titles[strings.Trim(title, "'")] = true
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(fixture, &payload); err != nil {
+		t.Fatalf("decode Connected Sheets fixture: %v", err)
+	}
+	sheetsValue, _ := payload["sheets"].([]any)
+	kept := make([]any, 0, len(sheetsValue))
+	for _, sheet := range sheetsValue {
+		entry, _ := sheet.(map[string]any)
+		properties, _ := entry["properties"].(map[string]any)
+		title, _ := properties["title"].(string)
+		if titles[title] {
+			kept = append(kept, sheet)
+		}
+	}
+	payload["sheets"] = kept
+
+	filtered, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("encode filtered Connected Sheets fixture: %v", err)
+	}
+
+	return filtered
 }

--- a/internal/cmd/testdata/sheets_connected_sheets.json
+++ b/internal/cmd/testdata/sheets_connected_sheets.json
@@ -139,6 +139,40 @@
           ]
         }
       ]
+    },
+    {
+      "properties": {
+        "sheetId": 202,
+        "title": "Synced Extract",
+        "index": 4,
+        "sheetType": "GRID",
+        "gridProperties": {
+          "rowCount": 1000,
+          "columnCount": 26
+        }
+      },
+      "data": [
+        {
+          "startRow": 0,
+          "startColumn": 0,
+          "rowData": [
+            {
+              "values": [
+                {
+                  "dataSourceTable": {
+                    "dataSourceId": "ds-query",
+                    "columnSelectionType": "SYNC_ALL",
+                    "dataExecutionStatus": {
+                      "state": "SUCCEEDED",
+                      "lastRefreshTime": "2026-08-13T16:32:00Z"
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/internal/cmd/testdata/sheets_connected_sheets.json
+++ b/internal/cmd/testdata/sheets_connected_sheets.json
@@ -6,7 +6,6 @@
   "dataSources": [
     {
       "dataSourceId": "ds-table",
-      "sheetId": 101,
       "spec": {
         "bigQuery": {
           "projectId": "billing-project",
@@ -20,7 +19,6 @@
     },
     {
       "dataSourceId": "ds-query",
-      "sheetId": 102,
       "spec": {
         "bigQuery": {
           "projectId": "billing-project",
@@ -43,9 +41,21 @@
   "sheets": [
     {
       "properties": {
+        "sheetId": 0,
+        "title": "Unrelated First Tab",
+        "index": 0,
+        "sheetType": "GRID",
+        "gridProperties": {
+          "rowCount": 100,
+          "columnCount": 10
+        }
+      }
+    },
+    {
+      "properties": {
         "sheetId": 101,
         "title": "Shakespeare Preview",
-        "index": 0,
+        "index": 1,
         "sheetType": "DATA_SOURCE",
         "gridProperties": {
           "rowCount": 500,
@@ -70,7 +80,7 @@
       "properties": {
         "sheetId": 102,
         "title": "Query Preview",
-        "index": 1,
+        "index": 2,
         "sheetType": "DATA_SOURCE",
         "gridProperties": {
           "rowCount": 500,
@@ -95,7 +105,7 @@
       "properties": {
         "sheetId": 201,
         "title": "Extracts",
-        "index": 2,
+        "index": 3,
         "sheetType": "GRID",
         "gridProperties": {
           "rowCount": 1000,


### PR DESCRIPTION
Refs #938

Live validation of the read-only Connected Sheets surface from #989, against a real set of
BigQuery-backed spreadsheets, surfaced two defects. Both are invisible to the current tests
because the fixture does not match what the API actually returns.

## Summary

- resolve a data source's linked sheet by data source id, and treat that sheet's own id as
  authoritative, so `sheets datasource list` stops reporting `sheetId: 0`
- fall back to an unranged, properties-only fetch when a ranged `spreadsheets.get` cannot supply
  an extract's column count, which unblocks every `SYNC_ALL` extract
- make the fixture server range-aware and drop `dataSources[].sheetId` from the fixture, so both
  paths are exercised the way the live API behaves

## Details

**`datasource list` always reported `sheetId: 0`.** Live `spreadsheets.get` responses do not
populate `Spreadsheet.dataSources[].sheetId`; it comes back null. `sheetsDataSourceToItem` emitted
`source.SheetId` directly. The correct id is already available on the matched sheet, and
`datasource table list` uses it, so the two code paths now agree.

That same zero value also made `findSheetsDataSourceSheet` unsafe: it compared
`properties.SheetId == source.SheetId` before checking the data source id, so in a spreadsheet
containing a tab with sheet id 0, every data source would match that unrelated tab and report its
title and `dataExecutionStatus`. I could not reproduce this in practice — none of the 59
spreadsheets I scanned has a tab with sheet id 0 — so I am flagging it as latent rather than
observed. The ordering is wrong either way.

**`datasource table read` failed for every `SYNC_ALL` extract.** A `SYNC_ALL` table carries no
inline column list, so the column count has to come from `dataSourceSheetProperties` on the
associated `DATA_SOURCE` sheet. The anchor lookup passes `ranges`, and a ranged `spreadsheets.get`
returns only the sheets those ranges intersect, which excludes the `DATA_SOURCE` sheet:

```
ranges absent  -> grid sheets + DATA_SOURCE sheets
ranges present -> the anchor's grid sheet only
```

So `dataSourceColumnCount` found nothing and the command exited with
`cannot determine columns for data-source table`.

## Proof

- `make ci`
- `go test ./internal/cmd -run 'TestSheetsDataSource' -count=1 -v`
- both new assertions were confirmed to fail before their corresponding fix: the sheet-identity
  test reports the decoy tab, and the SYNC_ALL read test reproduces the exact
  `cannot determine columns` error

Live validation was read-only throughout (`--readonly` on every invocation; no spreadsheet was
modified):

| | before | after |
|---|---|---|
| data sources resolving a real linked sheet id | 0 / 56 | 56 / 56 |
| extracts readable via `datasource table read` | 0 / 54 | 54 / 54 |

Corpus: 59 spreadsheets scanned, 21 with Connected Sheets, 54 anchored extracts. Every extract in
it uses `SYNC_ALL`; there was not a single `SELECTED` extract, which is why this path failing was
total rather than partial.

Two notes:

- the `SYNC_ALL` fallback costs a second `spreadsheets.get` on that path. Reading all 54 extracts
  back to back tripped Sheets rate limits a few times; pacing the loop cleared it. Worth knowing
  before scripting bulk extract reads.
- `docs/sheets-connected.md` presents `--extra-scopes .../bigquery.readonly --force-consent` as a
  required step. It is not required when the stored token already carries a superset: all of the
  above ran on a token holding `cloud-platform` and `spreadsheets`, with no re-consent. That may
  be a cheaper route to a live Connected Sheets environment than provisioning the exact scopes.
