### PR TITLE
feat(gmail): reference sanitized body links as [link:N] markers, resolved on demand with gmail link

### DIFF
--- a/docs/commands.generated.md
+++ b/docs/commands.generated.md
@@ -422,6 +422,7 @@ Generated from `gog schema --json`.
       - [`gog gmail (mail,email) labels (label) modify (update,edit,set) <threadId> ... [flags]`](commands/gog-gmail-labels-modify.md) - Modify labels on threads
       - [`gog gmail (mail,email) labels (label) rename (mv) <labelIdOrName> <newName>`](commands/gog-gmail-labels-rename.md) - Rename a label
       - [`gog gmail (mail,email) labels (label) style (color,colour) <labelIdOrName> [flags]`](commands/gog-gmail-labels-style.md) - Change a user label color or visibility
+    - [`gog gmail (mail,email) link <messageId> <index>`](commands/gog-gmail-link.md) - Resolve a [link:N] marker from sanitized output to its full URL
     - [`gog gmail (mail,email) mark-read (read-messages) [<messageId> ...] [flags]`](commands/gog-gmail-mark-read.md) - Mark messages as read
     - [`gog gmail (mail,email) messages (message,msg,msgs) <command>`](commands/gog-gmail-messages.md) - Message operations
       - [`gog gmail (mail,email) messages (message,msg,msgs) modify (update,edit,set) <messageId> [flags]`](commands/gog-gmail-messages-modify.md) - Modify labels on a single message

--- a/docs/commands.generated.md
+++ b/docs/commands.generated.md
@@ -422,7 +422,7 @@ Generated from `gog schema --json`.
       - [`gog gmail (mail,email) labels (label) modify (update,edit,set) <threadId> ... [flags]`](commands/gog-gmail-labels-modify.md) - Modify labels on threads
       - [`gog gmail (mail,email) labels (label) rename (mv) <labelIdOrName> <newName>`](commands/gog-gmail-labels-rename.md) - Rename a label
       - [`gog gmail (mail,email) labels (label) style (color,colour) <labelIdOrName> [flags]`](commands/gog-gmail-labels-style.md) - Change a user label color or visibility
-    - [`gog gmail (mail,email) link <messageId> <index>`](commands/gog-gmail-link.md) - Resolve a [link:N] marker from sanitized output to its full URL
+    - [`gog gmail (mail,email) link <messageId> <index> [flags]`](commands/gog-gmail-link.md) - Resolve a [link:N] marker from sanitized output to its full URL
     - [`gog gmail (mail,email) mark-read (read-messages) [<messageId> ...] [flags]`](commands/gog-gmail-mark-read.md) - Mark messages as read
     - [`gog gmail (mail,email) messages (message,msg,msgs) <command>`](commands/gog-gmail-messages.md) - Message operations
       - [`gog gmail (mail,email) messages (message,msg,msgs) modify (update,edit,set) <messageId> [flags]`](commands/gog-gmail-messages-modify.md) - Modify labels on a single message

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -2,7 +2,7 @@
 
 Every `gog` command has a generated docs page. The source of truth is the live CLI schema; run `make docs-commands` after changing command names, flags, help text, aliases, or arguments.
 
-Generated pages: 719.
+Generated pages: 720.
 
 ## Top-level Commands
 
@@ -475,6 +475,7 @@ Generated pages: 719.
       - [gog gmail labels modify](gog-gmail-labels-modify.md) - Modify labels on threads
       - [gog gmail labels rename](gog-gmail-labels-rename.md) - Rename a label
       - [gog gmail labels style](gog-gmail-labels-style.md) - Change a user label color or visibility
+    - [gog gmail link](gog-gmail-link.md) - Resolve a [link:N] marker from sanitized output to its full URL
     - [gog gmail mark-read](gog-gmail-mark-read.md) - Mark messages as read
     - [gog gmail messages](gog-gmail-messages.md) - Message operations
       - [gog gmail messages modify](gog-gmail-messages-modify.md) - Modify labels on a single message

--- a/docs/commands/gog-gmail-link.md
+++ b/docs/commands/gog-gmail-link.md
@@ -1,45 +1,18 @@
-# `gog gmail`
+# `gog gmail link`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Gmail
+Resolve a [link:N] marker from sanitized output to its full URL
 
 ## Usage
 
 ```bash
-gog gmail (mail,email) <command> [flags]
+gog gmail (mail,email) link <messageId> <index>
 ```
 
 ## Parent
 
-- [gog](gog.md)
-
-## Subcommands
-
-- [gog gmail archive](gog-gmail-archive.md) - Archive messages or explicit threads (remove from inbox)
-- [gog gmail attachment](gog-gmail-attachment.md) - Download a single attachment
-- [gog gmail autoreply](gog-gmail-autoreply.md) - Reply once to matching messages
-- [gog gmail batch](gog-gmail-batch.md) - Batch operations (permanent delete requires broader Gmail scope; use gmail trash for normal trashing)
-- [gog gmail drafts](gog-gmail-drafts.md) - Draft operations
-- [gog gmail forward](gog-gmail-forward.md) - Forward a message to new recipients
-- [gog gmail get](gog-gmail-get.md) - Get a message (full|metadata|raw)
-- [gog gmail history](gog-gmail-history.md) - Gmail history
-- [gog gmail import](gog-gmail-import.md) - Import an RFC822/EML message into Gmail
-- [gog gmail labels](gog-gmail-labels.md) - Label operations
-- [gog gmail link](gog-gmail-link.md) - Resolve a [link:N] marker from sanitized output to its full URL
-- [gog gmail mark-read](gog-gmail-mark-read.md) - Mark messages as read
-- [gog gmail messages](gog-gmail-messages.md) - Message operations
-- [gog gmail raw](gog-gmail-raw.md) - Dump raw Gmail API response as JSON (Users.Messages.Get; lossless; for scripting and LLM consumption)
-- [gog gmail reply](gog-gmail-reply.md) - Reply to a message
-- [gog gmail reply-all](gog-gmail-reply-all.md) - Reply to all message participants
-- [gog gmail search](gog-gmail-search.md) - Search threads using Gmail query syntax
-- [gog gmail send](gog-gmail-send.md) - Send an email
-- [gog gmail settings](gog-gmail-settings.md) - Settings and admin
-- [gog gmail thread](gog-gmail-thread.md) - Thread operations (get, modify)
-- [gog gmail track](gog-gmail-track.md) - Email open tracking
-- [gog gmail trash](gog-gmail-trash.md) - Move messages to trash
-- [gog gmail unread](gog-gmail-unread.md) - Mark messages as unread
-- [gog gmail url](gog-gmail-url.md) - Print Gmail web URLs for threads
+- [gog gmail](gog-gmail.md)
 
 ## Flags
 
@@ -69,5 +42,5 @@ gog gmail (mail,email) <command> [flags]
 
 ## See Also
 
-- [gog](gog.md)
+- [gog gmail](gog-gmail.md)
 - [Command index](README.md)

--- a/docs/commands/gog-gmail-link.md
+++ b/docs/commands/gog-gmail-link.md
@@ -7,7 +7,7 @@ Resolve a [link:N] marker from sanitized output to its full URL
 ## Usage
 
 ```bash
-gog gmail (mail,email) link <messageId> <index>
+gog gmail (mail,email) link <messageId> <index> [flags]
 ```
 
 ## Parent
