### PR TITLE
docs: document projection order for --results-only and --select

### DIFF
--- a/.agents/skills/gog/SKILL.md
+++ b/.agents/skills/gog/SKILL.md
@@ -29,6 +29,13 @@ For JSON output projection, `--fields` is accepted as an alias for `--select` on
 commands that do not define their own API field-mask `--fields`; commands with a
 local field-mask flag keep that command-specific meaning.
 
+`--results-only` is applied before `--select`, so a projection runs against the
+unwrapped primary result. To project each element of a list response, select
+fields relative to a single element, such as `--results-only --select id`. Dot
+paths do not broadcast across the elements of a nested array, so an envelope
+path such as `--select items.id` selects nothing, and object paths that do not
+match are omitted rather than reported.
+
 Pick the account explicitly for API work:
 
 ```bash

--- a/.agents/skills/gog/SKILL.md
+++ b/.agents/skills/gog/SKILL.md
@@ -29,12 +29,10 @@ For JSON output projection, `--fields` is accepted as an alias for `--select` on
 commands that do not define their own API field-mask `--fields`; commands with a
 local field-mask flag keep that command-specific meaning.
 
-`--results-only` is applied before `--select`, so a projection runs against the
-unwrapped primary result. To project each element of a list response, select
-fields relative to a single element, such as `--results-only --select id`. Dot
-paths do not broadcast across the elements of a nested array, so an envelope
-path such as `--select items.id` selects nothing, and object paths that do not
-match are omitted rather than reported.
+`--results-only` unwraps the primary result before `--select` projects it. For
+lists, select item-relative fields: `--results-only --select id`. Dot paths do
+not broadcast through nested arrays (`--select items.id` selects nothing).
+Unmatched object fields are omitted.
 
 Pick the account explicitly for API work:
 

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -49,14 +49,11 @@ being silently ignored. Explicit output flags override `GOG_JSON` and
 that do not define their own API field-mask `--fields`; commands with a local
 field-mask flag keep that command-specific meaning.
 
-`--results-only` is applied before `--select`, so a projection runs against the
-unwrapped primary result. To project each element of a list response, select
-fields relative to a single element, such as `--results-only --select id`. Dot
-paths descend through object keys and numeric array indexes; they do not
-broadcast across every element of a nested array, so an envelope path such as
-`--select items.id` selects nothing. Object paths that do not match are omitted
-from the projection rather than reported, so a projection in which no path
-matches yields an empty object.
+`--results-only` unwraps the primary result before `--select` projects it. For
+lists, select item-relative fields: `--results-only --select id`. Dot paths
+traverse object keys or numeric array indexes; they do not broadcast through
+nested arrays (`--select items.id` selects nothing). Unmatched object fields
+are omitted.
 
 Use `--no-input` in CI and unattended processes. Use `--wrap-untrusted` when
 Google-hosted free text will be consumed by an LLM or another instruction-aware

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -49,6 +49,15 @@ being silently ignored. Explicit output flags override `GOG_JSON` and
 that do not define their own API field-mask `--fields`; commands with a local
 field-mask flag keep that command-specific meaning.
 
+`--results-only` is applied before `--select`, so a projection runs against the
+unwrapped primary result. To project each element of a list response, select
+fields relative to a single element, such as `--results-only --select id`. Dot
+paths descend through object keys and numeric array indexes; they do not
+broadcast across every element of a nested array, so an envelope path such as
+`--select items.id` selects nothing. Object paths that do not match are omitted
+from the projection rather than reported, so a projection in which no path
+matches yields an empty object.
+
 Use `--no-input` in CI and unattended processes. Use `--wrap-untrusted` when
 Google-hosted free text will be consumed by an LLM or another instruction-aware
 system.


### PR DESCRIPTION
## Scope

Documents the existing interaction between `--results-only` and `--select`. No behavior change.

The two global flags are documented separately today, so nothing states that `--results-only` is applied first, or how to project one field from every element of a list response. Reaching for the envelope path `--select items.id` returns `{}`, which is consistent with the best-effort projection contract but is not discoverable from the flag help.

Adds a short paragraph to the two places that describe these flags in prose:

- `docs/automation.md`, next to the existing `--fields` alias note
- `.agents/skills/gog/SKILL.md`, same

Content:

> `--results-only` is applied before `--select`, so a projection runs against the unwrapped primary result. To project each element of a list response, select fields relative to a single element, such as `--results-only --select id`. Dot paths descend through object keys and numeric array indexes; they do not broadcast across every element of a nested array, so an envelope path such as `--select items.id` selects nothing. Object paths that do not match are omitted from the projection rather than reported.

This follows #816, which documented the `--fields` alias in the same two files after #814. #816 also touched `README.md`, but the global-flags list it edited is no longer in the README, and the current "Automate safely" section defers to `docs/automation.md` for output contracts, so I left the README alone.

## Why not a help-string change

`--select` and `--results-only` help text lives in `internal/cmd/root.go`, and editing either regenerates 719 of the 720 pages under `docs/commands/`. That seemed like the wrong trade for a clarification, so this stays in the hand-maintained prose. Happy to move it if you would rather it live in the flag help.

## Testing

- `make docs-check` and `make agent-skills-check`
- Behavior claims verified against `v0.37.0` and a source build of `main` at `eb85a993`, using `gog api list` against the public Discovery directory:

| command | result |
| --- | --- |
| `--select 'items.name'` | `{}` |
| `--select 'items.0.name'` | `{"items.0.name": "..."}` |
| `--results-only --select 'name'` | one `{"name": ...}` per item |
| `--select 'kind,nope'` | `{"kind": "..."}`, unmatched path omitted |

## User-facing changes

Documentation only. No new flags, no behavior change.
