### PR TITLE
fix(paging): stop calendar and Gmail listing on a repeated page token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Security: bound `gmail watch serve` and the local OAuth callback HTTP servers with read, idle, and header-size limits so a slow or oversized request cannot stall the listener.
+- Calendar/Gmail: stop listing immediately when Google repeats a pagination token, including resumed Gmail backups. (#1004) — thanks @SebTardif.
 
 ## v0.37.0 - 2026-08-14
 

--- a/internal/backup/gmail/fetch.go
+++ b/internal/backup/gmail/fetch.go
@@ -20,6 +20,7 @@ var (
 	errCacheRequired     = errors.New("gmail backup cache is required")
 	errFetchStopped      = errors.New("gmail backup fetch stopped before completion")
 	errMessageIDMismatch = errors.New("gmail backup source returned a different message ID")
+	errRepeatedPageToken = errors.New("repeated page token")
 )
 
 type CacheStore interface {
@@ -85,6 +86,7 @@ func ListMessageIDs(ctx context.Context, source Source, opts ListOptions) ([]str
 
 	ids := make([]string, 0)
 	seen := make(map[string]struct{})
+	seenTokens := map[string]struct{}{}
 	pageToken := ""
 	if opts.UseCache && !opts.Refresh {
 		state, found, err := opts.Cache.ReadListState(opts.Selection)
@@ -134,7 +136,8 @@ func ListMessageIDs(ctx context.Context, source Source, opts ListOptions) ([]str
 		ids = appendUniqueIDs(ids, seen, page.IDs, opts.Selection.Max)
 		emitEvent(opts.Progress, Event{Phase: EventPhaseList, Done: len(ids)})
 
-		complete := strings.TrimSpace(page.NextPageToken) == "" || reachedSelectionMax(ids, opts.Selection.Max)
+		next := strings.TrimSpace(page.NextPageToken)
+		complete := next == "" || reachedSelectionMax(ids, opts.Selection.Max)
 		if opts.UseCache {
 			nextToken := page.NextPageToken
 			if complete {
@@ -147,6 +150,10 @@ func ListMessageIDs(ctx context.Context, source Source, opts ListOptions) ([]str
 		if complete {
 			break
 		}
+		if _, exists := seenTokens[next]; exists {
+			return nil, fmt.Errorf("list Gmail backup messages: %w %q", errRepeatedPageToken, next)
+		}
+		seenTokens[next] = struct{}{}
 		pageToken = page.NextPageToken
 	}
 	return ids, nil

--- a/internal/backup/gmail/fetch.go
+++ b/internal/backup/gmail/fetch.go
@@ -109,6 +109,9 @@ func ListMessageIDs(ctx context.Context, source Source, opts ListOptions) ([]str
 		}
 	}
 	emitEvent(opts.Progress, Event{Phase: EventPhaseList, Resume: "start", Done: len(ids)})
+	if initial := strings.TrimSpace(pageToken); initial != "" {
+		seenTokens[initial] = struct{}{}
+	}
 
 	for {
 		if err := ctx.Err(); err != nil {
@@ -138,8 +141,14 @@ func ListMessageIDs(ctx context.Context, source Source, opts ListOptions) ([]str
 
 		next := strings.TrimSpace(page.NextPageToken)
 		complete := next == "" || reachedSelectionMax(ids, opts.Selection.Max)
+		if !complete {
+			if _, exists := seenTokens[next]; exists {
+				return nil, fmt.Errorf("list Gmail backup messages: %w %q", errRepeatedPageToken, next)
+			}
+			seenTokens[next] = struct{}{}
+		}
 		if opts.UseCache {
-			nextToken := page.NextPageToken
+			nextToken := next
 			if complete {
 				nextToken = ""
 			}
@@ -150,11 +159,7 @@ func ListMessageIDs(ctx context.Context, source Source, opts ListOptions) ([]str
 		if complete {
 			break
 		}
-		if _, exists := seenTokens[next]; exists {
-			return nil, fmt.Errorf("list Gmail backup messages: %w %q", errRepeatedPageToken, next)
-		}
-		seenTokens[next] = struct{}{}
-		pageToken = page.NextPageToken
+		pageToken = next
 	}
 	return ids, nil
 }

--- a/internal/backup/gmail/fetch_test.go
+++ b/internal/backup/gmail/fetch_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -120,6 +121,31 @@ func TestListMessageIDsMarksMaxedPartialStateComplete(t *testing.T) {
 	if len(source.listRequests) != 0 {
 		t.Fatalf("requests = %+v", source.listRequests)
 	}
+}
+
+type stuckPageTokenSource struct{}
+
+func (stuckPageTokenSource) Labels(context.Context) ([]Label, error) {
+	return nil, nil
+}
+
+func (stuckPageTokenSource) ListMessageIDs(context.Context, ListRequest) (ListPage, error) {
+	return ListPage{IDs: []string{"m1"}, NextPageToken: "stuck"}, nil
+}
+
+func (stuckPageTokenSource) RawMessage(context.Context, string) (Message, error) {
+	return Message{}, nil
+}
+
+func TestListMessageIDsRejectsRepeatedPageToken(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+	_, err := ListMessageIDs(ctx, stuckPageTokenSource{}, ListOptions{})
+	if err == nil || !strings.Contains(err.Error(), `repeated page token "stuck"`) {
+		t.Fatalf("err = %v", err)
+	}
+	t.Logf("err = %v", err)
 }
 
 func TestFetchMessagesPreservesInputOrderAcrossWorkers(t *testing.T) {

--- a/internal/backup/gmail/fetch_test.go
+++ b/internal/backup/gmail/fetch_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -123,29 +122,40 @@ func TestListMessageIDsMarksMaxedPartialStateComplete(t *testing.T) {
 	}
 }
 
-type stuckPageTokenSource struct{}
-
-func (stuckPageTokenSource) Labels(context.Context) ([]Label, error) {
-	return nil, nil
-}
-
-func (stuckPageTokenSource) ListMessageIDs(context.Context, ListRequest) (ListPage, error) {
-	return ListPage{IDs: []string{"m1"}, NextPageToken: "stuck"}, nil
-}
-
-func (stuckPageTokenSource) RawMessage(context.Context, string) (Message, error) {
-	return Message{}, nil
-}
-
 func TestListMessageIDsRejectsRepeatedPageToken(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
-	defer cancel()
-	_, err := ListMessageIDs(ctx, stuckPageTokenSource{}, ListOptions{})
-	if err == nil || !strings.Contains(err.Error(), `repeated page token "stuck"`) {
+	source := &fakeSource{listPages: map[string]ListPage{
+		"":      {IDs: []string{"m1"}, NextPageToken: "stuck"},
+		"stuck": {IDs: []string{"m1"}, NextPageToken: "stuck"},
+	}}
+	_, err := ListMessageIDs(context.Background(), source, ListOptions{})
+	if !errors.Is(err, errRepeatedPageToken) || len(source.listRequests) != 2 {
 		t.Fatalf("err = %v", err)
 	}
-	t.Logf("err = %v", err)
+}
+
+func TestListMessageIDsRejectsRepeatedResumeTokenBeforeCacheWrite(t *testing.T) {
+	t.Parallel()
+	cache := newPlannerCache(t)
+	selection := Selection{AccountHash: "accthash"}
+	if err := cache.WriteListState(selection, []string{"cached"}, "stuck", false); err != nil {
+		t.Fatalf("WriteListState: %v", err)
+	}
+	source := &fakeSource{listPages: map[string]ListPage{
+		"stuck": {IDs: []string{"new"}, NextPageToken: "stuck"},
+	}}
+	_, err := ListMessageIDs(context.Background(), source, ListOptions{
+		Selection: selection,
+		Cache:     cache,
+		UseCache:  true,
+	})
+	if !errors.Is(err, errRepeatedPageToken) || len(source.listRequests) != 1 {
+		t.Fatalf("err = %v, requests = %+v", err, source.listRequests)
+	}
+	state, found, err := cache.ReadListState(selection)
+	if err != nil || !found || fmt.Sprint(state.IDs) != "[cached]" || state.PageToken != "stuck" {
+		t.Fatalf("cache state changed after repeated token: state=%+v found=%t err=%v", state, found, err)
+	}
 }
 
 func TestFetchMessagesPreservesInputOrderAcrossWorkers(t *testing.T) {

--- a/internal/backup/gmail/source_test.go
+++ b/internal/backup/gmail/source_test.go
@@ -5,9 +5,11 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"google.golang.org/api/gmail/v1"
@@ -95,5 +97,47 @@ func TestNewServiceSourceRejectsNil(t *testing.T) {
 	t.Parallel()
 	if _, err := NewServiceSource(nil); err == nil {
 		t.Fatal("NewServiceSource(nil) succeeded")
+	}
+}
+
+func TestListMessageIDsRejectsRepeatedPageTokenFromServiceSource(t *testing.T) {
+	t.Parallel()
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !strings.HasSuffix(r.URL.Path, "/messages") {
+			http.NotFound(w, r)
+			return
+		}
+		request := requests.Add(1)
+		wantToken := ""
+		if request > 1 {
+			wantToken = "stuck"
+		}
+		if token := r.URL.Query().Get("pageToken"); token != wantToken {
+			t.Errorf("request %d page token = %q, want %q", request, token, wantToken)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"messages":      []map[string]string{{"id": "message"}},
+			"nextPageToken": "stuck",
+		})
+	}))
+	defer server.Close()
+
+	service, err := gmail.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(server.Client()),
+		option.WithEndpoint(server.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("gmail.NewService: %v", err)
+	}
+	source, err := NewServiceSource(service)
+	if err != nil {
+		t.Fatalf("NewServiceSource: %v", err)
+	}
+	_, err = ListMessageIDs(context.Background(), source, ListOptions{})
+	if !errors.Is(err, errRepeatedPageToken) || requests.Load() != 2 {
+		t.Fatalf("repeated token detection: err=%v HTTP requests=%d", err, requests.Load())
 	}
 }

--- a/internal/cmd/calendar_list.go
+++ b/internal/cmd/calendar_list.go
@@ -361,28 +361,18 @@ func resolveCalendarIDs(ctx context.Context, store *config.ConfigStore, svc *cal
 }
 
 func listCalendarList(ctx context.Context, svc *calendar.Service) ([]*calendar.CalendarListEntry, error) {
-	var (
-		items     []*calendar.CalendarListEntry
-		pageToken string
-	)
-	for {
+	fetch := func(pageToken string) ([]*calendar.CalendarListEntry, string, error) {
 		call := svc.CalendarList.List().MaxResults(250).Context(ctx)
 		if pageToken != "" {
 			call = call.PageToken(pageToken)
 		}
 		resp, err := call.Do()
 		if err != nil {
-			return nil, err
+			return nil, "", err
 		}
-		if len(resp.Items) > 0 {
-			items = append(items, resp.Items...)
-		}
-		if resp.NextPageToken == "" {
-			break
-		}
-		pageToken = resp.NextPageToken
+		return resp.Items, resp.NextPageToken, nil
 	}
-	return items, nil
+	return collectAllPages("", fetch)
 }
 
 // sortEventsBy sorts events in place by the given key (start|end|summary|calendar).

--- a/internal/cmd/calendar_list_test.go
+++ b/internal/cmd/calendar_list_test.go
@@ -8,7 +8,6 @@ import (
 	"slices"
 	"strings"
 	"testing"
-	"time"
 
 	"google.golang.org/api/calendar/v3"
 	"google.golang.org/api/option"
@@ -84,7 +83,7 @@ func TestCalendarEventsListCall_EventTypesFilter(t *testing.T) {
 }
 
 func TestListCalendarListRejectsRepeatedPageToken(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	svc, cleanup := newTestCalendarService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !(strings.Contains(r.URL.Path, "calendarList") && r.Method == http.MethodGet) {
 			http.NotFound(w, r)
 			return
@@ -97,22 +96,9 @@ func TestListCalendarListRejectsRepeatedPageToken(t *testing.T) {
 			"nextPageToken": "stuck",
 		})
 	}))
-	defer srv.Close()
-
-	svc, err := calendar.NewService(context.Background(),
-		option.WithHTTPClient(srv.Client()),
-		option.WithEndpoint(srv.URL+"/"),
-		option.WithoutAuthentication(),
-	)
-	if err != nil {
-		t.Fatalf("NewService: %v", err)
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
-	defer cancel()
-	_, err = listCalendarList(ctx, svc)
+	defer cleanup()
+	_, err := listCalendarList(context.Background(), svc)
 	if err == nil || !strings.Contains(err.Error(), "repeated page token") {
 		t.Fatalf("err = %v", err)
 	}
-	t.Logf("err = %v", err)
 }

--- a/internal/cmd/calendar_list_test.go
+++ b/internal/cmd/calendar_list_test.go
@@ -6,7 +6,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"slices"
+	"strings"
 	"testing"
+	"time"
 
 	"google.golang.org/api/calendar/v3"
 	"google.golang.org/api/option"
@@ -79,4 +81,38 @@ func TestCalendarEventsListCall_EventTypesFilter(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestListCalendarListRejectsRepeatedPageToken(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !(strings.Contains(r.URL.Path, "calendarList") && r.Method == http.MethodGet) {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"items": []map[string]any{
+				{"id": "c1", "summary": "One", "accessRole": "owner"},
+			},
+			"nextPageToken": "stuck",
+		})
+	}))
+	defer srv.Close()
+
+	svc, err := calendar.NewService(context.Background(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+		option.WithoutAuthentication(),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+	_, err = listCalendarList(ctx, svc)
+	if err == nil || !strings.Contains(err.Error(), "repeated page token") {
+		t.Fatalf("err = %v", err)
+	}
+	t.Logf("err = %v", err)
 }


### PR DESCRIPTION
## What Problem This Solves

`gog calendar events --all` (and any other path that lists every calendar) walks `CalendarList.List` with no memory of page tokens it has already seen. Gmail backup ID listing does the same on `users.messages.list`. If Google repeats `nextPageToken`, both loops never finish.

## Why

The repo already has this guard. `collectAllPages` errors with `pagination loop: repeated page token`. Photos Picker and Drive changes do the same with a local seen-token map. `listCalendarList` is in package `cmd`, so it now calls `collectAllPages` instead of growing a second helper. Gmail backup lives under `internal/backup/gmail` and cannot import `cmd`, so it adds the same local `seenTokens` map Photos Picker already uses.

## User Impact

A stuck Google page token now fails with `repeated page token` instead of hanging `gog calendar events --all` or a Gmail backup list until the process is killed.

## Evidence

terminal output from the unpatched loops versus this patch, using a Calendar `httptest` server and a Gmail source that always return `nextPageToken=stuck`.

Unpatched (300ms context; the HTTP peer answers immediately, so the deadline is the only stop):

```console
$ go test ./internal/cmd/ -count=1 -timeout 5s -v -run TestListCalendarListRejectsRepeatedPageToken
=== RUN   TestListCalendarListRejectsRepeatedPageToken
    calendar_list_test.go:115: err = context deadline exceeded
--- FAIL: TestListCalendarListRejectsRepeatedPageToken (0.30s)
FAIL

$ go test ./internal/backup/gmail/ -count=1 -timeout 5s -v -run TestListMessageIDsRejectsRepeatedPageToken
=== RUN   TestListMessageIDsRejectsRepeatedPageToken
    fetch_test.go:146: err = list Gmail backup messages: context deadline exceeded
--- FAIL: TestListMessageIDsRejectsRepeatedPageToken (0.30s)
FAIL
```

Patched (same commands, same stuck token, returns immediately):

```console
$ go test ./internal/cmd/ -count=1 -timeout 10s -v -run TestListCalendarListRejectsRepeatedPageToken
=== RUN   TestListCalendarListRejectsRepeatedPageToken
    calendar_list_test.go:117: err = pagination loop: repeated page token "stuck"
--- PASS: TestListCalendarListRejectsRepeatedPageToken (0.00s)
PASS

$ go test ./internal/backup/gmail/ -count=1 -timeout 10s -v -run TestListMessageIDsRejectsRepeatedPageToken
=== RUN   TestListMessageIDsRejectsRepeatedPageToken
    fetch_test.go:148: err = list Gmail backup messages: repeated page token "stuck"
--- PASS: TestListMessageIDsRejectsRepeatedPageToken (0.00s)
PASS

$ go run proof_gmail_pages.go
elapsed=0s ids=[] err=list Gmail backup messages: repeated page token "stuck"
```

`go test ./internal/cmd/ ./internal/backup/gmail/ -count=1` also completed on this tree.

## Real behavior proof

- **Behavior or issue addressed:** Repeated Google `nextPageToken` values could hang calendar listing (`--all`) and Gmail backup ID listing.
- **Real environment tested:** macOS Darwin 25.6.0 arm64, Go go1.26.6, full clone at `/tmp/pr-gogcli-pages` on `fix/repeated-page-tokens` from `upstream/main`.
- **Exact steps or command run after this patch:** From `/tmp/pr-gogcli-pages`, ran the same `go test` commands shown above against a Calendar `httptest` that always returns `nextPageToken=stuck`, then ran `go run proof_gmail_pages.go` which calls exported `ListMessageIDs` with a source that always returns `NextPageToken "stuck"`.
- **Evidence after fix:** terminal output above. Calendar listing now returns `pagination loop: repeated page token "stuck"` in 0.00s. Gmail `ListMessageIDs` returns `list Gmail backup messages: repeated page token "stuck"` with `elapsed=0s`.
- **Observed result after fix:** The stuck token no longer runs until a context deadline. The process returns the repeated-token error on the next page instead of hanging.
- **What was not tested:** A live Google CalendarList or Gmail messages.list response that actually repeats a token. That requires a faulty Google page, which we cannot force from a healthy account.

## Related

- Same-repo guard already used by `collectAllPages` in `internal/cmd/paging.go`, Photos Picker (`errPhotosPickerRepeatedPage`), and Drive changes.
- Calendar listing without a seen-set dates to [#131](https://github.com/openclaw/gogcli/pull/131) ([`9977c0be`](https://github.com/openclaw/gogcli/commit/9977c0be), 2026-02-15, 184 days ago).
- Gmail backup ID paging dates to [`12461f5d`](https://github.com/openclaw/gogcli/commit/12461f5df6f5a5ea490579ee6b53a7e6f9e620de) (2026-06-13, 66 days ago).
