### PR TITLE
feat(appscript): add push, pull, deploy, and version management

### DIFF
--- a/.agents/skills/gog-appscript/SKILL.md
+++ b/.agents/skills/gog-appscript/SKILL.md
@@ -30,8 +30,14 @@ gog --readonly --account user@example.com appscript --help
 | --- | --- |
 | `content` | Get Apps Script project content |
 | `create` | Create an Apps Script project |
+| `deploy` | Create a version and deploy it (web app URL is printed) |
+| `deployments` | List deployments |
 | `get` | Get Apps Script project metadata |
+| `pull` | Pull an Apps Script project into a local directory |
+| `push` | Push a local directory into an Apps Script project (replaces every remote file) |
 | `run` | Run a deployed Apps Script function |
+| `undeploy` | Delete a deployment |
+| `versions` | List versions |
 
 Run `gog appscript <command> --help` for flags and `gog schema appscript <command> --json`
 for the machine-readable contract. Do not guess command syntax.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Apps Script: add `push`, `pull`, `deploy`, `deployments`, `undeploy`, and `versions` so a project's source can be synced from a local directory and released to a web app without leaving the CLI.
 - Security: bound `gmail watch serve` and the local OAuth callback HTTP servers with read, idle, and header-size limits so a slow or oversized request cannot stall the listener.
 
 ## v0.37.0 - 2026-08-14

--- a/docs/commands.generated.md
+++ b/docs/commands.generated.md
@@ -32,8 +32,14 @@ Generated from `gog schema --json`.
   - [`gog appscript (script,apps-script) <command> [flags]`](commands/gog-appscript.md) - Google Apps Script
     - [`gog appscript (script,apps-script) content (cat) <scriptId>`](commands/gog-appscript-content.md) - Get Apps Script project content
     - [`gog appscript (script,apps-script) create (new) --title=STRING [flags]`](commands/gog-appscript-create.md) - Create an Apps Script project
+    - [`gog appscript (script,apps-script) deploy <scriptId> [flags]`](commands/gog-appscript-deploy.md) - Create a version and deploy it (web app URL is printed)
+    - [`gog appscript (script,apps-script) deployments (list-deployments) <scriptId> [flags]`](commands/gog-appscript-deployments.md) - List deployments
     - [`gog appscript (script,apps-script) get (info,show) <scriptId>`](commands/gog-appscript-get.md) - Get Apps Script project metadata
+    - [`gog appscript (script,apps-script) pull <scriptId> <dir>`](commands/gog-appscript-pull.md) - Pull an Apps Script project into a local directory
+    - [`gog appscript (script,apps-script) push <scriptId> <dir>`](commands/gog-appscript-push.md) - Push a local directory into an Apps Script project (replaces every remote file)
     - [`gog appscript (script,apps-script) run <scriptId> <function> [flags]`](commands/gog-appscript-run.md) - Run a deployed Apps Script function
+    - [`gog appscript (script,apps-script) undeploy (delete-deployment) <scriptId> <deploymentId>`](commands/gog-appscript-undeploy.md) - Delete a deployment
+    - [`gog appscript (script,apps-script) versions (list-versions) <scriptId> [flags]`](commands/gog-appscript-versions.md) - List versions
   - [`gog auth <command> [flags]`](commands/gog-auth.md) - Auth and credentials
     - [`gog auth add <email> [flags]`](commands/gog-auth-add.md) - Authorize and store a refresh token
     - [`gog auth alias <command>`](commands/gog-auth-alias.md) - Manage account aliases

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -2,7 +2,7 @@
 
 Every `gog` command has a generated docs page. The source of truth is the live CLI schema; run `make docs-commands` after changing command names, flags, help text, aliases, or arguments.
 
-Generated pages: 719.
+Generated pages: 725.
 
 ## Top-level Commands
 
@@ -85,8 +85,14 @@ Generated pages: 719.
   - [gog appscript](gog-appscript.md) - Google Apps Script
     - [gog appscript content](gog-appscript-content.md) - Get Apps Script project content
     - [gog appscript create](gog-appscript-create.md) - Create an Apps Script project
+    - [gog appscript deploy](gog-appscript-deploy.md) - Create a version and deploy it (web app URL is printed)
+    - [gog appscript deployments](gog-appscript-deployments.md) - List deployments
     - [gog appscript get](gog-appscript-get.md) - Get Apps Script project metadata
+    - [gog appscript pull](gog-appscript-pull.md) - Pull an Apps Script project into a local directory
+    - [gog appscript push](gog-appscript-push.md) - Push a local directory into an Apps Script project (replaces every remote file)
     - [gog appscript run](gog-appscript-run.md) - Run a deployed Apps Script function
+    - [gog appscript undeploy](gog-appscript-undeploy.md) - Delete a deployment
+    - [gog appscript versions](gog-appscript-versions.md) - List versions
   - [gog auth](gog-auth.md) - Auth and credentials
     - [gog auth add](gog-auth-add.md) - Authorize and store a refresh token
     - [gog auth alias](gog-auth-alias.md) - Manage account aliases

--- a/docs/commands/gog-appscript-deploy.md
+++ b/docs/commands/gog-appscript-deploy.md
@@ -1,31 +1,18 @@
-# `gog appscript`
+# `gog appscript deploy`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Google Apps Script
+Create a version and deploy it (web app URL is printed)
 
 ## Usage
 
 ```bash
-gog appscript (script,apps-script) <command> [flags]
+gog appscript (script,apps-script) deploy <scriptId> [flags]
 ```
 
 ## Parent
 
-- [gog](gog.md)
-
-## Subcommands
-
-- [gog appscript content](gog-appscript-content.md) - Get Apps Script project content
-- [gog appscript create](gog-appscript-create.md) - Create an Apps Script project
-- [gog appscript deploy](gog-appscript-deploy.md) - Create a version and deploy it (web app URL is printed)
-- [gog appscript deployments](gog-appscript-deployments.md) - List deployments
-- [gog appscript get](gog-appscript-get.md) - Get Apps Script project metadata
-- [gog appscript pull](gog-appscript-pull.md) - Pull an Apps Script project into a local directory
-- [gog appscript push](gog-appscript-push.md) - Push a local directory into an Apps Script project (replaces every remote file)
-- [gog appscript run](gog-appscript-run.md) - Run a deployed Apps Script function
-- [gog appscript undeploy](gog-appscript-undeploy.md) - Delete a deployment
-- [gog appscript versions](gog-appscript-versions.md) - List versions
+- [gog appscript](gog-appscript.md)
 
 ## Flags
 
@@ -35,6 +22,8 @@ gog appscript (script,apps-script) <command> [flags]
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email, alias, or auto for authenticated Google API commands |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
+| `--deployment-id` | `string` |  | Update this existing deployment instead of creating a new one (keeps the same URL) |
+| `--description` | `string` |  | Version and deployment description |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
 | `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
 | `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
@@ -55,5 +44,5 @@ gog appscript (script,apps-script) <command> [flags]
 
 ## See Also
 
-- [gog](gog.md)
+- [gog appscript](gog-appscript.md)
 - [Command index](README.md)

--- a/docs/commands/gog-appscript-deployments.md
+++ b/docs/commands/gog-appscript-deployments.md
@@ -1,31 +1,18 @@
-# `gog appscript`
+# `gog appscript deployments`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Google Apps Script
+List deployments
 
 ## Usage
 
 ```bash
-gog appscript (script,apps-script) <command> [flags]
+gog appscript (script,apps-script) deployments (list-deployments) <scriptId> [flags]
 ```
 
 ## Parent
 