@@ -36,6 +36,7 @@ gog gmail (mail,email) link <messageId> <index>
 | `--readonly` | `bool` | false | Block mutating API requests at runtime; auth add also requests read-only OAuth scopes |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `--trim-punctuation` | `bool` |  | Strip trailing sentence punctuation (and an unbalanced trailing parenthesis) that a bare URL likely captured from the prose around it; anchor hrefs are byte-exact and unaffected |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |
 | `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |

--- a/docs/gmail-workflows.md
+++ b/docs/gmail-workflows.md
@@ -27,6 +27,13 @@ message text for automation. Message JSON remains under the `message` key;
 add `--results-only` to emit that sanitized message directly. Both shapes emit
 the message headers and body once.
 
+Sanitized bodies reference every link as a `[link:N]` marker next to its text
+instead of carrying the URL. Resolve a marker on demand:
+
+```bash
+gog gmail link <messageId> <index>
+```
+
 ## Filters
 
 Export filters as Gmail WebUI-compatible XML:

--- a/internal/cmd/gmail.go
+++ b/internal/cmd/gmail.go
@@ -7,6 +7,7 @@ type GmailCmd struct {
 	Get        GmailGetCmd        `cmd:"" name:"get" aliases:"info,show" group:"Read" help:"Get a message (full|metadata|raw)"`
 	Raw        GmailRawCmd        `cmd:"" name:"raw" group:"Read" help:"Dump raw Gmail API response as JSON (Users.Messages.Get; lossless; for scripting and LLM consumption)"`
 	Attachment GmailAttachmentCmd `cmd:"" name:"attachment" group:"Read" help:"Download a single attachment"`
+	Link       GmailLinkCmd       `cmd:"" name:"link" group:"Read" help:"Resolve a [link:N] marker from sanitized output to its full URL"`
 	URL        GmailURLCmd        `cmd:"" name:"url" group:"Read" help:"Print Gmail web URLs for threads"`
 	History    GmailHistoryCmd    `cmd:"" name:"history" group:"Read" help:"Gmail history"`
 

--- a/internal/cmd/gmail_link.go
+++ b/internal/cmd/gmail_link.go
@@ -62,11 +62,21 @@ func (c *GmailLinkCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return err
 	}
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(ctx, stdoutWriter(ctx), link)
+		payload := map[string]any{"url": link.URL}
+		if link.Text != "" {
+			payload["text"] = link.Text
+		}
+		if note := link.trailingProseNote(); note != "" {
+			payload["note"] = note
+		}
+		return outfmt.WriteJSON(ctx, stdoutWriter(ctx), payload)
 	}
 	u.Out().Linef("url\t%s", tsvSafeValue(link.URL))
 	if link.Text != "" {
 		u.Out().Linef("text\t%s", tsvSafeValue(link.Text))
+	}
+	if note := link.trailingProseNote(); note != "" {
+		u.Out().Linef("note\t%s", note)
 	}
 	return nil
 }

--- a/internal/cmd/gmail_link.go
+++ b/internal/cmd/gmail_link.go
@@ -66,8 +66,8 @@ func (c *GmailLinkCmd) Run(ctx context.Context, flags *RootFlags) error {
 		if link.Text != "" {
 			payload["text"] = link.Text
 		}
-		if note := link.trailingProseNote(); note != "" {
-			payload["note"] = note
+		if cleaned := link.cleanedURL(); cleaned != "" {
+			payload["urlCleaned"] = cleaned
 		}
 		return outfmt.WriteJSON(ctx, stdoutWriter(ctx), payload)
 	}
@@ -75,8 +75,8 @@ func (c *GmailLinkCmd) Run(ctx context.Context, flags *RootFlags) error {
 	if link.Text != "" {
 		u.Out().Linef("text\t%s", tsvSafeValue(link.Text))
 	}
-	if note := link.trailingProseNote(); note != "" {
-		u.Out().Linef("note\t%s", note)
+	if cleaned := link.cleanedURL(); cleaned != "" {
+		u.Out().Linef("urlCleaned\t%s", tsvSafeValue(cleaned))
 	}
 	return nil
 }

--- a/internal/cmd/gmail_link.go
+++ b/internal/cmd/gmail_link.go
@@ -14,8 +14,9 @@ import (
 )
 
 type GmailLinkCmd struct {
-	MessageID string `arg:"" name:"messageId" help:"Message ID"`
-	Index     string `arg:"" name:"index" help:"0-based link index from the sanitized body's [link:N] marker"`
+	MessageID       string `arg:"" name:"messageId" help:"Message ID"`
+	Index           string `arg:"" name:"index" help:"0-based link index from the sanitized body's [link:N] marker"`
+	TrimPunctuation bool   `name:"trim-punctuation" help:"Strip trailing sentence punctuation (and an unbalanced trailing parenthesis) that a bare URL likely captured from the prose around it; anchor hrefs are byte-exact and unaffected"`
 }
 
 // linkByIndex resolves a 0-based index from a sanitized body's [link:N] marker to the
@@ -61,22 +62,22 @@ func (c *GmailLinkCmd) Run(ctx context.Context, flags *RootFlags) error {
 	if err != nil {
 		return err
 	}
+	url := link.URL
+	if c.TrimPunctuation {
+		if trimmed := link.trimmedURL(); trimmed != "" {
+			url = trimmed
+		}
+	}
 	if outfmt.IsJSON(ctx) {
-		payload := map[string]any{"url": link.URL}
+		payload := map[string]any{"url": url}
 		if link.Text != "" {
 			payload["text"] = link.Text
 		}
-		if cleaned := link.cleanedURL(); cleaned != "" {
-			payload["urlCleaned"] = cleaned
-		}
 		return outfmt.WriteJSON(ctx, stdoutWriter(ctx), payload)
 	}
-	u.Out().Linef("url\t%s", tsvSafeValue(link.URL))
+	u.Out().Linef("url\t%s", tsvSafeValue(url))
 	if link.Text != "" {
 		u.Out().Linef("text\t%s", tsvSafeValue(link.Text))
-	}
-	if cleaned := link.cleanedURL(); cleaned != "" {
-		u.Out().Linef("urlCleaned\t%s", tsvSafeValue(cleaned))
 	}
 	return nil
 }

--- a/internal/cmd/gmail_link.go
+++ b/internal/cmd/gmail_link.go
@@ -1,0 +1,72 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"google.golang.org/api/gmail/v1"
+
+	"github.com/openclaw/gogcli/internal/gmailcontent"
+	"github.com/openclaw/gogcli/internal/outfmt"
+	"github.com/openclaw/gogcli/internal/ui"
+)
+
+type GmailLinkCmd struct {
+	MessageID string `arg:"" name:"messageId" help:"Message ID"`
+	Index     string `arg:"" name:"index" help:"0-based link index from the sanitized body's [link:N] marker"`
+}
+
+// linkByIndex resolves a 0-based index from a sanitized body's [link:N] marker to the
+// link itself. It reruns the body conversion that numbered the markers, so the index is
+// a stable reference as long as the message content is unchanged.
+func linkByIndex(ctx context.Context, svc *gmail.Service, messageID string, idx int) (gmailLink, error) {
+	if idx < 0 {
+		return gmailLink{}, usagef("link index must be >= 0, got %d", idx)
+	}
+	msg, err := svc.Users.Messages.Get("me", messageID).Format("full").Context(ctx).Do()
+	if err != nil {
+		return gmailLink{}, fmt.Errorf("resolve link index %d: %w", idx, err)
+	}
+	body, isHTML := gmailcontent.BestBodyForDisplay(msg.Payload)
+	_, links := sanitizeGmailBodyLinks(body, isHTML)
+	if idx >= len(links) {
+		return gmailLink{}, usagef("link index %d out of range: message has %d link(s)", idx, len(links))
+	}
+	return links[idx], nil
+}
+
+func (c *GmailLinkCmd) Run(ctx context.Context, flags *RootFlags) error {
+	u := ui.FromContext(ctx)
+	messageID := normalizeGmailMessageID(strings.TrimSpace(c.MessageID))
+	if messageID == "" {
+		return usage("empty messageId")
+	}
+	idx, err := strconv.Atoi(strings.TrimSpace(c.Index))
+	if err != nil {
+		return usagef("the link argument must be a 0-based index, got %q", c.Index)
+	}
+
+	account, err := requireAccount(flags)
+	if err != nil {
+		return err
+	}
+	svc, err := gmailService(ctx, account)
+	if err != nil {
+		return err
+	}
+
+	link, err := linkByIndex(ctx, svc, messageID, idx)
+	if err != nil {
+		return err
+	}
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(ctx, stdoutWriter(ctx), link)
+	}
+	u.Out().Linef("url\t%s", link.URL)
+	if link.Text != "" {
+		u.Out().Linef("text\t%s", link.Text)
+	}
+	return nil
+}

--- a/internal/cmd/gmail_link.go
+++ b/internal/cmd/gmail_link.go
@@ -64,9 +64,9 @@ func (c *GmailLinkCmd) Run(ctx context.Context, flags *RootFlags) error {
 	if outfmt.IsJSON(ctx) {
 		return outfmt.WriteJSON(ctx, stdoutWriter(ctx), link)
 	}
-	u.Out().Linef("url\t%s", link.URL)
+	u.Out().Linef("url\t%s", tsvSafeValue(link.URL))
 	if link.Text != "" {
-		u.Out().Linef("text\t%s", link.Text)
+		u.Out().Linef("text\t%s", tsvSafeValue(link.Text))
 	}
 	return nil
 }

--- a/internal/cmd/gmail_link_test.go
+++ b/internal/cmd/gmail_link_test.go
@@ -103,6 +103,39 @@ func TestGmailLinkCmd_IndexParityWithSanitizedGet(t *testing.T) {
 	}
 }
 
+func TestGmailLinkCmd_EscapesControlCharactersInLineOutput(t *testing.T) {
+	// Entities in the href decode to a raw newline and tab in the captured URL.
+	htmlBody := base64.RawURLEncoding.EncodeToString([]byte(
+		`<p><a href="https://evil.example/a&#10;url&#9;forged">click</a></p>`,
+	))
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id": "m1", "threadId": "t1",
+			"payload": map[string]any{
+				"mimeType": "text/html",
+				"body":     map[string]any{"data": htmlBody},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	result := executeWithGmailTestService(
+		t,
+		[]string{"--account", "a@b.com", "gmail", "link", "m1", "0"},
+		newGmailServiceFromServer(t, srv),
+	)
+	if result.err != nil {
+		t.Fatalf("Execute: %v\nstderr=%q", result.err, result.stderr)
+	}
+	if !strings.Contains(result.stdout, `"https://evil.example/a\nurl\tforged"`) {
+		t.Fatalf("control characters should be quoted: %q", result.stdout)
+	}
+	if strings.Contains(result.stdout, "evil.example/a\nurl") {
+		t.Fatalf("raw control characters leaked to line output: %q", result.stdout)
+	}
+}
+
 func TestGmailLinkCmd_UsageErrors(t *testing.T) {
 	srv := newGmailLinkTestServer(t)
 	defer srv.Close()

--- a/internal/cmd/gmail_link_test.go
+++ b/internal/cmd/gmail_link_test.go
@@ -1,0 +1,127 @@
+package cmd
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func newGmailLinkTestServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	htmlBody := base64.RawURLEncoding.EncodeToString([]byte(
+		`<p>Pay <a href="https://pay.example/btn">Pay now</a> or visit https://info.example/page</p>`,
+	))
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/gmail/v1/users/me/messages/") {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":       "m1",
+			"threadId": "t1",
+			"payload": map[string]any{
+				"mimeType": "text/html",
+				"body":     map[string]any{"data": htmlBody},
+				"headers": []map[string]any{
+					{"name": "From", "value": "a@example.com"},
+					{"name": "Subject", "value": "Pay up"},
+				},
+			},
+		})
+	}))
+}
+
+func TestGmailLinkCmd_ResolvesMarkerIndex(t *testing.T) {
+	srv := newGmailLinkTestServer(t)
+	defer srv.Close()
+
+	result := executeWithGmailTestService(
+		t,
+		[]string{"--json", "--account", "a@b.com", "gmail", "link", "m1", "0"},
+		newGmailServiceFromServer(t, srv),
+	)
+	if result.err != nil {
+		t.Fatalf("Execute: %v\nstderr=%q", result.err, result.stderr)
+	}
+	var link struct {
+		URL  string `json:"url"`
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal([]byte(result.stdout), &link); err != nil {
+		t.Fatalf("decode JSON: %v", err)
+	}
+	if link.URL != "https://pay.example/btn" || link.Text != "Pay now" {
+		t.Fatalf("unexpected link: %#v", link)
+	}
+
+	result = executeWithGmailTestService(
+		t,
+		[]string{"--json", "--account", "a@b.com", "gmail", "link", "m1", "1"},
+		newGmailServiceFromServer(t, srv),
+	)
+	if result.err != nil {
+		t.Fatalf("Execute: %v\nstderr=%q", result.err, result.stderr)
+	}
+	if err := json.Unmarshal([]byte(result.stdout), &link); err != nil {
+		t.Fatalf("decode JSON: %v", err)
+	}
+	if link.URL != "https://info.example/page" {
+		t.Fatalf("unexpected link: %#v", link)
+	}
+	// A bare URL has no anchor text, so the field is absent entirely.
+	if strings.Contains(result.stdout, "\"text\"") {
+		t.Fatalf("bare url should have no text field: %s", result.stdout)
+	}
+}
+
+func TestGmailLinkCmd_IndexParityWithSanitizedGet(t *testing.T) {
+	srv := newGmailLinkTestServer(t)
+	defer srv.Close()
+
+	result := executeWithGmailTestService(
+		t,
+		[]string{"--json", "--account", "a@b.com", "gmail", "get", "m1", "--sanitize-content"},
+		newGmailServiceFromServer(t, srv),
+	)
+	if result.err != nil {
+		t.Fatalf("Execute: %v\nstderr=%q", result.err, result.stderr)
+	}
+	var envelope struct {
+		Message struct {
+			Body string `json:"body"`
+		} `json:"message"`
+	}
+	if err := json.Unmarshal([]byte(result.stdout), &envelope); err != nil {
+		t.Fatalf("decode JSON: %v", err)
+	}
+	if envelope.Message.Body != "Pay Pay now [link:0] or visit [link:1]" {
+		t.Fatalf("unexpected sanitized body: %q", envelope.Message.Body)
+	}
+}
+
+func TestGmailLinkCmd_UsageErrors(t *testing.T) {
+	srv := newGmailLinkTestServer(t)
+	defer srv.Close()
+
+	result := executeWithGmailTestService(
+		t,
+		[]string{"--account", "a@b.com", "gmail", "link", "m1", "x"},
+		newGmailServiceFromServer(t, srv),
+	)
+	if result.err == nil || !strings.Contains(result.err.Error(), "0-based index") {
+		t.Fatalf("expected non-numeric index usage error, got: %v", result.err)
+	}
+
+	result = executeWithGmailTestService(
+		t,
+		[]string{"--account", "a@b.com", "gmail", "link", "m1", "5"},
+		newGmailServiceFromServer(t, srv),
+	)
+	if result.err == nil || !strings.Contains(result.err.Error(), "link index 5 out of range: message has 2 link(s)") {
+		t.Fatalf("expected out-of-range usage error, got: %v", result.err)
+	}
+}

--- a/internal/cmd/gmail_link_test.go
+++ b/internal/cmd/gmail_link_test.go
@@ -12,7 +12,7 @@ import (
 func newGmailLinkTestServer(t *testing.T) *httptest.Server {
 	t.Helper()
 	htmlBody := base64.RawURLEncoding.EncodeToString([]byte(
-		`<p>Pay <a href="https://pay.example/btn">Pay now</a> or visit https://info.example/page</p>`,
+		`<p>Click <a href="https://pay.example/btn">Pay now</a> or visit https://info.example/page</p>`,
 	))
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !strings.Contains(r.URL.Path, "/gmail/v1/users/me/messages/") {
@@ -98,7 +98,7 @@ func TestGmailLinkCmd_IndexParityWithSanitizedGet(t *testing.T) {
 	if err := json.Unmarshal([]byte(result.stdout), &envelope); err != nil {
 		t.Fatalf("decode JSON: %v", err)
 	}
-	if envelope.Message.Body != "Pay Pay now [link:0] or visit [link:1]" {
+	if envelope.Message.Body != "Click Pay now [link:0] or visit [link:1]" {
 		t.Fatalf("unexpected sanitized body: %q", envelope.Message.Body)
 	}
 }

--- a/internal/cmd/gmail_link_test.go
+++ b/internal/cmd/gmail_link_test.go
@@ -103,7 +103,7 @@ func TestGmailLinkCmd_IndexParityWithSanitizedGet(t *testing.T) {
 	}
 }
 
-func TestGmailLinkCmd_CleanedURLForProsePunctuation(t *testing.T) {
+func TestGmailLinkCmd_TrimPunctuation(t *testing.T) {
 	htmlBody := base64.RawURLEncoding.EncodeToString([]byte(
 		`<p>Details (https://info.example/x) here, button: <a href="https://pay.example/a_(b)">Pay</a></p>`,
 	))
@@ -119,7 +119,7 @@ func TestGmailLinkCmd_CleanedURLForProsePunctuation(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	// The bare URL keeps its captured prose ")" in url; urlCleaned carries the guess.
+	// Default: url is the exact capture, prose ")" included.
 	result := executeWithGmailTestService(
 		t,
 		[]string{"--json", "--account", "a@b.com", "gmail", "link", "m1", "0"},
@@ -129,8 +129,7 @@ func TestGmailLinkCmd_CleanedURLForProsePunctuation(t *testing.T) {
 		t.Fatalf("Execute: %v\nstderr=%q", result.err, result.stderr)
 	}
 	var resolved struct {
-		URL        string `json:"url"`
-		URLCleaned string `json:"urlCleaned"`
+		URL string `json:"url"`
 	}
 	if err := json.Unmarshal([]byte(result.stdout), &resolved); err != nil {
 		t.Fatalf("decode JSON: %v", err)
@@ -138,25 +137,41 @@ func TestGmailLinkCmd_CleanedURLForProsePunctuation(t *testing.T) {
 	if resolved.URL != "https://info.example/x)" {
 		t.Fatalf("unexpected url: %q", resolved.URL)
 	}
-	if resolved.URLCleaned != "https://info.example/x" {
-		t.Fatalf("unexpected urlCleaned: %q", resolved.URLCleaned)
-	}
 
-	// The anchor href is byte-exact; its balanced ")" is data, so no urlCleaned.
+	// --trim-punctuation strips the prose suffix from the text-captured URL.
 	result = executeWithGmailTestService(
 		t,
-		[]string{"--json", "--account", "a@b.com", "gmail", "link", "m1", "1"},
+		[]string{"--json", "--account", "a@b.com", "gmail", "link", "m1", "0", "--trim-punctuation"},
 		newGmailServiceFromServer(t, srv),
 	)
 	if result.err != nil {
 		t.Fatalf("Execute: %v\nstderr=%q", result.err, result.stderr)
 	}
-	if strings.Contains(result.stdout, "urlCleaned") {
-		t.Fatalf("anchor href should have no urlCleaned: %s", result.stdout)
+	if err := json.Unmarshal([]byte(result.stdout), &resolved); err != nil {
+		t.Fatalf("decode JSON: %v", err)
+	}
+	if resolved.URL != "https://info.example/x" {
+		t.Fatalf("unexpected trimmed url: %q", resolved.URL)
+	}
+
+	// The anchor href is byte-exact; its balanced ")" is data even with the flag.
+	result = executeWithGmailTestService(
+		t,
+		[]string{"--json", "--account", "a@b.com", "gmail", "link", "m1", "1", "--trim-punctuation"},
+		newGmailServiceFromServer(t, srv),
+	)
+	if result.err != nil {
+		t.Fatalf("Execute: %v\nstderr=%q", result.err, result.stderr)
+	}
+	if err := json.Unmarshal([]byte(result.stdout), &resolved); err != nil {
+		t.Fatalf("decode JSON: %v", err)
+	}
+	if resolved.URL != "https://pay.example/a_(b)" {
+		t.Fatalf("unexpected anchor url: %q", resolved.URL)
 	}
 }
 
-func TestGmailLinkCleanedURL(t *testing.T) {
+func TestGmailLinkTrimmedURL(t *testing.T) {
 	tests := []struct {
 		name string
 		link gmailLink
@@ -170,12 +185,12 @@ func TestGmailLinkCleanedURL(t *testing.T) {
 		{name: "balanced parens then period", link: gmailLink{URL: "https://x.example/wiki/Foo_(bar).", fromText: true}, want: "https://x.example/wiki/Foo_(bar)"},
 		{name: "clean url untouched", link: gmailLink{URL: "https://x.example/y", fromText: true}, want: ""},
 		{name: "nothing left after scheme", link: gmailLink{URL: "https://...", fromText: true}, want: ""},
-		{name: "anchor href never cleaned", link: gmailLink{URL: "https://x.example/y."}, want: ""},
+		{name: "anchor href never trimmed", link: gmailLink{URL: "https://x.example/y."}, want: ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.link.cleanedURL(); got != tt.want {
-				t.Fatalf("cleanedURL() = %q, want %q", got, tt.want)
+			if got := tt.link.trimmedURL(); got != tt.want {
+				t.Fatalf("trimmedURL() = %q, want %q", got, tt.want)
 			}
 		})
 	}

--- a/internal/cmd/gmail_link_test.go
+++ b/internal/cmd/gmail_link_test.go
@@ -103,7 +103,7 @@ func TestGmailLinkCmd_IndexParityWithSanitizedGet(t *testing.T) {
 	}
 }
 
-func TestGmailLinkCmd_NotesTrailingProsePunctuation(t *testing.T) {
+func TestGmailLinkCmd_CleanedURLForProsePunctuation(t *testing.T) {
 	htmlBody := base64.RawURLEncoding.EncodeToString([]byte(
 		`<p>Details (https://info.example/x) here, button: <a href="https://pay.example/a_(b)">Pay</a></p>`,
 	))
@@ -119,7 +119,7 @@ func TestGmailLinkCmd_NotesTrailingProsePunctuation(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	// The bare URL captured its prose ")" and says so.
+	// The bare URL keeps its captured prose ")" in url; urlCleaned carries the guess.
 	result := executeWithGmailTestService(
 		t,
 		[]string{"--json", "--account", "a@b.com", "gmail", "link", "m1", "0"},
@@ -129,8 +129,8 @@ func TestGmailLinkCmd_NotesTrailingProsePunctuation(t *testing.T) {
 		t.Fatalf("Execute: %v\nstderr=%q", result.err, result.stderr)
 	}
 	var resolved struct {
-		URL  string `json:"url"`
-		Note string `json:"note"`
+		URL        string `json:"url"`
+		URLCleaned string `json:"urlCleaned"`
 	}
 	if err := json.Unmarshal([]byte(result.stdout), &resolved); err != nil {
 		t.Fatalf("decode JSON: %v", err)
@@ -138,11 +138,11 @@ func TestGmailLinkCmd_NotesTrailingProsePunctuation(t *testing.T) {
 	if resolved.URL != "https://info.example/x)" {
 		t.Fatalf("unexpected url: %q", resolved.URL)
 	}
-	if !strings.Contains(resolved.Note, "sentence punctuation") {
-		t.Fatalf("expected prose note, got: %q", resolved.Note)
+	if resolved.URLCleaned != "https://info.example/x" {
+		t.Fatalf("unexpected urlCleaned: %q", resolved.URLCleaned)
 	}
 
-	// The anchor href is byte-exact, so its trailing ")" gets no note.
+	// The anchor href is byte-exact; its balanced ")" is data, so no urlCleaned.
 	result = executeWithGmailTestService(
 		t,
 		[]string{"--json", "--account", "a@b.com", "gmail", "link", "m1", "1"},
@@ -151,8 +151,30 @@ func TestGmailLinkCmd_NotesTrailingProsePunctuation(t *testing.T) {
 	if result.err != nil {
 		t.Fatalf("Execute: %v\nstderr=%q", result.err, result.stderr)
 	}
-	if strings.Contains(result.stdout, "note") {
-		t.Fatalf("anchor href should have no note: %s", result.stdout)
+	if strings.Contains(result.stdout, "urlCleaned") {
+		t.Fatalf("anchor href should have no urlCleaned: %s", result.stdout)
+	}
+}
+
+func TestGmailLinkCleanedURL(t *testing.T) {
+	tests := []struct {
+		name string
+		link gmailLink
+		want string
+	}{
+		{name: "prose paren dropped", link: gmailLink{URL: "https://x.example/y)", fromText: true}, want: "https://x.example/y"},
+		{name: "sentence period dropped", link: gmailLink{URL: "https://x.example/y.", fromText: true}, want: "https://x.example/y"},
+		{name: "period then paren dropped", link: gmailLink{URL: "https://x.example/y.)", fromText: true}, want: "https://x.example/y"},
+		{name: "balanced parens kept", link: gmailLink{URL: "https://x.example/wiki/Foo_(bar)", fromText: true}, want: ""},
+		{name: "clean url untouched", link: gmailLink{URL: "https://x.example/y", fromText: true}, want: ""},
+		{name: "anchor href never cleaned", link: gmailLink{URL: "https://x.example/y."}, want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.link.cleanedURL(); got != tt.want {
+				t.Fatalf("cleanedURL() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/cmd/gmail_link_test.go
+++ b/internal/cmd/gmail_link_test.go
@@ -103,6 +103,59 @@ func TestGmailLinkCmd_IndexParityWithSanitizedGet(t *testing.T) {
 	}
 }
 
+func TestGmailLinkCmd_NotesTrailingProsePunctuation(t *testing.T) {
+	htmlBody := base64.RawURLEncoding.EncodeToString([]byte(
+		`<p>Details (https://info.example/x) here, button: <a href="https://pay.example/a_(b)">Pay</a></p>`,
+	))
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id": "m1", "threadId": "t1",
+			"payload": map[string]any{
+				"mimeType": "text/html",
+				"body":     map[string]any{"data": htmlBody},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	// The bare URL captured its prose ")" and says so.
+	result := executeWithGmailTestService(
+		t,
+		[]string{"--json", "--account", "a@b.com", "gmail", "link", "m1", "0"},
+		newGmailServiceFromServer(t, srv),
+	)
+	if result.err != nil {
+		t.Fatalf("Execute: %v\nstderr=%q", result.err, result.stderr)
+	}
+	var resolved struct {
+		URL  string `json:"url"`
+		Note string `json:"note"`
+	}
+	if err := json.Unmarshal([]byte(result.stdout), &resolved); err != nil {
+		t.Fatalf("decode JSON: %v", err)
+	}
+	if resolved.URL != "https://info.example/x)" {
+		t.Fatalf("unexpected url: %q", resolved.URL)
+	}
+	if !strings.Contains(resolved.Note, "sentence punctuation") {
+		t.Fatalf("expected prose note, got: %q", resolved.Note)
+	}
+
+	// The anchor href is byte-exact, so its trailing ")" gets no note.
+	result = executeWithGmailTestService(
+		t,
+		[]string{"--json", "--account", "a@b.com", "gmail", "link", "m1", "1"},
+		newGmailServiceFromServer(t, srv),
+	)
+	if result.err != nil {
+		t.Fatalf("Execute: %v\nstderr=%q", result.err, result.stderr)
+	}
+	if strings.Contains(result.stdout, "note") {
+		t.Fatalf("anchor href should have no note: %s", result.stdout)
+	}
+}
+
 func TestGmailLinkCmd_EscapesControlCharactersInLineOutput(t *testing.T) {
 	// Entities in the href decode to a raw newline and tab in the captured URL.
 	htmlBody := base64.RawURLEncoding.EncodeToString([]byte(

--- a/internal/cmd/gmail_link_test.go
+++ b/internal/cmd/gmail_link_test.go
@@ -164,9 +164,12 @@ func TestGmailLinkCleanedURL(t *testing.T) {
 	}{
 		{name: "prose paren dropped", link: gmailLink{URL: "https://x.example/y)", fromText: true}, want: "https://x.example/y"},
 		{name: "sentence period dropped", link: gmailLink{URL: "https://x.example/y.", fromText: true}, want: "https://x.example/y"},
-		{name: "period then paren dropped", link: gmailLink{URL: "https://x.example/y.)", fromText: true}, want: "https://x.example/y"},
+		{name: "comma dropped", link: gmailLink{URL: "https://x.example/y,", fromText: true}, want: "https://x.example/y"},
+		{name: "mixed trailing run dropped", link: gmailLink{URL: "https://x.example/y.)!,", fromText: true}, want: "https://x.example/y"},
 		{name: "balanced parens kept", link: gmailLink{URL: "https://x.example/wiki/Foo_(bar)", fromText: true}, want: ""},
+		{name: "balanced parens then period", link: gmailLink{URL: "https://x.example/wiki/Foo_(bar).", fromText: true}, want: "https://x.example/wiki/Foo_(bar)"},
 		{name: "clean url untouched", link: gmailLink{URL: "https://x.example/y", fromText: true}, want: ""},
+		{name: "nothing left after scheme", link: gmailLink{URL: "https://...", fromText: true}, want: ""},
 		{name: "anchor href never cleaned", link: gmailLink{URL: "https://x.example/y."}, want: ""},
 	}
 	for _, tt := range tests {

--- a/internal/cmd/gmail_sanitize.go
+++ b/internal/cmd/gmail_sanitize.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	htmlpkg "html"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"golang.org/x/net/html"
@@ -13,7 +14,9 @@ import (
 
 var (
 	sanitizeURLPattern = regexp.MustCompile(`https?://[^\s<>"'` + "`" + `\]\)]+`)
-	sanitizeWhitespace = regexp.MustCompile(`\s+`)
+	// A NUL-delimited anchor placeholder from extractSanitizedHTMLText, or a bare URL.
+	sanitizeLinkPattern = regexp.MustCompile("\x00[^\x00]*\x00|" + `https?://[^\s<>"'` + "`" + `\]\)]+`)
+	sanitizeWhitespace  = regexp.MustCompile(`\s+`)
 	sanitizeBlockTags  = map[string]bool{
 		"article": true, "blockquote": true, "br": true, "dd": true, "div": true,
 		"dl": true, "dt": true, "footer": true, "h1": true, "h2": true,
@@ -45,33 +48,117 @@ func sanitizeGmailText(value string) string {
 	return sanitizeURLPattern.ReplaceAllString(value, "[url removed]")
 }
 
-func sanitizeGmailBody(body string, isHTML bool) string {
-	if body == "" {
-		return ""
-	}
-	text := body
-	if isHTML {
-		text = extractSanitizedHTMLText(text)
-	}
-	text = sanitizeGmailText(text)
-	text = sanitizeWhitespace.ReplaceAllString(text, " ")
-	return strings.TrimSpace(text)
+type gmailLink struct {
+	URL  string `json:"url"`
+	Text string `json:"text,omitempty"`
 }
 
-func extractSanitizedHTMLText(value string) string {
+// linkCollector numbers the links a body conversion keeps out of the text. Indexes are
+// assigned in first-seen order; registering an href again returns its existing index,
+// so a repeated link shares one [link:N] reference.
+type linkCollector struct {
+	links []gmailLink
+	byURL map[string]int
+}
+
+func newLinkCollector() *linkCollector {
+	return &linkCollector{byURL: map[string]int{}}
+}
+
+func (c *linkCollector) add(url, text string) int {
+	if idx, ok := c.byURL[url]; ok {
+		return idx
+	}
+	idx := len(c.links)
+	c.links = append(c.links, gmailLink{URL: url, Text: text})
+	c.byURL[url] = idx
+	return idx
+}
+
+func sanitizeGmailBody(body string, isHTML bool) string {
+	text, _ := sanitizeGmailBodyLinks(body, isHTML)
+	return text
+}
+
+// sanitizeGmailBodyLinks converts a body like sanitizeGmailBody and also returns the
+// links behind the body's [link:N] markers, ordered by index. gmail link replays this
+// on the same message to resolve a marker, so the conversion must stay deterministic.
+func sanitizeGmailBodyLinks(body string, isHTML bool) (string, []gmailLink) {
+	if body == "" {
+		return "", nil
+	}
+	// NUL delimits the anchor placeholders below and cannot occur in tokenizer output
+	// (HTML parsing replaces it); strip it from the input so a crafted body cannot
+	// fabricate a placeholder.
+	text := strings.ReplaceAll(body, "\x00", "")
+	anchorTexts := map[string]string{}
+	if isHTML {
+		text = extractSanitizedHTMLText(text, anchorTexts)
+	}
+	text = htmlpkg.UnescapeString(text)
+	// One left-to-right pass numbers anchor placeholders and bare URLs alike, so
+	// indexes follow document order. A bare URL has no anchor text; its marker
+	// replaces it.
+	links := newLinkCollector()
+	text = sanitizeLinkPattern.ReplaceAllStringFunc(text, func(match string) string {
+		url, linkText := match, ""
+		if strings.HasPrefix(match, "\x00") {
+			url = strings.Trim(match, "\x00")
+			linkText = anchorTexts[url]
+		}
+		return "[link:" + strconv.Itoa(links.add(url, linkText)) + "]"
+	})
+	text = sanitizeWhitespace.ReplaceAllString(text, " ")
+	return strings.TrimSpace(text), links.links
+}
+
+func extractSanitizedHTMLText(value string, anchorTexts map[string]string) string {
 	tokenizer := html.NewTokenizer(strings.NewReader(value))
 	var out strings.Builder
 	skipDepth := 0
+	// Href and visible text of the anchor currently open; the placeholder is emitted
+	// at the anchor's close so its marker follows the link text. Alt text of images
+	// inside the anchor stands in when the anchor has no visible text of its own.
+	anchorHref := ""
+	var anchorText strings.Builder
+	var anchorAlt strings.Builder
 	for {
 		switch tokenizer.Next() {
 		case html.ErrorToken:
-			text := sanitizeWhitespace.ReplaceAllString(out.String(), " ")
-			return strings.TrimSpace(text)
+			return strings.TrimSpace(out.String())
 		case html.StartTagToken, html.SelfClosingTagToken:
-			name, _ := tokenizer.TagName()
+			name, hasAttr := tokenizer.TagName()
 			tag := strings.ToLower(string(name))
 			if tag == "script" || tag == literalStyle {
 				skipDepth++
+			}
+			if tag == "a" && hasAttr {
+				anchorHref = ""
+				anchorText.Reset()
+				anchorAlt.Reset()
+				for {
+					key, val, more := tokenizer.TagAttr()
+					if strings.EqualFold(string(key), "href") {
+						href := string(val)
+						if strings.HasPrefix(href, "https://") || strings.HasPrefix(href, "http://") || strings.HasPrefix(href, "mailto:") {
+							anchorHref = href
+						}
+					}
+					if !more {
+						break
+					}
+				}
+			}
+			if tag == "img" && anchorHref != "" && hasAttr {
+				for {
+					key, val, more := tokenizer.TagAttr()
+					if strings.EqualFold(string(key), "alt") {
+						anchorAlt.WriteString(" " + string(val))
+					}
+					if !more {
+						break
+					}
+				}
 			}
 			if sanitizeBlockTags[tag] {
 				out.WriteByte(' ')
@@ -82,12 +169,33 @@ func extractSanitizedHTMLText(value string) string {
 			if (tag == "script" || tag == literalStyle) && skipDepth > 0 {
 				skipDepth--
 			}
+			if tag == "a" && anchorHref != "" {
+				if skipDepth == 0 {
+					out.WriteString(" \x00" + anchorHref + "\x00")
+					text := strings.TrimSpace(sanitizeWhitespace.ReplaceAllString(anchorText.String(), " "))
+					if text == "" {
+						text = strings.TrimSpace(sanitizeWhitespace.ReplaceAllString(anchorAlt.String(), " "))
+					}
+					// The first site with text names the link; later sites of the
+					// same href share its index and therefore its text.
+					if anchorTexts[anchorHref] == "" {
+						anchorTexts[anchorHref] = text
+					}
+				}
+				anchorHref = ""
+				anchorText.Reset()
+				anchorAlt.Reset()
+			}
 			if sanitizeBlockTags[tag] {
 				out.WriteByte(' ')
 			}
 		case html.TextToken:
 			if skipDepth == 0 {
-				out.Write(tokenizer.Text())
+				text := tokenizer.Text()
+				out.Write(text)
+				if anchorHref != "" {
+					anchorText.Write(text)
+				}
 			}
 		}
 	}

--- a/internal/cmd/gmail_sanitize.go
+++ b/internal/cmd/gmail_sanitize.go
@@ -60,12 +60,12 @@ type gmailLink struct {
 	fromText bool
 }
 
-// cleanedURL is the best guess at a text-matched URL without trailing prose
-// punctuation, or "" when cleaning changes nothing. url stays the exact capture; this
-// derived field is where the guessing lives: trailing sentence punctuation is dropped,
-// and a trailing ")" only while the URL's parentheses are unbalanced, since a balanced
-// pair is likely part of the path. An anchor href is byte-exact and never cleaned.
-func (l gmailLink) cleanedURL() string {
+// trimmedURL is the text-matched URL without trailing prose punctuation, or "" when
+// trimming changes nothing. It backs the --trim-punctuation flag; the untrimmed URL
+// stays the exact capture. Trailing sentence punctuation is dropped, and a trailing ")"
+// only while the URL's parentheses are unbalanced, since a balanced pair is likely part
+// of the path. An anchor href is byte-exact and never trimmed.
+func (l gmailLink) trimmedURL() string {
 	if !l.fromText {
 		return ""
 	}
@@ -79,7 +79,7 @@ func (l gmailLink) cleanedURL() string {
 		}
 		url = url[:len(url)-1]
 	}
-	// A guess that ate everything after the scheme is no guess.
+	// A trim that ate everything after the scheme is no guess worth returning.
 	if url == l.URL || strings.HasSuffix(url, "://") {
 		return ""
 	}

--- a/internal/cmd/gmail_sanitize.go
+++ b/internal/cmd/gmail_sanitize.go
@@ -60,11 +60,11 @@ type gmailLink struct {
 	fromText bool
 }
 
-// cleanedURL is the best guess at a text-matched URL without surrounding prose
-// punctuation, or "" when cleaning would change nothing. url stays the exact capture;
-// this derived field is where the guessing lives: trailing dots are dropped, and a
-// trailing ")" only while the parentheses in the URL are unbalanced (a balanced pair is
-// likely part of the path). An anchor href is byte-exact and never cleaned.
+// cleanedURL is the best guess at a text-matched URL without trailing prose
+// punctuation, or "" when cleaning changes nothing. url stays the exact capture; this
+// derived field is where the guessing lives: trailing sentence punctuation is dropped,
+// and a trailing ")" only while the URL's parentheses are unbalanced, since a balanced
+// pair is likely part of the path. An anchor href is byte-exact and never cleaned.
 func (l gmailLink) cleanedURL() string {
 	if !l.fromText {
 		return ""
@@ -72,13 +72,15 @@ func (l gmailLink) cleanedURL() string {
 	url := l.URL
 	for len(url) > 0 {
 		last := url[len(url)-1]
-		if last == '.' || (last == ')' && strings.Count(url, ")") > strings.Count(url, "(")) {
-			url = url[:len(url)-1]
-			continue
+		prose := strings.IndexByte(".,;:!?", last) >= 0 ||
+			(last == ')' && strings.Count(url, ")") > strings.Count(url, "("))
+		if !prose {
+			break
 		}
-		break
+		url = url[:len(url)-1]
 	}
-	if url == l.URL {
+	// A guess that ate everything after the scheme is no guess.
+	if url == l.URL || strings.HasSuffix(url, "://") {
 		return ""
 	}
 	return url

--- a/internal/cmd/gmail_sanitize.go
+++ b/internal/cmd/gmail_sanitize.go
@@ -17,7 +17,7 @@ var (
 	// A NUL-delimited anchor placeholder from extractSanitizedHTMLText, or a bare URL.
 	sanitizeLinkPattern = regexp.MustCompile("\x00[^\x00]*\x00|" + `https?://[^\s<>"'` + "`" + `\]\)]+`)
 	sanitizeWhitespace  = regexp.MustCompile(`\s+`)
-	sanitizeBlockTags  = map[string]bool{
+	sanitizeBlockTags   = map[string]bool{
 		"article": true, "blockquote": true, "br": true, "dd": true, "div": true,
 		"dl": true, "dt": true, "footer": true, "h1": true, "h2": true,
 		"h3": true, "h4": true, "h5": true, "h6": true, "header": true,

--- a/internal/cmd/gmail_sanitize.go
+++ b/internal/cmd/gmail_sanitize.go
@@ -60,17 +60,28 @@ type gmailLink struct {
 	fromText bool
 }
 
-// trailingProseNote flags the one boundary a pattern cannot judge: a text-matched URL
-// ending in a character that is URL-legal but also common sentence punctuation.
-func (l gmailLink) trailingProseNote() string {
-	if !l.fromText || l.URL == "" {
+// cleanedURL is the best guess at a text-matched URL without surrounding prose
+// punctuation, or "" when cleaning would change nothing. url stays the exact capture;
+// this derived field is where the guessing lives: trailing dots are dropped, and a
+// trailing ")" only while the parentheses in the URL are unbalanced (a balanced pair is
+// likely part of the path). An anchor href is byte-exact and never cleaned.
+func (l gmailLink) cleanedURL() string {
+	if !l.fromText {
 		return ""
 	}
-	last := l.URL[len(l.URL)-1]
-	if last != '.' && last != ')' {
+	url := l.URL
+	for len(url) > 0 {
+		last := url[len(url)-1]
+		if last == '.' || (last == ')' && strings.Count(url, ")") > strings.Count(url, "(")) {
+			url = url[:len(url)-1]
+			continue
+		}
+		break
+	}
+	if url == l.URL {
 		return ""
 	}
-	return "the URL was captured from body text and its trailing " + string(last) + " may be sentence punctuation rather than part of the URL"
+	return url
 }
 
 // linkCollector numbers the links a body conversion keeps out of the text. Indexes are

--- a/internal/cmd/gmail_sanitize.go
+++ b/internal/cmd/gmail_sanitize.go
@@ -15,7 +15,11 @@ import (
 var (
 	sanitizeURLPattern = regexp.MustCompile(`https?://[^\s<>"'` + "`" + `\]\)]+`)
 	// A NUL-delimited anchor placeholder from extractSanitizedHTMLText, or a bare URL.
-	sanitizeLinkPattern = regexp.MustCompile("\x00[^\x00]*\x00|" + `https?://[^\s<>"'` + "`" + `\]\)]+`)
+	// Unlike sanitizeURLPattern, ")" stays in the URL: where a bare URL really ends is
+	// prose context no pattern can judge, and a resolved link must carry every captured
+	// character — the reader can drop a trailing ")" or "." it reads as punctuation,
+	// but nothing downstream can restore a character the pattern cut off.
+	sanitizeLinkPattern = regexp.MustCompile("\x00[^\x00]*\x00|" + `https?://[^\s<>"'` + "`" + `\]]+`)
 	sanitizeWhitespace  = regexp.MustCompile(`\s+`)
 	sanitizeBlockTags   = map[string]bool{
 		"article": true, "blockquote": true, "br": true, "dd": true, "div": true,
@@ -49,8 +53,24 @@ func sanitizeGmailText(value string) string {
 }
 
 type gmailLink struct {
-	URL  string `json:"url"`
-	Text string `json:"text,omitempty"`
+	URL  string
+	Text string
+	// True when the URL was matched in body text rather than read from an anchor
+	// href. Only then can its boundary be off: an href is byte-exact by construction.
+	fromText bool
+}
+
+// trailingProseNote flags the one boundary a pattern cannot judge: a text-matched URL
+// ending in a character that is URL-legal but also common sentence punctuation.
+func (l gmailLink) trailingProseNote() string {
+	if !l.fromText || l.URL == "" {
+		return ""
+	}
+	last := l.URL[len(l.URL)-1]
+	if last != '.' && last != ')' {
+		return ""
+	}
+	return "the URL was captured from body text and its trailing " + string(last) + " may be sentence punctuation rather than part of the URL"
 }
 
 // linkCollector numbers the links a body conversion keeps out of the text. Indexes are
@@ -65,12 +85,12 @@ func newLinkCollector() *linkCollector {
 	return &linkCollector{byURL: map[string]int{}}
 }
 
-func (c *linkCollector) add(url, text string) int {
+func (c *linkCollector) add(url, text string, fromText bool) int {
 	if idx, ok := c.byURL[url]; ok {
 		return idx
 	}
 	idx := len(c.links)
-	c.links = append(c.links, gmailLink{URL: url, Text: text})
+	c.links = append(c.links, gmailLink{URL: url, Text: text, fromText: fromText})
 	c.byURL[url] = idx
 	return idx
 }
@@ -101,12 +121,13 @@ func sanitizeGmailBodyLinks(body string, isHTML bool) (string, []gmailLink) {
 	// replaces it.
 	links := newLinkCollector()
 	text = sanitizeLinkPattern.ReplaceAllStringFunc(text, func(match string) string {
-		url, linkText := match, ""
+		url, linkText, fromText := match, "", true
 		if strings.HasPrefix(match, "\x00") {
 			url = strings.Trim(match, "\x00")
 			linkText = anchorTexts[url]
+			fromText = false
 		}
-		return "[link:" + strconv.Itoa(links.add(url, linkText)) + "]"
+		return "[link:" + strconv.Itoa(links.add(url, linkText, fromText)) + "]"
 	})
 	text = sanitizeWhitespace.ReplaceAllString(text, " ")
 	return strings.TrimSpace(text), links.links

--- a/internal/cmd/gmail_sanitize_test.go
+++ b/internal/cmd/gmail_sanitize_test.go
@@ -64,8 +64,31 @@ func TestSanitizeGmailBodyLinks(t *testing.T) {
 	}
 	wantLinks := []gmailLink{
 		{URL: "https://pay.example/btn", Text: "Pay now"},
-		{URL: "https://info.example/page"},
+		{URL: "https://info.example/page", fromText: true},
 		{URL: "mailto:billing@example.com", Text: "billing"},
+	}
+	if len(links) != len(wantLinks) {
+		t.Fatalf("unexpected links: %#v", links)
+	}
+	for i, wantLink := range wantLinks {
+		if links[i] != wantLink {
+			t.Fatalf("link %d = %#v, want %#v", i, links[i], wantLink)
+		}
+	}
+}
+
+func TestSanitizeGmailBodyLinks_BareURLBoundaries(t *testing.T) {
+	body := "See https://en.wikipedia.org/wiki/Foo_(bar) and (https://info.example/x) for details"
+	text, links := sanitizeGmailBodyLinks(body, false)
+	want := "See [link:0] and ([link:1] for details"
+	if text != want {
+		t.Fatalf("unexpected text:\n got %q\nwant %q", text, want)
+	}
+	// Every captured character is kept: the balanced-paren path survives whole, and the
+	// prose paren after the second URL is captured rather than cut — the reader decides.
+	wantLinks := []gmailLink{
+		{URL: "https://en.wikipedia.org/wiki/Foo_(bar)", fromText: true},
+		{URL: "https://info.example/x)", fromText: true},
 	}
 	if len(links) != len(wantLinks) {
 		t.Fatalf("unexpected links: %#v", links)

--- a/internal/cmd/gmail_sanitize_test.go
+++ b/internal/cmd/gmail_sanitize_test.go
@@ -17,22 +17,22 @@ func TestSanitizeGmailBody(t *testing.T) {
 		want   string
 	}{
 		{
-			name:   "html strips scripts and visible urls",
+			name:   "html strips scripts and marks visible urls",
 			body:   `<script>fetch("https://tracker.example/open")</script><p>Hello https://phish.example/login</p>`,
 			isHTML: true,
-			want:   "Hello [url removed]",
+			want:   "Hello [link:0]",
 		},
 		{
 			name:   "plain decodes entity-obfuscated url",
 			body:   `open &#104;ttps://evil.example/path now`,
 			isHTML: false,
-			want:   "open [url removed] now",
+			want:   "open [link:0] now",
 		},
 		{
-			name:   "html keeps link text but drops href target",
+			name:   "html keeps link text and marks its target",
 			body:   `<p>Click <a href="https://evil.example">here</a></p>`,
 			isHTML: true,
-			want:   "Click here",
+			want:   "Click here [link:0]",
 		},
 		{
 			name:   "style block removed",
@@ -48,6 +48,56 @@ func TestSanitizeGmailBody(t *testing.T) {
 				t.Fatalf("sanitizeGmailBody() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestSanitizeGmailBodyLinks(t *testing.T) {
+	body := `<script>fetch("https://tracker.example/open")</script>` +
+		`<p>Pay <a href="https://pay.example/btn">Pay now</a></p>` +
+		`<p>Visit https://info.example/page for details</p>` +
+		`<p>Again <a href="https://pay.example/btn">same target</a></p>` +
+		`<p>Write to <a href="mailto:billing@example.com">billing</a></p>`
+	text, links := sanitizeGmailBodyLinks(body, true)
+	want := "Pay Pay now [link:0] Visit [link:1] for details Again same target [link:0] Write to billing [link:2]"
+	if text != want {
+		t.Fatalf("unexpected text:\n got %q\nwant %q", text, want)
+	}
+	wantLinks := []gmailLink{
+		{URL: "https://pay.example/btn", Text: "Pay now"},
+		{URL: "https://info.example/page"},
+		{URL: "mailto:billing@example.com", Text: "billing"},
+	}
+	if len(links) != len(wantLinks) {
+		t.Fatalf("unexpected links: %#v", links)
+	}
+	for i, wantLink := range wantLinks {
+		if links[i] != wantLink {
+			t.Fatalf("link %d = %#v, want %#v", i, links[i], wantLink)
+		}
+	}
+}
+
+func TestSanitizeGmailBodyLinks_ImageAnchors(t *testing.T) {
+	body := `<p><a href="https://promo.example/go"><img src="hero.png" alt="Start now"></a></p>` +
+		`<p><a href="https://docs.example/x"><img src="icon.png"></a> then <a href="https://docs.example/x">read the docs</a></p>`
+	text, links := sanitizeGmailBodyLinks(body, true)
+	want := "[link:0] [link:1] then read the docs [link:1]"
+	if text != want {
+		t.Fatalf("unexpected text:\n got %q\nwant %q", text, want)
+	}
+	wantLinks := []gmailLink{
+		// No visible text: the wrapped image's alt stands in.
+		{URL: "https://promo.example/go", Text: "Start now"},
+		// The first site is textless; the second site's text names the link.
+		{URL: "https://docs.example/x", Text: "read the docs"},
+	}
+	if len(links) != len(wantLinks) {
+		t.Fatalf("unexpected links: %#v", links)
+	}
+	for i, wantLink := range wantLinks {
+		if links[i] != wantLink {
+			t.Fatalf("link %d = %#v, want %#v", i, links[i], wantLink)
+		}
 	}
 }
 
@@ -113,7 +163,7 @@ func TestGmailGetCmd_SanitizeContent_JSONUsesSafeEnvelope(t *testing.T) {
 	if err := json.Unmarshal(envelope["message"], &parsed); err != nil {
 		t.Fatalf("decode sanitized message: %v", err)
 	}
-	if parsed.Body != "Hello [url removed]" {
+	if parsed.Body != "Hello [link:0]" {
 		t.Fatalf("unexpected body: %q", parsed.Body)
 	}
 	if parsed.Headers["subject"] != "Visit [url removed] now" {
@@ -148,6 +198,9 @@ func TestGmailThreadGet_SanitizeContent_JSONUsesSafeEnvelope(t *testing.T) {
 	htmlBody := base64.RawURLEncoding.EncodeToString([]byte(
 		`<style>.x{background:url(https://tracker.example)}</style><p>Hello https://phish.example/login</p>`,
 	))
+	secondBody := base64.RawURLEncoding.EncodeToString([]byte(
+		`<p>Bye <a href="https://other.example/x">there</a></p>`,
+	))
 	threadResp := map[string]any{
 		"id": "t1",
 		"messages": []map[string]any{
@@ -164,6 +217,18 @@ func TestGmailThreadGet_SanitizeContent_JSONUsesSafeEnvelope(t *testing.T) {
 					},
 					"mimeType": "text/html",
 					"body":     map[string]any{"data": htmlBody},
+				},
+			},
+			{
+				"id":       "m2",
+				"threadId": "t1",
+				"payload": map[string]any{
+					"headers": []map[string]any{
+						{"name": "From", "value": "b@example.com"},
+						{"name": "Subject", "value": "Re: Check"},
+					},
+					"mimeType": "text/html",
+					"body":     map[string]any{"data": secondBody},
 				},
 			},
 		},
@@ -202,10 +267,14 @@ func TestGmailThreadGet_SanitizeContent_JSONUsesSafeEnvelope(t *testing.T) {
 	if err := json.Unmarshal([]byte(result.stdout), &parsed); err != nil {
 		t.Fatalf("decode JSON: %v", err)
 	}
-	if len(parsed.Thread.Messages) != 1 {
+	if len(parsed.Thread.Messages) != 2 {
 		t.Fatalf("unexpected messages: %#v", parsed.Thread.Messages)
 	}
-	if got := parsed.Thread.Messages[0].Body; got != "Hello [url removed]" {
+	if got := parsed.Thread.Messages[0].Body; got != "Hello [link:0]" {
 		t.Fatalf("unexpected body: %q", got)
+	}
+	// Marker numbering restarts per message.
+	if got := parsed.Thread.Messages[1].Body; got != "Bye there [link:0]" {
+		t.Fatalf("unexpected second body: %q", got)
 	}
 }

--- a/internal/cmd/gmail_sanitize_test.go
+++ b/internal/cmd/gmail_sanitize_test.go
@@ -53,12 +53,12 @@ func TestSanitizeGmailBody(t *testing.T) {
 
 func TestSanitizeGmailBodyLinks(t *testing.T) {
 	body := `<script>fetch("https://tracker.example/open")</script>` +
-		`<p>Pay <a href="https://pay.example/btn">Pay now</a></p>` +
+		`<p>Click <a href="https://pay.example/btn">Pay now</a></p>` +
 		`<p>Visit https://info.example/page for details</p>` +
 		`<p>Again <a href="https://pay.example/btn">same target</a></p>` +
 		`<p>Write to <a href="mailto:billing@example.com">billing</a></p>`
 	text, links := sanitizeGmailBodyLinks(body, true)
-	want := "Pay Pay now [link:0] Visit [link:1] for details Again same target [link:0] Write to billing [link:2]"
+	want := "Click Pay now [link:0] Visit [link:1] for details Again same target [link:0] Write to billing [link:2]"
 	if text != want {
 		t.Fatalf("unexpected text:\n got %q\nwant %q", text, want)
 	}

--- a/safety-profiles/agent-safe.yaml
+++ b/safety-profiles/agent-safe.yaml
@@ -9,6 +9,7 @@ gmail:
   get: true
   messages: true
   attachment: true
+  link: true
   url: true
   history: true
   thread:

--- a/safety-profiles/readonly.yaml
+++ b/safety-profiles/readonly.yaml
@@ -11,6 +11,7 @@ gmail:
     search: true
     modify: false
   attachment: true
+  link: true
   url: true
   history: true
   thread:


### PR DESCRIPTION
## Problem

`--sanitize-content` loses every link destination: visible URLs are replaced with
`[url removed]`, and anchor `href`s are dropped with the markup. Sanitized mail therefore
cannot be acted on — a task like "open the invoice" or "unsubscribe me from this" needs the
destination. Keeping URLs inline is no answer either: they can be really long (400–1000
chars each) and would dominate the sanitized body.

## Change

Attachments already solve this shape of problem: the output carries a compact reference,
and the content is fetched on demand. This PR gives URLs the same treatment.

- `[url removed]` in the sanitized body is replaced with `[link:N]` instead, so you can
  reference the link by its index `N` when you actually want to fetch it.
- Indexes are assigned in document order; the same href at several sites shares one index.
- An anchor without visible text (an image-wrapper link) is named by its image's `alt`.
- Script/style content is dropped as before and never numbered.
- New command, mirroring `gmail attachment`:

  ```
  gog gmail link <messageId> <index>
  ```

  It re-runs the same deterministic body conversion, so its indexes are the ones in the
  sanitized body. JSON output is `{"url": ..., "text": ...}` with `text` being the
  anchor text, omitted for a bare URL; a bad index is a usage error.
- The `readonly` and `agent-safe` profiles allow `gmail link`; command docs regenerated;
  `docs/gmail-workflows.md` updated.

## Proof (real mailbox, redacted)

A payment notice whose actions are HTML buttons. Sanitized body on v0.37.0 — the button
texts survive, their destinations are silently gone:

```
... Falls Sie es noch nicht getan haben, fügen Sie einen Beleg hinzu, um Zeit bei der
Buchhaltung zu sparen.   Beleg hinzufügen   Möchten Sie diese Zahlung per Lastschrift
anfechten? Rufen Sie die Zahlung auf und prüfen Sie Ihre Möglichkeiten. ...
```

Same message with this branch:

```
$ gog --version
v0.34.2-38-g1b5fbc1f (1b5fbc1fdc64 2026-08-20T10:42:03Z)
$ gog gmail get MSG_ID --json --sanitize-content
... Falls Sie es noch nicht getan haben, fügen Sie einen Beleg hinzu, um Zeit bei der
Buchhaltung zu sparen.   Beleg hinzufügen [link:0]   Möchten Sie diese Zahlung per
Lastschrift anfechten? Rufen Sie die Zahlung [link:1] auf und prüfen Sie Ihre
Möglichkeiten. ...
$ gog gmail link MSG_ID 0 --json
{
  "url": "https://url2820.qonto.com/ls/click?upn=u001.PALJKS45jlsSqfTO[...redacted, 1023 chars total...]",
  "text": "Beleg hinzufügen"
}
```

The resolved URL is byte-identical to the anchor's `href` in the message's HTML. No URL
appears anywhere in the sanitized output; the original example message carries six long
tracked URLs which would otherwise add ~5 kB to every read.
Before this change, needing to open even a single one of these links meant giving up on
sanitizing entirely and reading the message unsanitized, with all URLs and the raw
payload, just to get at one `href`.

## Testing

- Unit: body conversion (anchor text + marker, bare-URL replacement, `mailto`, duplicate
  href sharing one index, image-anchor `alt` naming, script/style URLs never numbered).
- Execute-level: sanitized `gmail get` emits markers and no URLs; `gmail link` resolves
  index → exact URL and anchor text; non-numeric / out-of-range indexes are usage errors;
  index parity between `get` and `link` on one fixture; thread output numbers per message.
- Local gate: `make fmt-check`, `make lint`, `make deadcode`, `make docs-check`, `make
  test` all pass.

User-facing changes: the new `gmail link` command; sanitized bodies now mark links as
`[link:N]` instead of `[url removed]`/dropping them.