-- [gog](gog.md)
-
-## Subcommands
-
-- [gog appscript content](gog-appscript-content.md) - Get Apps Script project content
-- [gog appscript create](gog-appscript-create.md) - Create an Apps Script project
-- [gog appscript deploy](gog-appscript-deploy.md) - Create a version and deploy it (web app URL is printed)
-- [gog appscript deployments](gog-appscript-deployments.md) - List deployments
-- [gog appscript get](gog-appscript-get.md) - Get Apps Script project metadata
-- [gog appscript pull](gog-appscript-pull.md) - Pull an Apps Script project into a local directory
-- [gog appscript push](gog-appscript-push.md) - Push a local directory into an Apps Script project (replaces every remote file)
-- [gog appscript run](gog-appscript-run.md) - Run a deployed Apps Script function
-- [gog appscript undeploy](gog-appscript-undeploy.md) - Delete a deployment
-- [gog appscript versions](gog-appscript-versions.md) - List versions
+- [gog appscript](gog-appscript.md)
 
 ## Flags
 
@@ -33,18 +20,22 @@ gog appscript (script,apps-script) <command> [flags]
 | --- | --- | --- | --- |
 | `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email, alias, or auto for authenticated Google API commands |
+| `--all`<br>`--all-pages`<br>`--allpages` | `bool` |  | Fetch all pages |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
 | `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
 | `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
 | `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
+| `--fail-empty`<br>`--non-empty`<br>`--require-results` | `bool` |  | Exit with code 3 if no deployments |
 | `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
 | `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
 | `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--max`<br>`--limit` | `int64` | 100 | Max results |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `--page`<br>`--cursor` | `string` |  | Page token |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
 | `--readonly` | `bool` | false | Block mutating API requests at runtime; auth add also requests read-only OAuth scopes |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
@@ -55,5 +46,5 @@ gog appscript (script,apps-script) <command> [flags]
 
 ## See Also
 
-- [gog](gog.md)
+- [gog appscript](gog-appscript.md)
 - [Command index](README.md)

--- a/docs/commands/gog-appscript-pull.md
+++ b/docs/commands/gog-appscript-pull.md
@@ -1,31 +1,18 @@
-# `gog appscript`
+# `gog appscript pull`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Google Apps Script
+Pull an Apps Script project into a local directory
 
 ## Usage
 
 ```bash
-gog appscript (script,apps-script) <command> [flags]
+gog appscript (script,apps-script) pull <scriptId> <dir>
 ```
 
 ## Parent
 
-- [gog](gog.md)
-
-## Subcommands
-
-- [gog appscript content](gog-appscript-content.md) - Get Apps Script project content
-- [gog appscript create](gog-appscript-create.md) - Create an Apps Script project
-- [gog appscript deploy](gog-appscript-deploy.md) - Create a version and deploy it (web app URL is printed)
-- [gog appscript deployments](gog-appscript-deployments.md) - List deployments
-- [gog appscript get](gog-appscript-get.md) - Get Apps Script project metadata
-- [gog appscript pull](gog-appscript-pull.md) - Pull an Apps Script project into a local directory
-- [gog appscript push](gog-appscript-push.md) - Push a local directory into an Apps Script project (replaces every remote file)
-- [gog appscript run](gog-appscript-run.md) - Run a deployed Apps Script function
-- [gog appscript undeploy](gog-appscript-undeploy.md) - Delete a deployment
-- [gog appscript versions](gog-appscript-versions.md) - List versions
+- [gog appscript](gog-appscript.md)
 
 ## Flags
 
@@ -55,5 +42,5 @@ gog appscript (script,apps-script) <command> [flags]
 
 ## See Also
 
-- [gog](gog.md)
+- [gog appscript](gog-appscript.md)
 - [Command index](README.md)

--- a/docs/commands/gog-appscript-push.md
+++ b/docs/commands/gog-appscript-push.md
@@ -1,31 +1,18 @@
-# `gog appscript`
+# `gog appscript push`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Google Apps Script
+Push a local directory into an Apps Script project (replaces every remote file)
 
 ## Usage
 
 ```bash
-gog appscript (script,apps-script) <command> [flags]
+gog appscript (script,apps-script) push <scriptId> <dir>
 ```
 
 ## Parent
 
-- [gog](gog.md)
-
-## Subcommands
-
-- [gog appscript content](gog-appscript-content.md) - Get Apps Script project content
-- [gog appscript create](gog-appscript-create.md) - Create an Apps Script project
-- [gog appscript deploy](gog-appscript-deploy.md) - Create a version and deploy it (web app URL is printed)
-- [gog appscript deployments](gog-appscript-deployments.md) - List deployments
-- [gog appscript get](gog-appscript-get.md) - Get Apps Script project metadata
-- [gog appscript pull](gog-appscript-pull.md) - Pull an Apps Script project into a local directory
-- [gog appscript push](gog-appscript-push.md) - Push a local directory into an Apps Script project (replaces every remote file)
-- [gog appscript run](gog-appscript-run.md) - Run a deployed Apps Script function
-- [gog appscript undeploy](gog-appscript-undeploy.md) - Delete a deployment
-- [gog appscript versions](gog-appscript-versions.md) - List versions
+- [gog appscript](gog-appscript.md)
 
 ## Flags
 
@@ -55,5 +42,5 @@ gog appscript (script,apps-script) <command> [flags]
 
 ## See Also
 
-- [gog](gog.md)
+- [gog appscript](gog-appscript.md)
 - [Command index](README.md)

--- a/docs/commands/gog-appscript-undeploy.md
+++ b/docs/commands/gog-appscript-undeploy.md
@@ -1,31 +1,18 @@
-# `gog appscript`
+# `gog appscript undeploy`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Google Apps Script
+Delete a deployment
 
 ## Usage
 
 ```bash
-gog appscript (script,apps-script) <command> [flags]
+gog appscript (script,apps-script) undeploy (delete-deployment) <scriptId> <deploymentId>
 ```
 
 ## Parent
 
-- [gog](gog.md)
-
-## Subcommands
-
-- [gog appscript content](gog-appscript-content.md) - Get Apps Script project content
-- [gog appscript create](gog-appscript-create.md) - Create an Apps Script project
-- [gog appscript deploy](gog-appscript-deploy.md) - Create a version and deploy it (web app URL is printed)
-- [gog appscript deployments](gog-appscript-deployments.md) - List deployments
-- [gog appscript get](gog-appscript-get.md) - Get Apps Script project metadata
-- [gog appscript pull](gog-appscript-pull.md) - Pull an Apps Script project into a local directory
-- [gog appscript push](gog-appscript-push.md) - Push a local directory into an Apps Script project (replaces every remote file)
-- [gog appscript run](gog-appscript-run.md) - Run a deployed Apps Script function
-- [gog appscript undeploy](gog-appscript-undeploy.md) - Delete a deployment
-- [gog appscript versions](gog-appscript-versions.md) - List versions
+- [gog appscript](gog-appscript.md)
 
 ## Flags
 
@@ -55,5 +42,5 @@ gog appscript (script,apps-script) <command> [flags]
 
 ## See Also
 
-- [gog](gog.md)
+- [gog appscript](gog-appscript.md)
 - [Command index](README.md)

--- a/docs/commands/gog-appscript-versions.md
+++ b/docs/commands/gog-appscript-versions.md
@@ -1,31 +1,18 @@
-# `gog appscript`
+# `gog appscript versions`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Google Apps Script
+List versions
 
 ## Usage
 
 ```bash
-gog appscript (script,apps-script) <command> [flags]
+gog appscript (script,apps-script) versions (list-versions) <scriptId> [flags]
 ```
 
 ## Parent
 
-- [gog](gog.md)
-
-## Subcommands
-
-- [gog appscript content](gog-appscript-content.md) - Get Apps Script project content
-- [gog appscript create](gog-appscript-create.md) - Create an Apps Script project
-- [gog appscript deploy](gog-appscript-deploy.md) - Create a version and deploy it (web app URL is printed)
-- [gog appscript deployments](gog-appscript-deployments.md) - List deployments
-- [gog appscript get](gog-appscript-get.md) - Get Apps Script project metadata
-- [gog appscript pull](gog-appscript-pull.md) - Pull an Apps Script project into a local directory
-- [gog appscript push](gog-appscript-push.md) - Push a local directory into an Apps Script project (replaces every remote file)
-- [gog appscript run](gog-appscript-run.md) - Run a deployed Apps Script function
-- [gog appscript undeploy](gog-appscript-undeploy.md) - Delete a deployment
-- [gog appscript versions](gog-appscript-versions.md) - List versions
+- [gog appscript](gog-appscript.md)
 
 ## Flags
 
@@ -33,18 +20,22 @@ gog appscript (script,apps-script) <command> [flags]
 | --- | --- | --- | --- |
 | `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email, alias, or auto for authenticated Google API commands |
+| `--all`<br>`--all-pages`<br>`--allpages` | `bool` |  | Fetch all pages |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
 | `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
 | `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
 | `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
+| `--fail-empty`<br>`--non-empty`<br>`--require-results` | `bool` |  | Exit with code 3 if no versions |
 | `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
 | `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
 | `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--max`<br>`--limit` | `int64` | 100 | Max results |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `--page`<br>`--cursor` | `string` |  | Page token |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
 | `--readonly` | `bool` | false | Block mutating API requests at runtime; auth add also requests read-only OAuth scopes |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
@@ -55,5 +46,5 @@ gog appscript (script,apps-script) <command> [flags]
 
 ## See Also
 
-- [gog](gog.md)
+- [gog appscript](gog-appscript.md)
 - [Command index](README.md)

--- a/internal/cmd/appscript.go
+++ b/internal/cmd/appscript.go
@@ -16,6 +16,13 @@ type AppScriptCmd struct {
 	Content AppScriptContentCmd `cmd:"" name:"content" aliases:"cat" help:"Get Apps Script project content"`
 	Run     AppScriptRunCmd     `cmd:"" name:"run" help:"Run a deployed Apps Script function"`
 	Create  AppScriptCreateCmd  `cmd:"" name:"create" aliases:"new" help:"Create an Apps Script project"`
+
+	Push        AppScriptPushCmd        `cmd:"" name:"push" help:"Push a local directory into an Apps Script project (replaces every remote file)"`
+	Pull        AppScriptPullCmd        `cmd:"" name:"pull" help:"Pull an Apps Script project into a local directory"`
+	Deploy      AppScriptDeployCmd      `cmd:"" name:"deploy" help:"Create a version and deploy it (web app URL is printed)"`
+	Deployments AppScriptDeploymentsCmd `cmd:"" name:"deployments" aliases:"list-deployments" help:"List deployments"`
+	Undeploy    AppScriptUndeployCmd    `cmd:"" name:"undeploy" aliases:"delete-deployment" help:"Delete a deployment"`
+	Versions    AppScriptVersionsCmd    `cmd:"" name:"versions" aliases:"list-versions" help:"List versions"`
 }
 
 type AppScriptGetCmd struct {
@@ -97,13 +104,7 @@ func (c *AppScriptContentCmd) Run(ctx context.Context, flags *RootFlags) error {
 
 	u := ui.FromContext(ctx)
 	u.Out().Linef("script_id\t%s", content.ScriptId)
-	u.Out().Linef("files\t%d", len(content.Files))
-	for _, file := range content.Files {
-		if file == nil {
-			continue
-		}
-		u.Out().Linef("file\t%s\t%s", file.Name, file.Type)
-	}
+	printAppScriptFiles(u, content.Files)
 	return nil
 }
 
@@ -262,6 +263,16 @@ func parseExecutionError(status *scriptapi.Status) *scriptapi.ExecutionError {
 		return nil
 	}
 	return &detail
+}
+
+func printAppScriptFiles(u *ui.UI, files []*scriptapi.File) {
+	u.Out().Linef("files\t%d", len(files))
+	for _, file := range files {
+		if file == nil {
+			continue
+		}
+		u.Out().Linef("file\t%s\t%s", sanitizeTab(file.Name), file.Type)
+	}
 }
 
 func appScriptEditURL(scriptID string) string {

--- a/internal/cmd/appscript_deploy.go
+++ b/internal/cmd/appscript_deploy.go
@@ -1,0 +1,369 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	scriptapi "google.golang.org/api/script/v1"
+
+	"github.com/openclaw/gogcli/internal/outfmt"
+	"github.com/openclaw/gogcli/internal/ui"
+)
+
+type AppScriptDeployCmd struct {
+	ScriptID     string `arg:"" name:"scriptId" help:"Script ID"`
+	Description  string `name:"description" help:"Version and deployment description"`
+	DeploymentID string `name:"deployment-id" help:"Update this existing deployment instead of creating a new one (keeps the same URL)"`
+}
+
+func (c *AppScriptDeployCmd) Run(ctx context.Context, flags *RootFlags) error {
+	scriptID := strings.TrimSpace(normalizeGoogleID(c.ScriptID))
+	if scriptID == "" {
+		return usage("empty scriptId")
+	}
+
+	deploymentID := strings.TrimSpace(c.DeploymentID)
+	description := strings.TrimSpace(c.Description)
+
+	if dryRunErr := dryRunExit(ctx, flags, "appscript.deploy", map[string]any{
+		"script_id":     scriptID,
+		"description":   description,
+		"deployment_id": deploymentID,
+	}); dryRunErr != nil {
+		return dryRunErr
+	}
+
+	svc, err := requireAppScriptService(ctx, flags)
+	if err != nil {
+		return err
+	}
+
+	// A deployment always points at an immutable version, so every deploy needs a
+	// fresh version cut from the current content first.
+	version, err := svc.Projects.Versions.Create(scriptID, &scriptapi.Version{
+		Description: description,
+	}).Context(ctx).Do()
+	if err != nil {
+		return err
+	}
+
+	config := &scriptapi.DeploymentConfig{
+		Description:      description,
+		ManifestFileName: appScriptManifest,
+		ScriptId:         scriptID,
+		VersionNumber:    version.VersionNumber,
+	}
+
+	deployment, err := createOrUpdateAppScriptDeployment(ctx, svc, scriptID, deploymentID, config)
+	if err != nil {
+		return err
+	}
+
+	webAppURL := appScriptWebAppURL(deployment)
+
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(ctx, stdoutWriter(ctx), map[string]any{
+			"deployed":    true,
+			"version":     version.VersionNumber,
+			"deployment":  deployment,
+			"web_app_url": webAppURL,
+		})
+	}
+
+	u := ui.FromContext(ctx)
+	u.Out().Linef("deployed\ttrue")
+	u.Out().Linef("version\t%d", version.VersionNumber)
+	u.Out().Linef("deployment_id\t%s", deployment.DeploymentId)
+
+	if webAppURL != "" {
+		u.Out().Linef("web_app_url\t%s", webAppURL)
+	}
+
+	return nil
+}
+
+func createOrUpdateAppScriptDeployment(
+	ctx context.Context,
+	svc *scriptapi.Service,
+	scriptID string,
+	deploymentID string,
+	config *scriptapi.DeploymentConfig,
+) (*scriptapi.Deployment, error) {
+	if deploymentID == "" {
+		return svc.Projects.Deployments.Create(scriptID, config).Context(ctx).Do()
+	}
+
+	return svc.Projects.Deployments.Update(scriptID, deploymentID, &scriptapi.UpdateDeploymentRequest{
+		DeploymentConfig: config,
+	}).Context(ctx).Do()
+}
+
+type AppScriptDeploymentsCmd struct {
+	ScriptID  string `arg:"" name:"scriptId" help:"Script ID"`
+	Max       int64  `name:"max" aliases:"limit" help:"Max results" default:"100"`
+	Page      string `name:"page" aliases:"cursor" help:"Page token"`
+	All       bool   `name:"all" aliases:"all-pages,allpages" help:"Fetch all pages"`
+	FailEmpty bool   `name:"fail-empty" aliases:"non-empty,require-results" help:"Exit with code 3 if no deployments"`
+}
+
+func (c *AppScriptDeploymentsCmd) Run(ctx context.Context, flags *RootFlags) error {
+	scriptID, svc, err := appScriptListSetup(ctx, flags, c.ScriptID, c.Max)
+	if err != nil {
+		return err
+	}
+
+	return runAppScriptList(ctx, appScriptListRequest[*scriptapi.Deployment]{
+		ScriptID:     scriptID,
+		ItemsKey:     "deployments",
+		EmptyMessage: "No deployments",
+		Page:         c.Page,
+		All:          c.All,
+		FailEmpty:    c.FailEmpty,
+		Columns:      appScriptDeploymentColumns(),
+		Fetch:        appScriptDeploymentPager(ctx, svc, scriptID, c.Max),
+	})
+}
+
+func appScriptDeploymentPager(ctx context.Context, svc *scriptapi.Service, scriptID string, maxResults int64) pageFetchFunc[*scriptapi.Deployment] {
+	return func(pageToken string) ([]*scriptapi.Deployment, string, error) {
+		call := svc.Projects.Deployments.List(scriptID).PageSize(maxResults).Context(ctx)
+		if page := strings.TrimSpace(pageToken); page != "" {
+			call = call.PageToken(page)
+		}
+
+		resp, err := call.Do()
+		if err != nil {
+			return nil, "", err
+		}
+
+		return resp.Deployments, resp.NextPageToken, nil
+	}
+}
+
+func appScriptVersionPager(ctx context.Context, svc *scriptapi.Service, scriptID string, maxResults int64) pageFetchFunc[*scriptapi.Version] {
+	return func(pageToken string) ([]*scriptapi.Version, string, error) {
+		call := svc.Projects.Versions.List(scriptID).PageSize(maxResults).Context(ctx)
+		if page := strings.TrimSpace(pageToken); page != "" {
+			call = call.PageToken(page)
+		}
+
+		resp, err := call.Do()
+		if err != nil {
+			return nil, "", err
+		}
+
+		return resp.Versions, resp.NextPageToken, nil
+	}
+}
+
+// appScriptListSetup applies the validation and service construction the
+// appscript list commands share.
+func appScriptListSetup(ctx context.Context, flags *RootFlags, rawScriptID string, maxResults int64) (string, *scriptapi.Service, error) {
+	scriptID := strings.TrimSpace(normalizeGoogleID(rawScriptID))
+	if scriptID == "" {
+		return "", nil, usage("empty scriptId")
+	}
+
+	if maxResults <= 0 {
+		return "", nil, usage("max must be > 0")
+	}
+
+	svc, err := requireAppScriptService(ctx, flags)
+	if err != nil {
+		return "", nil, err
+	}
+
+	return scriptID, svc, nil
+}
+
+// appScriptListRequest carries everything the two appscript list commands vary:
+// the API call, how their items are named, and how they render.
+type appScriptListRequest[T any] struct {
+	ScriptID     string
+	ItemsKey     string
+	EmptyMessage string
+	Page         string
+	All          bool
+	FailEmpty    bool
+	Columns      []outfmt.Column[T]
+	Fetch        pageFetchFunc[T]
+}
+
+func runAppScriptList[T any](ctx context.Context, req appScriptListRequest[T]) error {
+	u := ui.FromContext(ctx)
+
+	items, nextPageToken, err := loadPagedItems(req.Page, req.All, req.Fetch)
+	if err != nil {
+		return err
+	}
+
+	if items == nil {
+		items = []T{}
+	}
+
+	if outfmt.IsJSON(ctx) {
+		return writePagedJSONResult(ctx, map[string]any{
+			"scriptId":      req.ScriptID,
+			req.ItemsKey:    items,
+			"nextPageToken": nextPageToken,
+		}, len(items), req.FailEmpty)
+	}
+
+	if len(items) == 0 {
+		u.Err().Println(req.EmptyMessage)
+		return failEmptyExit(req.FailEmpty)
+	}
+
+	if err := outfmt.WriteTable(ctx, stdoutWriter(ctx), items, req.Columns); err != nil {
+		return err
+	}
+
+	printNextPageHintWithAll(u, nextPageToken, "--all/--all-pages")
+
+	return nil
+}
+
+func appScriptDeploymentColumns() []outfmt.Column[*scriptapi.Deployment] {
+	return []outfmt.Column[*scriptapi.Deployment]{
+		{Header: "DEPLOYMENT_ID", Value: appScriptDeploymentID},
+		{Header: "VERSION", Value: appScriptDeploymentVersion},
+		{Header: "DESCRIPTION", Value: appScriptDeploymentDescription},
+		{Header: "WEB_APP_URL", Value: appScriptWebAppURL},
+	}
+}
+
+func appScriptDeploymentID(deployment *scriptapi.Deployment) string {
+	if deployment == nil {
+		return ""
+	}
+
+	return deployment.DeploymentId
+}
+
+// appScriptDeploymentVersion reports HEAD for a deployment pinned to the live
+// editor content rather than to a cut version.
+func appScriptDeploymentVersion(deployment *scriptapi.Deployment) string {
+	if deployment == nil || deployment.DeploymentConfig == nil || deployment.DeploymentConfig.VersionNumber == 0 {
+		return "HEAD"
+	}
+
+	return "v" + strconv.FormatInt(deployment.DeploymentConfig.VersionNumber, 10)
+}
+
+func appScriptDeploymentDescription(deployment *scriptapi.Deployment) string {
+	if deployment == nil || deployment.DeploymentConfig == nil {
+		return ""
+	}
+
+	return sanitizeTab(deployment.DeploymentConfig.Description)
+}
+
+func appScriptWebAppURL(deployment *scriptapi.Deployment) string {
+	if deployment == nil {
+		return ""
+	}
+
+	for _, entry := range deployment.EntryPoints {
+		if entry == nil || entry.WebApp == nil {
+			continue
+		}
+
+		if entry.WebApp.Url != "" {
+			return entry.WebApp.Url
+		}
+	}
+
+	return ""
+}
+
+type AppScriptUndeployCmd struct {
+	ScriptID     string `arg:"" name:"scriptId" help:"Script ID"`
+	DeploymentID string `arg:"" name:"deploymentId" help:"Deployment ID to delete"`
+}
+
+func (c *AppScriptUndeployCmd) Run(ctx context.Context, flags *RootFlags) error {
+	scriptID := strings.TrimSpace(normalizeGoogleID(c.ScriptID))
+	if scriptID == "" {
+		return usage("empty scriptId")
+	}
+
+	deploymentID := strings.TrimSpace(c.DeploymentID)
+	if deploymentID == "" {
+		return usage("empty deploymentId")
+	}
+
+	if err := dryRunAndConfirmDestructive(ctx, flags, "appscript.undeploy", map[string]any{
+		"script_id":     scriptID,
+		"deployment_id": deploymentID,
+	}, fmt.Sprintf("delete Apps Script deployment %s (its web app URL stops working)", deploymentID)); err != nil {
+		return err
+	}
+
+	svc, err := requireAppScriptService(ctx, flags)
+	if err != nil {
+		return err
+	}
+
+	if _, err := svc.Projects.Deployments.Delete(scriptID, deploymentID).Context(ctx).Do(); err != nil {
+		return err
+	}
+
+	return writeResult(ctx, ui.FromContext(ctx),
+		kv("deleted", true),
+		kv("deployment_id", deploymentID),
+	)
+}
+
+type AppScriptVersionsCmd struct {
+	ScriptID  string `arg:"" name:"scriptId" help:"Script ID"`
+	Max       int64  `name:"max" aliases:"limit" help:"Max results" default:"100"`
+	Page      string `name:"page" aliases:"cursor" help:"Page token"`
+	All       bool   `name:"all" aliases:"all-pages,allpages" help:"Fetch all pages"`
+	FailEmpty bool   `name:"fail-empty" aliases:"non-empty,require-results" help:"Exit with code 3 if no versions"`
+}
+
+func (c *AppScriptVersionsCmd) Run(ctx context.Context, flags *RootFlags) error {
+	scriptID, svc, err := appScriptListSetup(ctx, flags, c.ScriptID, c.Max)
+	if err != nil {
+		return err
+	}
+
+	return runAppScriptList(ctx, appScriptListRequest[*scriptapi.Version]{
+		ScriptID:     scriptID,
+		ItemsKey:     "versions",
+		EmptyMessage: "No versions",
+		Page:         c.Page,
+		All:          c.All,
+		FailEmpty:    c.FailEmpty,
+		Columns:      appScriptVersionColumns(),
+		Fetch:        appScriptVersionPager(ctx, svc, scriptID, c.Max),
+	})
+}
+
+func appScriptVersionColumns() []outfmt.Column[*scriptapi.Version] {
+	return []outfmt.Column[*scriptapi.Version]{
+		{Header: "VERSION", Value: func(version *scriptapi.Version) string {
+			if version == nil {
+				return ""
+			}
+
+			return strconv.FormatInt(version.VersionNumber, 10)
+		}},
+		{Header: "CREATED", Value: func(version *scriptapi.Version) string {
+			if version == nil {
+				return ""
+			}
+
+			return formatDateTime(version.CreateTime)
+		}},
+		{Header: "DESCRIPTION", Value: func(version *scriptapi.Version) string {
+			if version == nil {
+				return ""
+			}
+
+			return sanitizeTab(version.Description)
+		}},
+	}
+}

--- a/internal/cmd/appscript_deploy_test.go
+++ b/internal/cmd/appscript_deploy_test.go
@@ -1,0 +1,236 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	scriptapi "google.golang.org/api/script/v1"
+)
+
+func TestAppScriptDeploymentVersion(t *testing.T) {
+	cases := []struct {
+		name       string
+		deployment *scriptapi.Deployment
+		want       string
+	}{
+		{name: "nil deployment", deployment: nil, want: "HEAD"},
+		{name: "no config", deployment: &scriptapi.Deployment{}, want: "HEAD"},
+		{
+			name:       "unversioned config tracks the editor",
+			deployment: &scriptapi.Deployment{DeploymentConfig: &scriptapi.DeploymentConfig{}},
+			want:       "HEAD",
+		},
+		{
+			name:       "versioned",
+			deployment: &scriptapi.Deployment{DeploymentConfig: &scriptapi.DeploymentConfig{VersionNumber: 7}},
+			want:       "v7",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := appScriptDeploymentVersion(tc.deployment); got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAppScriptWebAppURL(t *testing.T) {
+	if got := appScriptWebAppURL(nil); got != "" {
+		t.Fatalf("nil deployment: got %q", got)
+	}
+
+	deployment := &scriptapi.Deployment{
+		EntryPoints: []*scriptapi.EntryPoint{
+			nil,
+			{EntryPointType: "EXECUTION_API"},
+			{WebApp: &scriptapi.GoogleAppsScriptTypeWebAppEntryPoint{Url: "https://example.test/exec"}},
+		},
+	}
+	if got := appScriptWebAppURL(deployment); got != "https://example.test/exec" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestExecute_AppScriptDeploy_CutsVersionThenDeploys(t *testing.T) {
+	var paths []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.Method+" "+r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/versions"):
+			_ = json.NewEncoder(w).Encode(map[string]any{"scriptId": "script123", "versionNumber": 4})
+		case strings.HasSuffix(r.URL.Path, "/deployments"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"deploymentId": "AKfyc123",
+				"entryPoints": []map[string]any{
+					{"webApp": map[string]any{"url": "https://example.test/exec"}},
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	result := executeWithAppScriptTestService(t, []string{
+		"--account", "a@b.com",
+		"appscript", "deploy", "script123", "--description", "  nightly  ",
+	}, newAppScriptTestService(t, srv))
+	if result.err != nil {
+		t.Fatalf("Execute: %v", result.err)
+	}
+
+	if len(paths) != 2 || !strings.Contains(paths[0], "/versions") || !strings.Contains(paths[1], "/deployments") {
+		t.Fatalf("unexpected call order: %v", paths)
+	}
+	if !strings.Contains(result.stdout, "version\t4") ||
+		!strings.Contains(result.stdout, "deployment_id\tAKfyc123") ||
+		!strings.Contains(result.stdout, "web_app_url\thttps://example.test/exec") {
+		t.Fatalf("unexpected out=%q", result.stdout)
+	}
+}
+
+func TestExecute_AppScriptDeploy_DeploymentIDUpdatesInPlace(t *testing.T) {
+	var deploymentMethod string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		if strings.HasSuffix(r.URL.Path, "/versions") {
+			_ = json.NewEncoder(w).Encode(map[string]any{"versionNumber": 9})
+			return
+		}
+
+		deploymentMethod = r.Method
+		_ = json.NewEncoder(w).Encode(map[string]any{"deploymentId": "AKfyc123"})
+	}))
+	defer srv.Close()
+
+	result := executeWithAppScriptTestService(t, []string{
+		"--account", "a@b.com",
+		"appscript", "deploy", "script123", "--deployment-id", "AKfyc123",
+	}, newAppScriptTestService(t, srv))
+	if result.err != nil {
+		t.Fatalf("Execute: %v", result.err)
+	}
+	if deploymentMethod != http.MethodPut {
+		t.Fatalf("expected an in-place update (PUT), got %s", deploymentMethod)
+	}
+}
+
+func TestExecute_AppScriptDeployments_AllFetchesEveryPage(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/deployments") {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+
+		if r.URL.Query().Get("pageToken") == "" {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"deployments":   []map[string]any{{"deploymentId": "one"}},
+				"nextPageToken": "page2",
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"deployments": []map[string]any{{"deploymentId": "two"}},
+		})
+	}))
+	defer srv.Close()
+
+	result := executeWithAppScriptTestService(t, []string{
+		"--account", "a@b.com",
+		"appscript", "deployments", "script123", "--all",
+	}, newAppScriptTestService(t, srv))
+	if result.err != nil {
+		t.Fatalf("Execute: %v", result.err)
+	}
+	if !strings.Contains(result.stdout, "DEPLOYMENT_ID") ||
+		!strings.Contains(result.stdout, "one") ||
+		!strings.Contains(result.stdout, "two") {
+		t.Fatalf("expected both pages in out=%q", result.stdout)
+	}
+}
+
+func TestExecute_AppScriptVersions_JSONKeepsNextPageToken(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/versions") {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"versions":      []map[string]any{{"versionNumber": 1, "description": "first"}},
+			"nextPageToken": "page2",
+		})
+	}))
+	defer srv.Close()
+
+	result := executeWithAppScriptTestService(t, []string{
+		"--json", "--account", "a@b.com",
+		"appscript", "versions", "script123",
+	}, newAppScriptTestService(t, srv))
+	if result.err != nil {
+		t.Fatalf("Execute: %v", result.err)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(result.stdout), &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if parsed["nextPageToken"] != "page2" {
+		t.Fatalf("dropped nextPageToken: %#v", parsed)
+	}
+}
+
+func TestExecute_AppScriptVersions_RejectsNonPositiveMax(t *testing.T) {
+	result := executeWithAppScriptTestServiceFactory(t, []string{
+		"--account", "a@b.com",
+		"appscript", "versions", "script123", "--max", "0",
+	}, unexpectedAppScriptTestService(t, "max validation should run before creating the appscript service"))
+	if result.err == nil || !strings.Contains(result.err.Error(), "max must be > 0") {
+		t.Fatalf("unexpected err: %v", result.err)
+	}
+}
+
+// Deleting a deployment permanently breaks its web app URL, so a
+// non-interactive run must opt in explicitly.
+func TestExecute_AppScriptUndeploy_RequiresForceWhenNonInteractive(t *testing.T) {
+	result := executeWithAppScriptTestServiceFactory(t, []string{
+		"--account", "a@b.com",
+		"appscript", "undeploy", "script123", "AKfyc123",
+	}, unexpectedAppScriptTestService(t, "undeploy should stop at the confirmation gate"))
+	if result.err == nil || !strings.Contains(result.err.Error(), "without --force") {
+		t.Fatalf("unexpected err: %v", result.err)
+	}
+}
+
+func TestExecute_AppScriptUndeploy_ForceDeletes(t *testing.T) {
+	var method, path string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		method, path = r.Method, r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{})
+	}))
+	defer srv.Close()
+
+	result := executeWithAppScriptTestService(t, []string{
+		"--force", "--account", "a@b.com",
+		"appscript", "undeploy", "script123", "AKfyc123",
+	}, newAppScriptTestService(t, srv))
+	if result.err != nil {
+		t.Fatalf("Execute: %v", result.err)
+	}
+	if method != http.MethodDelete || !strings.Contains(path, "deployments/AKfyc123") {
+		t.Fatalf("unexpected request: %s %s", method, path)
+	}
+	if !strings.Contains(result.stdout, "deleted\ttrue") {
+		t.Fatalf("unexpected out=%q", result.stdout)
+	}
+}

--- a/internal/cmd/appscript_sync.go
+++ b/internal/cmd/appscript_sync.go
@@ -1,0 +1,244 @@
+package cmd
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+
+	scriptapi "google.golang.org/api/script/v1"
+
+	"github.com/openclaw/gogcli/internal/config"
+	"github.com/openclaw/gogcli/internal/outfmt"
+	"github.com/openclaw/gogcli/internal/ui"
+)
+
+// Apps Script stores a file's extension in its type, not its name: a file named
+// "Code" with type SERVER_JS is Code.gs in the editor. These two maps are the
+// translation in both directions.
+var appScriptTypeByExt = map[string]string{
+	".gs":   "SERVER_JS",
+	".js":   "SERVER_JS",
+	".html": "HTML",
+	".json": "JSON",
+}
+
+var appScriptExtByType = map[string]string{
+	"SERVER_JS": ".gs",
+	"HTML":      ".html",
+	"JSON":      ".json",
+}
+
+// appScriptManifest is the only JSON file a project may hold, and it is
+// mandatory: UpdateContent rejects a payload without appsscript.json.
+const appScriptManifest = "appsscript"
+
+type AppScriptPushCmd struct {
+	ScriptID string `arg:"" name:"scriptId" help:"Script ID"`
+	Dir      string `arg:"" name:"dir" help:"Local directory holding .gs/.js/.html files and appsscript.json" type:"path"`
+}
+
+func (c *AppScriptPushCmd) Run(ctx context.Context, flags *RootFlags) error {
+	scriptID := strings.TrimSpace(normalizeGoogleID(c.ScriptID))
+	if scriptID == "" {
+		return usage("empty scriptId")
+	}
+
+	dir, err := expandAppScriptDir(c.Dir)
+	if err != nil {
+		return err
+	}
+
+	files, err := readAppScriptDir(dir)
+	if err != nil {
+		return err
+	}
+
+	names := make([]string, 0, len(files))
+	for _, file := range files {
+		names = append(names, file.Name+appScriptExtByType[file.Type])
+	}
+
+	// UpdateContent replaces the project wholesale, so any remote file absent
+	// from dir is dropped. The dry-run payload lists exactly what would survive.
+	if dryRunErr := dryRunExit(ctx, flags, "appscript.push", map[string]any{
+		"script_id": scriptID,
+		"dir":       dir,
+		"files":     names,
+	}); dryRunErr != nil {
+		return dryRunErr
+	}
+
+	svc, err := requireAppScriptService(ctx, flags)
+	if err != nil {
+		return err
+	}
+
+	content, err := svc.Projects.UpdateContent(scriptID, &scriptapi.Content{
+		Files: files,
+	}).Context(ctx).Do()
+	if err != nil {
+		return err
+	}
+
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(ctx, stdoutWriter(ctx), map[string]any{
+			"pushed":     true,
+			"content":    content,
+			"editor_url": appScriptEditURL(scriptID),
+		})
+	}
+
+	u := ui.FromContext(ctx)
+	u.Out().Linef("pushed\ttrue")
+	u.Out().Linef("script_id\t%s", scriptID)
+	printAppScriptFiles(u, content.Files)
+	u.Out().Linef("editor_url\t%s", appScriptEditURL(scriptID))
+
+	return nil
+}
+
+type AppScriptPullCmd struct {
+	ScriptID string `arg:"" name:"scriptId" help:"Script ID"`
+	Dir      string `arg:"" name:"dir" help:"Local directory to write files into (created if missing)" type:"path"`
+}
+
+func (c *AppScriptPullCmd) Run(ctx context.Context, flags *RootFlags) error {
+	scriptID := strings.TrimSpace(normalizeGoogleID(c.ScriptID))
+	if scriptID == "" {
+		return usage("empty scriptId")
+	}
+
+	dir, err := expandAppScriptDir(c.Dir)
+	if err != nil {
+		return err
+	}
+
+	if dryRunErr := dryRunExit(ctx, flags, "appscript.pull", map[string]any{
+		"script_id": scriptID,
+		"dir":       dir,
+	}); dryRunErr != nil {
+		return dryRunErr
+	}
+
+	svc, err := requireAppScriptService(ctx, flags)
+	if err != nil {
+		return err
+	}
+
+	content, err := svc.Projects.GetContent(scriptID).Context(ctx).Do()
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+
+	written := make([]string, 0, len(content.Files))
+
+	for _, file := range content.Files {
+		if file == nil {
+			continue
+		}
+
+		// File names come from the API; keep them from escaping dir.
+		name := sanitizeAttachmentFilename(file.Name+appScriptExtByType[file.Type], "")
+		if name == "" {
+			continue
+		}
+
+		if err := writeFileAtomic(filepath.Join(dir, name), []byte(file.Source)); err != nil {
+			return err
+		}
+
+		written = append(written, name)
+	}
+
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(ctx, stdoutWriter(ctx), map[string]any{
+			"pulled": true,
+			"dir":    dir,
+			"files":  written,
+		})
+	}
+
+	u := ui.FromContext(ctx)
+	u.Out().Linef("pulled\ttrue")
+	u.Out().Linef("dir\t%s", dir)
+
+	for _, name := range written {
+		u.Out().Linef("file\t%s", name)
+	}
+
+	return nil
+}
+
+func expandAppScriptDir(dir string) (string, error) {
+	trimmed := strings.TrimSpace(dir)
+	if trimmed == "" {
+		return "", usage("empty dir")
+	}
+
+	return config.ExpandPath(trimmed)
+}
+
+// readAppScriptDir turns a local directory into the file list the API wants.
+// os.ReadDir yields entries sorted by name, so the pushed order is already
+// stable and needs no extra sort.
+func readAppScriptDir(dir string) ([]*scriptapi.File, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	var (
+		files       []*scriptapi.File
+		hasManifest bool
+	)
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		name := entry.Name()
+		ext := filepath.Ext(name)
+
+		fileType, ok := appScriptTypeByExt[strings.ToLower(ext)]
+		if !ok {
+			continue
+		}
+
+		// Decide before reading, so a stray package-lock.json is never loaded.
+		base := strings.TrimSuffix(name, ext)
+		if fileType == "JSON" {
+			if base != appScriptManifest {
+				continue
+			}
+
+			hasManifest = true
+		}
+
+		source, readErr := os.ReadFile(filepath.Join(dir, name)) // #nosec G304 -- path is confined to the caller-selected push directory.
+		if readErr != nil {
+			return nil, readErr
+		}
+
+		files = append(files, &scriptapi.File{
+			Name:   base,
+			Type:   fileType,
+			Source: string(source),
+		})
+	}
+
+	if len(files) == 0 {
+		return nil, usagef("no .gs/.js/.html/appsscript.json files found in %s", dir)
+	}
+
+	if !hasManifest {
+		return nil, usagef("%s must contain appsscript.json (the API rejects a push without a manifest)", dir)
+	}
+
+	return files, nil
+}

--- a/internal/cmd/appscript_sync_test.go
+++ b/internal/cmd/appscript_sync_test.go
@@ -1,0 +1,265 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeAppScriptFixture(t *testing.T, dir string, files map[string]string) {
+	t.Helper()
+	for name, body := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+}
+
+func TestReadAppScriptDir_MapsExtensionsToTypes(t *testing.T) {
+	dir := t.TempDir()
+	writeAppScriptFixture(t, dir, map[string]string{
+		"appsscript.json": `{"timeZone":"Etc/GMT"}`,
+		"Code.gs":         "function doGet() {}",
+		"Helper.js":       "function helper() {}",
+		"Index.html":      "<p>hi</p>",
+		"README.md":       "ignored",
+	})
+
+	files, err := readAppScriptDir(dir)
+	if err != nil {
+		t.Fatalf("readAppScriptDir: %v", err)
+	}
+
+	got := map[string]string{}
+	for _, file := range files {
+		got[file.Name] = file.Type
+	}
+
+	want := map[string]string{
+		"appsscript": "JSON",
+		"Code":       "SERVER_JS",
+		"Helper":     "SERVER_JS",
+		"Index":      "HTML",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("unexpected files: %#v", got)
+	}
+	for name, fileType := range want {
+		if got[name] != fileType {
+			t.Fatalf("%s: got type %q, want %q", name, got[name], fileType)
+		}
+	}
+}
+
+// os.ReadDir sorts entries, so the pushed order is stable without an extra sort.
+func TestReadAppScriptDir_OrdersFilesByName(t *testing.T) {
+	dir := t.TempDir()
+	writeAppScriptFixture(t, dir, map[string]string{
+		"appsscript.json": "{}",
+		"Zebra.gs":        "",
+		"Alpha.gs":        "",
+	})
+
+	files, err := readAppScriptDir(dir)
+	if err != nil {
+		t.Fatalf("readAppScriptDir: %v", err)
+	}
+
+	names := make([]string, 0, len(files))
+	for _, file := range files {
+		names = append(names, file.Name)
+	}
+	if strings.Join(names, ",") != "Alpha,Zebra,appsscript" {
+		t.Fatalf("unexpected order: %v", names)
+	}
+}
+
+func TestReadAppScriptDir_SkipsNonManifestJSON(t *testing.T) {
+	dir := t.TempDir()
+	writeAppScriptFixture(t, dir, map[string]string{
+		"appsscript.json":   "{}",
+		"Code.gs":           "",
+		"package.json":      `{"name":"local"}`,
+		"package-lock.json": `{"lockfileVersion":3}`,
+	})
+
+	files, err := readAppScriptDir(dir)
+	if err != nil {
+		t.Fatalf("readAppScriptDir: %v", err)
+	}
+
+	for _, file := range files {
+		if file.Type == "JSON" && file.Name != appScriptManifest {
+			t.Fatalf("unexpected JSON file pushed: %q", file.Name)
+		}
+	}
+	if len(files) != 2 {
+		t.Fatalf("expected manifest + Code, got %d files", len(files))
+	}
+}
+
+func TestReadAppScriptDir_RequiresManifest(t *testing.T) {
+	dir := t.TempDir()
+	writeAppScriptFixture(t, dir, map[string]string{"Code.gs": "function doGet() {}"})
+
+	if _, err := readAppScriptDir(dir); err == nil ||
+		!strings.Contains(err.Error(), "must contain appsscript.json") {
+		t.Fatalf("unexpected err: %v", err)
+	}
+}
+
+func TestReadAppScriptDir_RejectsEmptyDir(t *testing.T) {
+	if _, err := readAppScriptDir(t.TempDir()); err == nil ||
+		!strings.Contains(err.Error(), "no .gs/.js/.html/appsscript.json files found") {
+		t.Fatalf("unexpected err: %v", err)
+	}
+}
+
+func TestExecute_AppScriptPush_SendsDirectoryContents(t *testing.T) {
+	dir := t.TempDir()
+	writeAppScriptFixture(t, dir, map[string]string{
+		"appsscript.json": `{"timeZone":"Etc/GMT"}`,
+		"Code.gs":         "function doGet() {}",
+	})
+
+	var received map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "projects/script123/content") {
+			http.NotFound(w, r)
+			return
+		}
+		if err := json.NewDecoder(r.Body).Decode(&received); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"scriptId": "script123",
+			"files": []map[string]any{
+				{"name": "appsscript", "type": "JSON"},
+				{"name": "Code", "type": "SERVER_JS"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	result := executeWithAppScriptTestService(t, []string{
+		"--account", "a@b.com",
+		"appscript", "push", "script123", dir,
+	}, newAppScriptTestService(t, srv))
+	if result.err != nil {
+		t.Fatalf("Execute: %v", result.err)
+	}
+
+	sent, _ := received["files"].([]any)
+	if len(sent) != 2 {
+		t.Fatalf("expected 2 files in request, got %#v", received["files"])
+	}
+	if !strings.Contains(result.stdout, "pushed\ttrue") ||
+		!strings.Contains(result.stdout, "file\tCode\tSERVER_JS") {
+		t.Fatalf("unexpected out=%q", result.stdout)
+	}
+}
+
+func TestExecute_AppScriptPull_WritesFilesWithPrivatePermissions(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "nested")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "projects/script123/content") {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"scriptId": "script123",
+			"files": []map[string]any{
+				{"name": "Code", "type": "SERVER_JS", "source": "function doGet() {}"},
+				{"name": "appsscript", "type": "JSON", "source": "{}"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	result := executeWithAppScriptTestService(t, []string{
+		"--account", "a@b.com",
+		"appscript", "pull", "script123", dir,
+	}, newAppScriptTestService(t, srv))
+	if result.err != nil {
+		t.Fatalf("Execute: %v", result.err)
+	}
+
+	body, err := os.ReadFile(filepath.Join(dir, "Code.gs"))
+	if err != nil {
+		t.Fatalf("read pulled file: %v", err)
+	}
+	if string(body) != "function doGet() {}" {
+		t.Fatalf("unexpected body: %q", body)
+	}
+
+	info, err := os.Stat(filepath.Join(dir, "appsscript.json"))
+	if err != nil {
+		t.Fatalf("stat manifest: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("expected 0600 manifest, got %o", perm)
+	}
+}
+
+// A server-supplied name must not be able to escape the target directory.
+func TestExecute_AppScriptPull_ContainsTraversalNames(t *testing.T) {
+	base := t.TempDir()
+	dir := filepath.Join(base, "out")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "projects/script123/content") {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"scriptId": "script123",
+			"files": []map[string]any{
+				{"name": "../escaped", "type": "SERVER_JS", "source": "nope"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	result := executeWithAppScriptTestService(t, []string{
+		"--account", "a@b.com",
+		"appscript", "pull", "script123", dir,
+	}, newAppScriptTestService(t, srv))
+	if result.err != nil {
+		t.Fatalf("Execute: %v", result.err)
+	}
+
+	if _, err := os.Stat(filepath.Join(base, "escaped.gs")); !os.IsNotExist(err) {
+		t.Fatalf("file escaped the target directory: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "escaped.gs")); err != nil {
+		t.Fatalf("expected sanitized name inside dir: %v", err)
+	}
+}
+
+func TestExecute_AppScriptPush_DryRunSkipsService(t *testing.T) {
+	dir := t.TempDir()
+	writeAppScriptFixture(t, dir, map[string]string{
+		"appsscript.json": "{}",
+		"Code.gs":         "",
+	})
+
+	result := executeWithAppScriptTestServiceFactory(t, []string{
+		"--dry-run", "--account", "a@b.com",
+		"appscript", "push", "script123", dir,
+	}, unexpectedAppScriptTestService(t, "dry-run should not create appscript service"))
+	if result.err != nil {
+		t.Fatalf("Execute: %v", result.err)
+	}
+	if !strings.Contains(result.stdout, "Dry run: would appscript.push") ||
+		!strings.Contains(result.stdout, `"Code.gs"`) {
+		t.Fatalf("unexpected dry-run out=%q", result.stdout)
+	}
+}

--- a/internal/cmd/dryrun_e2e_test.go
+++ b/internal/cmd/dryrun_e2e_test.go
@@ -26,6 +26,10 @@ func TestDryRunE2E_CommandsSkipAuthAPIAndFileWrites(t *testing.T) {
 	if err := os.WriteFile(markdownPath, []byte("## Slide\nBody"), 0o600); err != nil {
 		t.Fatalf("write dry-run markdown: %v", err)
 	}
+	appScriptDryRunDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(appScriptDryRunDir, "appsscript.json"), []byte("{}"), 0o600); err != nil {
+		t.Fatalf("write dry-run appscript manifest: %v", err)
+	}
 	outputDir := t.TempDir()
 	outputPath := func(name string) string {
 		return filepath.Join(outputDir, name)
@@ -623,6 +627,27 @@ func TestDryRunE2E_CommandsSkipAuthAPIAndFileWrites(t *testing.T) {
 			name: "appscript create",
 			args: []string{"appscript", "create", "--title", "SmokeScript"},
 			op:   "appscript.create",
+		},
+		{
+			name: "appscript push",
+			args: []string{"appscript", "push", "script123", appScriptDryRunDir},
+			op:   "appscript.push",
+		},
+		{
+			name:    "appscript pull",
+			args:    []string{"appscript", "pull", "script123", outputPath("appscript-pull")},
+			op:      "appscript.pull",
+			outPath: outputPath("appscript-pull"),
+		},
+		{
+			name: "appscript deploy",
+			args: []string{"appscript", "deploy", "script123", "--description", "nightly"},
+			op:   "appscript.deploy",
+		},
+		{
+			name: "appscript undeploy",
+			args: []string{"appscript", "undeploy", "script123", "AKfyc123", "--force"},
+			op:   "appscript.undeploy",
 		},
 		{
 			name: "sheets banding clear all",

--- a/internal/cmd/safety_profile_test.go
+++ b/internal/cmd/safety_profile_test.go
@@ -124,6 +124,8 @@ func TestReadonlySafetyProfileBlocksNestedMutations(t *testing.T) {
 		{"gmail", "messages", "modify", "msg-1", "--add", "Label_1"},
 		{"calendar", "alias", "set", "work", "abc123@group.calendar.google.com"},
 		{"calendar", "alias", "unset", "work"},
+		{"appscript", "push", "script123", "."},
+		{"appscript", "undeploy", "script123", "AKfyc123", "--force"},
 	}
 	for _, args := range tests {
 		err := Execute(args)

--- a/internal/cmd/service_helpers.go
+++ b/internal/cmd/service_helpers.go
@@ -11,11 +11,20 @@ import (
 	"google.golang.org/api/driveactivity/v2"
 	"google.golang.org/api/gmail/v1"
 	"google.golang.org/api/meet/v2"
+	scriptapi "google.golang.org/api/script/v1"
 	"google.golang.org/api/sheets/v4"
 )
 
 func requireDocsService(ctx context.Context, flags *RootFlags) (*docs.Service, error) {
 	_, svc, err := requireGoogleService(ctx, flags, docsService)
+	if err != nil {
+		return nil, err
+	}
+	return svc, nil
+}
+
+func requireAppScriptService(ctx context.Context, flags *RootFlags) (*scriptapi.Service, error) {
+	_, svc, err := requireGoogleService(ctx, flags, appScriptService)
 	if err != nil {
 		return nil, err
 	}

--- a/safety-profiles/agent-safe.yaml
+++ b/safety-profiles/agent-safe.yaml
@@ -270,8 +270,14 @@ forms:
 appscript:
   get: true
   content: true
+  pull: true
+  deployments: true
+  versions: true
   run: false
   create: false
+  push: false
+  deploy: false
+  undeploy: false
 
 people:
   me: true

--- a/safety-profiles/readonly.yaml
+++ b/safety-profiles/readonly.yaml
@@ -275,8 +275,14 @@ forms:
 appscript:
   get: true
   content: true
+  pull: true
+  deployments: true
+  versions: true
   run: false
   create: false
+  push: false
+  deploy: false
+  undeploy: false
 
 people:
   me: true


### PR DESCRIPTION
## Scope

`gog appscript` could read a project (`get`, `content`) and run a deployed
function, but never change one. This adds the write half so an Apps Script
project can be developed and released from the CLI:

| Command | Purpose |
|---|---|
| `appscript push <scriptId> <dir>` | Replace project content from a local directory |
| `appscript pull <scriptId> <dir>` | Write project content into a local directory |
| `appscript deploy <scriptId>` | Cut a version and deploy it (prints the web app URL) |
| `appscript deployments <scriptId>` | List deployments |
| `appscript undeploy <scriptId> <deploymentId>` | Delete a deployment |
| `appscript versions <scriptId>` | List versions |

## Notes on the design

- **`deploy --deployment-id` updates in place**, so a redeploy keeps the same
  web app URL. Without it, every deploy mints a new URL, which is the main
  thing that makes scripted redeploys painful today.
- **Extension mapping.** Apps Script stores a file's extension in its `type`,
  not its `name`, so push/pull translate between `Code.gs` and
  `{name: "Code", type: SERVER_JS}`. Only `appsscript.json` is accepted as
  JSON, so a stray `package-lock.json` in the directory is skipped without
  being read.
- **The manifest is mandatory.** `UpdateContent` rejects a payload without
  `appsscript.json`; push checks up front and says so, instead of passing
  through an opaque API error.
- **Pagination.** Both list commands use `loadPagedItems` /
  `writePagedJSONResult` / `printNextPageHintWithAll`, so `--max`, `--page`,
  `--all`, and `--fail-empty` behave as they do elsewhere. This matters here:
  the API defaults to 50 per page and `deploy` cuts a version every time, so
  dropping the next page token would silently under-report versions after a
  few months of use.
- **`undeploy` goes through `dryRunAndConfirmDestructive`** — deleting a
  deployment permanently breaks its web app URL, so it honours `-y/--force`
  and fails closed under `--no-input`.
- **Safety profiles.** `readonly.yaml` and `agent-safe.yaml` are allow-lists
  that fail closed, so the six new leaves are listed explicitly. Without this,
  even the read-only `pull`, `deployments`, and `versions` would be rejected
  (and hidden from help) in a baked build.
- `--readonly` needs no per-command code: `script.googleapis.com` is not on
  the POST allowlist in `internal/googleapi/read_only.go`, so push, deploy,
  and undeploy are already refused at the transport. `pull` still writes
  local files under `--readonly`, matching `drive download`.

## New flags

- `appscript deploy`: `--description`, `--deployment-id`
- `appscript deployments`, `appscript versions`: the standard
  `--max` / `--page` / `--all` / `--fail-empty` set

## Testing

- `make ci` passes (`fmt-check`, `lint`, `deadcode`, `test`, `docs-check`,
  `agent-skills-check`).
- New tests in `appscript_sync_test.go` and `appscript_deploy_test.go` cover
  the extension mapping, manifest enforcement, non-manifest JSON skipping,
  push/pull round trips, pulled-file permissions and path-traversal
  containment, `--all` across two pages, `nextPageToken` retention in
  `--json`, and the `undeploy` confirmation gate.
- `dryrun_e2e_test.go` gains rows for `appscript push/pull/deploy/undeploy`;
  `TestReadonlySafetyProfileBlocksNestedMutations` gains the two new
  mutations.
- Generated docs and agent skills were regenerated (`make docs-commands`,
  `make agent-skills`).

## Two open questions for maintainers

1. **Should `push` also require confirmation?** `UpdateContent` replaces the
   project wholesale, so any remote file absent from the local directory is
   deleted — `drive sync push` deliberately advertises "no remote deletes",
   so this repo is more conservative here. I left push without a prompt so it
   stays usable non-interactively, and instead spelled the behaviour out in
   the help text. Happy to route it through `dryRunAndConfirmDestructive` if
   you'd prefer.
2. **Command shape.** `deploy` / `deployments` / `undeploy` are flat sibling
   verbs over one sub-resource, whereas the rest of the CLI nests
   (`drive comments {list,create,delete}`). A nested
   `appscript deployments {list,create,delete}` would also make the safety
   profile and `--enable-commands` entries one block instead of three
   scattered keys. I kept the flat shape to preserve `appscript deploy` as
   the ergonomic one-liner, but I'll restructure if you want consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
