### PR TITLE
feat(slides): add skip and unskip commands

### DIFF
--- a/.agents/skills/gog-slides/SKILL.md
+++ b/.agents/skills/gog-slides/SKILL.md
@@ -42,7 +42,7 @@ gog --readonly --account user@example.com slides --help
 | `insert-image` | Insert a local or public image at a position and size |
 | `insert-text` | Insert text into an existing page element (shape or table) by objectId |
 | `link` | Apply a hyperlink to a text range in one page element |
-| `list-slides` | List all slides with their object IDs |
+| `list-slides` | List all slides with their object IDs and skipped state |
 | `locate` | Locate text in shapes and table cells with object IDs and UTF-16 ranges |
 | `move-slide` | Move a slide to a zero-based insertion index |
 | `new-slide` | Create a native themed slide |
@@ -50,9 +50,11 @@ gog --readonly --account user@example.com slides --help
 | `read-slide` | Read slide content: speaker notes, text elements, and images |
 | `replace-slide` | Replace an existing slide image from a local file or public URL |
 | `replace-text` | Find-and-replace text in an explicit object, slide, or presentation scope |
+| `skip-slide` | Skip a slide during presentation |
 | `style-text` | Apply range-scoped text styling to one page element |
 | `table` | Create and update native tables |
 | `thumbnail` | Get or download a rendered thumbnail for a slide |
+| `unskip-slide` | Include a skipped slide during presentation |
 | `update-notes` | Update speaker notes on an existing slide |
 
 Run `gog slides <command> --help` for flags and `gog schema slides <command> --json`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Slides: add skip/unskip commands and expose slide visibility without changing existing plain-text output. (#1009) — thanks @marnunez.
+- Config: serialize concurrent updates with shared platform-native file locks, preventing intermittent access-denied failures on Windows.
 - Calendar: correctly clear custom reminder overrides when restoring calendar defaults. (#1016) — thanks @sorenisanerd.
 - Security: remove overflow-prone capacity arithmetic from untrusted-output maps and versioned tracking ciphertext construction while preserving their wire formats.
 - Security: restrict the CI workflow's `GITHUB_TOKEN` to read-only repository contents instead of inheriting broader organization or repository defaults.

--- a/docs/commands.generated.md
+++ b/docs/commands.generated.md
@@ -646,7 +646,7 @@ Generated from `gog schema --json`.
     - [`gog slides (slide) insert-image --width=FLOAT-64 <presentationId> <slideId> [<image>] [flags]`](commands/gog-slides-insert-image.md) - Insert a local or public image at a position and size
     - [`gog slides (slide) insert-text <presentationId> <objectId> <text> [flags]`](commands/gog-slides-insert-text.md) - Insert text into an existing page element (shape or table) by objectId
     - [`gog slides (slide) link --range=STRING <presentationId> <objectId> [flags]`](commands/gog-slides-link.md) - Apply a hyperlink to a text range in one page element
-    - [`gog slides (slide) list-slides <presentationId>`](commands/gog-slides-list-slides.md) - List all slides with their object IDs
+    - [`gog slides (slide) list-slides <presentationId>`](commands/gog-slides-list-slides.md) - List all slides with their object IDs and skipped state
     - [`gog slides (slide) locate (find-element) <presentationId> <text> [flags]`](commands/gog-slides-locate.md) - Locate text in shapes and table cells with object IDs and UTF-16 ranges
     - [`gog slides (slide) move-slide --to-index=TO-INDEX <presentationId> <slideId>`](commands/gog-slides-move-slide.md) - Move a slide to a zero-based insertion index
     - [`gog slides (slide) new-slide <presentationId> [flags]`](commands/gog-slides-new-slide.md) - Create a native themed slide
@@ -654,6 +654,7 @@ Generated from `gog schema --json`.
     - [`gog slides (slide) read-slide <presentationId> <slideId> [flags]`](commands/gog-slides-read-slide.md) - Read slide content: speaker notes, text elements, and images
     - [`gog slides (slide) replace-slide <presentationId> <slideId> [<image>] [flags]`](commands/gog-slides-replace-slide.md) - Replace an existing slide image from a local file or public URL
     - [`gog slides (slide) replace-text <presentationId> <find> <replacement> [flags]`](commands/gog-slides-replace-text.md) - Find-and-replace text in an explicit object, slide, or presentation scope
+    - [`gog slides (slide) skip-slide (hide-slide) <presentationId> <slideId>`](commands/gog-slides-skip-slide.md) - Skip a slide during presentation
     - [`gog slides (slide) style-text --range=STRING <presentationId> <objectId> [flags]`](commands/gog-slides-style-text.md) - Apply range-scoped text styling to one page element
     - [`gog slides (slide) table <command>`](commands/gog-slides-table.md) - Create and update native tables
       - [`gog slides (slide) table border <command>`](commands/gog-slides-table-border.md) - Style table borders
@@ -672,6 +673,7 @@ Generated from `gog schema --json`.
         - [`gog slides (slide) table row size --row=INT-64 --height=FLOAT-64 <presentationId> <tableObjectId>`](commands/gog-slides-table-row-size.md) - Set a row's minimum height
       - [`gog slides (slide) table unmerge (split) --row=INT-64 --col=INT-64 <presentationId> <tableObjectId> [flags]`](commands/gog-slides-table-unmerge.md) - Unmerge cells in a rectangular table range
     - [`gog slides (slide) thumbnail (thumb) <presentationId> <slideId> [flags]`](commands/gog-slides-thumbnail.md) - Get or download a rendered thumbnail for a slide
+    - [`gog slides (slide) unskip-slide (unhide-slide) <presentationId> <slideId>`](commands/gog-slides-unskip-slide.md) - Include a skipped slide during presentation
     - [`gog slides (slide) update-notes <presentationId> <slideId> [flags]`](commands/gog-slides-update-notes.md) - Update speaker notes on an existing slide
   - [`gog status (st) [flags]`](commands/gog-status.md) - Show auth/config status (alias for 'auth status')
   - [`gog tasks (task) <command> [flags]`](commands/gog-tasks.md) - Google Tasks

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -2,7 +2,7 @@
 
 Every `gog` command has a generated docs page. The source of truth is the live CLI schema; run `make docs-commands` after changing command names, flags, help text, aliases, or arguments.
 
-Generated pages: 719.
+Generated pages: 721.
 
 ## Top-level Commands
 
@@ -699,7 +699,7 @@ Generated pages: 719.
     - [gog slides insert-image](gog-slides-insert-image.md) - Insert a local or public image at a position and size
     - [gog slides insert-text](gog-slides-insert-text.md) - Insert text into an existing page element (shape or table) by objectId
     - [gog slides link](gog-slides-link.md) - Apply a hyperlink to a text range in one page element
-    - [gog slides list-slides](gog-slides-list-slides.md) - List all slides with their object IDs
+    - [gog slides list-slides](gog-slides-list-slides.md) - List all slides with their object IDs and skipped state
     - [gog slides locate](gog-slides-locate.md) - Locate text in shapes and table cells with object IDs and UTF-16 ranges
     - [gog slides move-slide](gog-slides-move-slide.md) - Move a slide to a zero-based insertion index
     - [gog slides new-slide](gog-slides-new-slide.md) - Create a native themed slide
@@ -707,6 +707,7 @@ Generated pages: 719.
     - [gog slides read-slide](gog-slides-read-slide.md) - Read slide content: speaker notes, text elements, and images
     - [gog slides replace-slide](gog-slides-replace-slide.md) - Replace an existing slide image from a local file or public URL
     - [gog slides replace-text](gog-slides-replace-text.md) - Find-and-replace text in an explicit object, slide, or presentation scope
+    - [gog slides skip-slide](gog-slides-skip-slide.md) - Skip a slide during presentation
     - [gog slides style-text](gog-slides-style-text.md) - Apply range-scoped text styling to one page element
     - [gog slides table](gog-slides-table.md) - Create and update native tables
       - [gog slides table border](gog-slides-table-border.md) - Style table borders
@@ -725,6 +726,7 @@ Generated pages: 719.
         - [gog slides table row size](gog-slides-table-row-size.md) - Set a row's minimum height
       - [gog slides table unmerge](gog-slides-table-unmerge.md) - Unmerge cells in a rectangular table range
     - [gog slides thumbnail](gog-slides-thumbnail.md) - Get or download a rendered thumbnail for a slide
+    - [gog slides unskip-slide](gog-slides-unskip-slide.md) - Include a skipped slide during presentation
     - [gog slides update-notes](gog-slides-update-notes.md) - Update speaker notes on an existing slide
   - [gog status](gog-status.md) - Show auth/config status (alias for 'auth status')
   - [gog tasks](gog-tasks.md) - Google Tasks

--- a/docs/commands/gog-slides-skip-slide.md
+++ b/docs/commands/gog-slides-skip-slide.md
@@ -1,13 +1,13 @@
-# `gog slides list-slides`
+# `gog slides skip-slide`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-List all slides with their object IDs and skipped state
+Skip a slide during presentation
 
 ## Usage
 
 ```bash
-gog slides (slide) list-slides <presentationId>
+gog slides (slide) skip-slide (hide-slide) <presentationId> <slideId>
 ```
 
 ## Parent

--- a/docs/commands/gog-slides-unskip-slide.md
+++ b/docs/commands/gog-slides-unskip-slide.md
@@ -1,13 +1,13 @@
-# `gog slides list-slides`
+# `gog slides unskip-slide`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-List all slides with their object IDs and skipped state
+Include a skipped slide during presentation
 
 ## Usage
 
 ```bash
-gog slides (slide) list-slides <presentationId>
+gog slides (slide) unskip-slide (unhide-slide) <presentationId> <slideId>
 ```
 
 ## Parent

--- a/docs/commands/gog-slides.md
+++ b/docs/commands/gog-slides.md
@@ -30,7 +30,7 @@ gog slides (slide) <command> [flags]
 - [gog slides insert-image](gog-slides-insert-image.md) - Insert a local or public image at a position and size
 - [gog slides insert-text](gog-slides-insert-text.md) - Insert text into an existing page element (shape or table) by objectId
 - [gog slides link](gog-slides-link.md) - Apply a hyperlink to a text range in one page element
-- [gog slides list-slides](gog-slides-list-slides.md) - List all slides with their object IDs
+- [gog slides list-slides](gog-slides-list-slides.md) - List all slides with their object IDs and skipped state
 - [gog slides locate](gog-slides-locate.md) - Locate text in shapes and table cells with object IDs and UTF-16 ranges
 - [gog slides move-slide](gog-slides-move-slide.md) - Move a slide to a zero-based insertion index
 - [gog slides new-slide](gog-slides-new-slide.md) - Create a native themed slide
@@ -38,9 +38,11 @@ gog slides (slide) <command> [flags]
 - [gog slides read-slide](gog-slides-read-slide.md) - Read slide content: speaker notes, text elements, and images
 - [gog slides replace-slide](gog-slides-replace-slide.md) - Replace an existing slide image from a local file or public URL
 - [gog slides replace-text](gog-slides-replace-text.md) - Find-and-replace text in an explicit object, slide, or presentation scope
+- [gog slides skip-slide](gog-slides-skip-slide.md) - Skip a slide during presentation
 - [gog slides style-text](gog-slides-style-text.md) - Apply range-scoped text styling to one page element
 - [gog slides table](gog-slides-table.md) - Create and update native tables
 - [gog slides thumbnail](gog-slides-thumbnail.md) - Get or download a rendered thumbnail for a slide
+- [gog slides unskip-slide](gog-slides-unskip-slide.md) - Include a skipped slide during presentation
 - [gog slides update-notes](gog-slides-update-notes.md) - Update speaker notes on an existing slide
 
 ## Flags

--- a/docs/slides-structure.md
+++ b/docs/slides-structure.md
@@ -42,6 +42,22 @@ matching the Slides API. An index can range from zero through the slide count.
 Use `--dry-run --json` to inspect the exact batch request without contacting
 Google, and `slides list-slides --json` to verify the resulting order.
 
+## Skip and unskip
+
+Exclude a slide from presentation mode without deleting it, or include it again:
+
+```bash
+gog slides skip-slide <presentationId> <slideId>
+gog slides unskip-slide <presentationId> <slideId>
+```
+
+`hide-slide` and `unhide-slide` are aliases for the same operations. The slide
+remains in the deck and can still be edited. `slides list-slides` reports the
+skipped state for every slide; JSON output uses the `isSkipped` field.
+
+Both commands support `--dry-run --json` to inspect the
+`updateSlideProperties` request before contacting Google.
+
 ## Native elements
 
 Create editable shapes and lines on an existing slide:

--- a/internal/cmd/slides.go
+++ b/internal/cmd/slides.go
@@ -25,7 +25,9 @@ type SlidesCmd struct {
 	NewSlide           SlidesNewSlideCmd           `cmd:"" name:"new-slide" help:"Create a native themed slide"`
 	DuplicateSlide     SlidesDuplicateSlideCmd     `cmd:"" name:"duplicate-slide" help:"Duplicate a slide by object ID"`
 	MoveSlide          SlidesMoveSlideCmd          `cmd:"" name:"move-slide" help:"Move a slide to a zero-based insertion index"`
-	ListSlides         SlidesListSlidesCmd         `cmd:"" name:"list-slides" help:"List all slides with their object IDs"`
+	SkipSlide          SlidesSkipSlideCmd          `cmd:"" name:"skip-slide" aliases:"hide-slide" help:"Skip a slide during presentation"`
+	UnskipSlide        SlidesUnskipSlideCmd        `cmd:"" name:"unskip-slide" aliases:"unhide-slide" help:"Include a skipped slide during presentation"`
+	ListSlides         SlidesListSlidesCmd         `cmd:"" name:"list-slides" help:"List all slides with their object IDs and skipped state"`
 	DeleteSlide        SlidesDeleteSlideCmd        `cmd:"" name:"delete-slide" help:"Delete a slide by object ID"`
 	ReadSlide          SlidesReadSlideCmd          `cmd:"" name:"read-slide" help:"Read slide content: speaker notes, text elements, and images"`
 	Locate             SlidesLocateCmd             `cmd:"" name:"locate" aliases:"find-element" help:"Locate text in shapes and table cells with object IDs and UTF-16 ranges"`

--- a/internal/cmd/slides_list_slides.go
+++ b/internal/cmd/slides_list_slides.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"google.golang.org/api/slides/v1"
+
 	"github.com/openclaw/gogcli/internal/outfmt"
 	"github.com/openclaw/gogcli/internal/ui"
 )
@@ -41,8 +43,9 @@ func (c *SlidesListSlidesCmd) Run(ctx context.Context, flags *RootFlags) error {
 		items := make([]map[string]any, len(pres.Slides))
 		for i, s := range pres.Slides {
 			items[i] = map[string]any{
-				"number":   i + 1,
-				"objectId": s.ObjectId,
+				"number":    i + 1,
+				"objectId":  s.ObjectId,
+				"isSkipped": slideIsSkipped(s),
 			}
 		}
 		return outfmt.WriteJSON(ctx, stdoutWriter(ctx), map[string]any{
@@ -57,10 +60,14 @@ func (c *SlidesListSlidesCmd) Run(ctx context.Context, flags *RootFlags) error {
 	u.Out().Println("")
 
 	tw := tabwriter.NewWriter(stdoutWriter(ctx), 0, 4, 2, ' ', 0)
-	fmt.Fprintln(tw, "#\tOBJECT ID")
+	fmt.Fprintln(tw, "#\tOBJECT ID\tSKIPPED")
 	for i, s := range pres.Slides {
-		fmt.Fprintf(tw, "%d\t%s\n", i+1, s.ObjectId)
+		fmt.Fprintf(tw, "%d\t%s\t%t\n", i+1, s.ObjectId, slideIsSkipped(s))
 	}
 	_ = tw.Flush()
 	return nil
+}
+
+func slideIsSkipped(slide *slides.Page) bool {
+	return slide != nil && slide.SlideProperties != nil && slide.SlideProperties.IsSkipped
 }

--- a/internal/cmd/slides_list_slides_test.go
+++ b/internal/cmd/slides_list_slides_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -16,7 +17,7 @@ func TestSlidesListSlidesUsesRuntimeOutput(t *testing.T) {
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = io.WriteString(w, `{"presentationId":"deck","title":"Deck","slides":[{"objectId":"slide-1"},{"objectId":"slide-2"}]}`)
+		_, _ = io.WriteString(w, `{"presentationId":"deck","title":"Deck","slides":[{"objectId":"slide-1","slideProperties":{"isSkipped":true}},{"objectId":"slide-2"}]}`)
 	}))
 	defer server.Close()
 
@@ -28,7 +29,43 @@ func TestSlidesListSlidesUsesRuntimeOutput(t *testing.T) {
 	if err := (&SlidesListSlidesCmd{PresentationID: "deck"}).Run(ctx, &RootFlags{Account: "a@b.com"}); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
-	if got := output.String(); !strings.Contains(got, "Presentation: Deck (2 slides)") || !strings.Contains(got, "1  slide-1") {
+	if got := output.String(); !strings.Contains(got, "Presentation: Deck (2 slides)") ||
+		!strings.Contains(got, "OBJECT ID") || !strings.Contains(got, "SKIPPED") ||
+		!strings.Contains(got, "1  slide-1    true") || !strings.Contains(got, "2  slide-2    false") {
 		t.Fatalf("output = %q", got)
+	}
+}
+
+func TestSlidesListSlidesJSONIncludesSkippedState(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/presentations/deck") {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"presentationId":"deck","title":"Deck","slides":[{"objectId":"slide-1","slideProperties":{"isSkipped":true}},{"objectId":"slide-2"}]}`)
+	}))
+	defer server.Close()
+
+	var output bytes.Buffer
+	ctx := withSlidesTestService(
+		newCmdRuntimeJSONOutputContext(t, &output, io.Discard),
+		newMockSlidesService(t, server),
+	)
+	if err := (&SlidesListSlidesCmd{PresentationID: "deck"}).Run(ctx, &RootFlags{Account: "a@b.com"}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	var got struct {
+		Slides []struct {
+			ObjectID  string `json:"objectId"`
+			IsSkipped bool   `json:"isSkipped"`
+		} `json:"slides"`
+	}
+	if err := json.Unmarshal(output.Bytes(), &got); err != nil {
+		t.Fatalf("decode output: %v\n%s", err, output.String())
+	}
+	if len(got.Slides) != 2 || !got.Slides[0].IsSkipped || got.Slides[1].IsSkipped {
+		t.Fatalf("unexpected slides: %#v", got.Slides)
 	}
 }

--- a/internal/cmd/slides_visibility.go
+++ b/internal/cmd/slides_visibility.go
@@ -1,0 +1,103 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"google.golang.org/api/slides/v1"
+
+	"github.com/openclaw/gogcli/internal/outfmt"
+	"github.com/openclaw/gogcli/internal/ui"
+)
+
+type SlidesSkipSlideCmd struct {
+	PresentationID string `arg:"" name:"presentationId" help:"Presentation ID"`
+	SlideID        string `arg:"" name:"slideId" help:"Slide object ID to skip (use 'slides list-slides' to find IDs)"`
+}
+
+func (c *SlidesSkipSlideCmd) Run(ctx context.Context, flags *RootFlags) error {
+	return runSlidesSetSkipped(ctx, flags, c.PresentationID, c.SlideID, true, "slides.skip-slide")
+}
+
+type SlidesUnskipSlideCmd struct {
+	PresentationID string `arg:"" name:"presentationId" help:"Presentation ID"`
+	SlideID        string `arg:"" name:"slideId" help:"Slide object ID to include (use 'slides list-slides' to find IDs)"`
+}
+
+func (c *SlidesUnskipSlideCmd) Run(ctx context.Context, flags *RootFlags) error {
+	return runSlidesSetSkipped(ctx, flags, c.PresentationID, c.SlideID, false, "slides.unskip-slide")
+}
+
+func runSlidesSetSkipped(
+	ctx context.Context,
+	flags *RootFlags,
+	presentationIDValue, slideIDValue string,
+	isSkipped bool,
+	op string,
+) error {
+	u := ui.FromContext(ctx)
+
+	presentationID := strings.TrimSpace(presentationIDValue)
+	if presentationID == "" {
+		return usage("empty presentationId")
+	}
+	slideID := strings.TrimSpace(slideIDValue)
+	if slideID == "" {
+		return usage("empty slideId")
+	}
+
+	body := slidesVisibilityBatchUpdate(slideID, isSkipped)
+	if err := dryRunExit(ctx, flags, op, map[string]any{
+		"presentation_id": presentationID,
+		"slide_object_id": slideID,
+		"is_skipped":      isSkipped,
+		"batch_update":    body,
+	}); err != nil {
+		return err
+	}
+
+	account, err := requireAccount(flags)
+	if err != nil {
+		return err
+	}
+	slidesSvc, err := slidesService(ctx, account)
+	if err != nil {
+		return err
+	}
+	if _, err := slidesSvc.Presentations.BatchUpdate(presentationID, body).Context(ctx).Do(); err != nil {
+		return fmt.Errorf("update slide skipped state: %w", err)
+	}
+
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(ctx, stdoutWriter(ctx), map[string]any{
+			"presentationId": presentationID,
+			"slideObjectId":  slideID,
+			"isSkipped":      isSkipped,
+		})
+	}
+
+	u.Out().Linef("slideObjectId\t%s", slideID)
+	u.Out().Linef("presentationId\t%s", presentationID)
+	u.Out().Linef("isSkipped\t%t", isSkipped)
+	return nil
+}
+
+func slidesVisibilityBatchUpdate(slideID string, isSkipped bool) *slides.BatchUpdatePresentationRequest {
+	properties := &slides.SlideProperties{IsSkipped: isSkipped}
+	if !isSkipped {
+		properties.ForceSendFields = []string{"IsSkipped"}
+	}
+
+	return &slides.BatchUpdatePresentationRequest{
+		Requests: []*slides.Request{
+			{
+				UpdateSlideProperties: &slides.UpdateSlidePropertiesRequest{
+					ObjectId:        slideID,
+					SlideProperties: properties,
+					Fields:          "isSkipped",
+				},
+			},
+		},
+	}
+}

--- a/internal/cmd/slides_visibility_test.go
+++ b/internal/cmd/slides_visibility_test.go
@@ -1,0 +1,164 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/slides/v1"
+)
+
+func TestSlidesSkipSlide(t *testing.T) {
+	var captured []*slides.Request
+	srv := mockSlidesBatchUpdateServer(t, &captured, map[string]any{
+		"presentationId": "pres1",
+		"replies":        []any{map[string]any{}},
+	})
+	defer srv.Close()
+
+	var out bytes.Buffer
+	ctx := withSlidesTestService(
+		newCmdRuntimeJSONOutputContext(t, &out, io.Discard),
+		newSlidesServiceFromServer(t, srv),
+	)
+	cmd := &SlidesSkipSlideCmd{PresentationID: "pres1", SlideID: "slide_1"}
+	if err := cmd.Run(ctx, &RootFlags{Account: "a@b.com"}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if len(captured) != 1 || captured[0].UpdateSlideProperties == nil {
+		t.Fatalf("expected one UpdateSlideProperties request, got %+v", captured)
+	}
+	update := captured[0].UpdateSlideProperties
+	if update.ObjectId != "slide_1" || update.Fields != "isSkipped" {
+		t.Fatalf("unexpected update request: %+v", update)
+	}
+	if update.SlideProperties == nil || !update.SlideProperties.IsSkipped {
+		t.Fatalf("expected isSkipped=true, got %+v", update.SlideProperties)
+	}
+
+	var got struct {
+		PresentationID string `json:"presentationId"`
+		SlideObjectID  string `json:"slideObjectId"`
+		IsSkipped      bool   `json:"isSkipped"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("decode output: %v\n%s", err, out.String())
+	}
+	if got.PresentationID != "pres1" || got.SlideObjectID != "slide_1" || !got.IsSkipped {
+		t.Fatalf("unexpected output: %#v", got)
+	}
+}
+
+func TestSlidesUnskipSlideSendsFalse(t *testing.T) {
+	body := slidesVisibilityBatchUpdate("slide_1", false)
+	encoded, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	if !strings.Contains(string(encoded), `"slideProperties":{"isSkipped":false}`) {
+		t.Fatalf("request must explicitly send isSkipped=false: %s", encoded)
+	}
+
+	var captured []*slides.Request
+	srv := mockSlidesBatchUpdateServer(t, &captured, map[string]any{
+		"presentationId": "pres1",
+		"replies":        []any{map[string]any{}},
+	})
+	defer srv.Close()
+
+	var out bytes.Buffer
+	ctx := withSlidesTestService(
+		newCmdRuntimeJSONOutputContext(t, &out, io.Discard),
+		newSlidesServiceFromServer(t, srv),
+	)
+	cmd := &SlidesUnskipSlideCmd{PresentationID: "pres1", SlideID: "slide_1"}
+	if err := cmd.Run(ctx, &RootFlags{Account: "a@b.com"}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(captured) != 1 || captured[0].UpdateSlideProperties == nil {
+		t.Fatalf("expected one UpdateSlideProperties request, got %+v", captured)
+	}
+	if strings.Contains(out.String(), `"isSkipped": true`) || !strings.Contains(out.String(), `"isSkipped": false`) {
+		t.Fatalf("unexpected output: %s", out.String())
+	}
+}
+
+func TestSlidesUnskipSlideDryRunSkipsService(t *testing.T) {
+	var out bytes.Buffer
+	ctx := withSlidesTestServiceFactory(
+		newCmdRuntimeJSONOutputContext(t, &out, io.Discard),
+		func(context.Context, string) (*slides.Service, error) {
+			t.Fatal("slides service should not be created during dry-run")
+			return nil, context.Canceled
+		},
+	)
+
+	cmd := &SlidesUnskipSlideCmd{PresentationID: "pres1", SlideID: "slide_1"}
+	if err := cmd.Run(ctx, &RootFlags{Account: "a@b.com", DryRun: true}); err != nil && ExitCode(err) != 0 {
+		t.Fatalf("Run: %v", err)
+	}
+
+	var got struct {
+		DryRun  bool   `json:"dry_run"`
+		Op      string `json:"op"`
+		Request struct {
+			IsSkipped   bool                                  `json:"is_skipped"`
+			BatchUpdate slides.BatchUpdatePresentationRequest `json:"batch_update"`
+		} `json:"request"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("decode dry-run output: %v\n%s", err, out.String())
+	}
+	if !got.DryRun || got.Op != "slides.unskip-slide" || got.Request.IsSkipped {
+		t.Fatalf("unexpected dry-run output: %#v", got)
+	}
+	if len(got.Request.BatchUpdate.Requests) != 1 || got.Request.BatchUpdate.Requests[0].UpdateSlideProperties == nil {
+		t.Fatalf("expected UpdateSlideProperties dry-run request, got %+v", got.Request.BatchUpdate.Requests)
+	}
+}
+
+func TestSlidesVisibilityValidation(t *testing.T) {
+	ctx := withSlidesTestServiceFactory(
+		newCmdRuntimeOutputContext(t, io.Discard, io.Discard),
+		func(context.Context, string) (*slides.Service, error) {
+			t.Fatal("slides service should not be created")
+			return nil, context.Canceled
+		},
+	)
+
+	tests := []struct {
+		name string
+		run  func() error
+		want string
+	}{
+		{
+			name: "skip empty presentation",
+			run: func() error {
+				return (&SlidesSkipSlideCmd{PresentationID: " ", SlideID: "slide_1"}).Run(ctx, &RootFlags{Account: "a@b.com"})
+			},
+			want: "empty presentationId",
+		},
+		{
+			name: "unskip empty slide",
+			run: func() error {
+				return (&SlidesUnskipSlideCmd{PresentationID: "pres1", SlideID: " "}).Run(ctx, &RootFlags{Account: "a@b.com"})
+			},
+			want: "empty slideId",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.run()
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("expected %q error, got %v", tc.want, err)
+			}
+			if got := ExitCode(err); got != 2 {
+				t.Fatalf("ExitCode = %d, want 2 (err=%v)", got, err)
+			}
+		})
+	}
+}

--- a/internal/config/account_references_test.go
+++ b/internal/config/account_references_test.go
@@ -105,7 +105,7 @@ func TestConfigStoreMigrateAccountEmailReferencesSerializesConcurrentUpdate(t *t
 
 		<-start
 
-		errs <- store.Update(func(cfg *File) error {
+		errs <- NewConfigStore(store.Layout()).Update(func(cfg *File) error {
 			cfg.DefaultTimezone = "UTC"
 			return nil
 		})

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -60,28 +60,34 @@ func (s *ConfigStore) Path() string {
 	return s.layout.ConfigPath()
 }
 
-func (s *ConfigStore) ensureDir() (string, error) {
-	dir := s.layout.ConfigDir
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		return "", fmt.Errorf("ensure config dir: %w", err)
+func (s *ConfigStore) ensureDir() error {
+	if err := os.MkdirAll(s.layout.ConfigDir, 0o700); err != nil {
+		return fmt.Errorf("ensure config dir: %w", err)
 	}
 
-	return dir, nil
+	return nil
 }
 
-func (s *ConfigStore) Write(cfg File) error {
-	if _, err := s.ensureDir(); err != nil {
+func (s *ConfigStore) withLock(fn func() error) error {
+	if err := s.ensureDir(); err != nil {
 		return err
 	}
 
-	return s.lock.WithExclusive(func() error {
+	if err := s.lock.WithExclusive(fn); err != nil {
+		return fmt.Errorf("update config under lock: %w", err)
+	}
+
+	return nil
+}
+
+func (s *ConfigStore) Write(cfg File) error {
+	return s.withLock(func() error {
 		return s.write(cfg)
 	})
 }
 
 func (s *ConfigStore) write(cfg File) error {
-	_, err := s.ensureDir()
-	if err != nil {
+	if err := s.ensureDir(); err != nil {
 		return fmt.Errorf("ensure config dir: %w", err)
 	}
 
@@ -102,11 +108,7 @@ func (s *ConfigStore) write(cfg File) error {
 }
 
 func (s *ConfigStore) Update(update func(*File) error) error {
-	if _, err := s.ensureDir(); err != nil {
-		return err
-	}
-
-	return s.lock.WithExclusive(func() error {
+	return s.withLock(func() error {
 		cfg, err := s.Read()
 		if err != nil {
 			return err

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,13 +2,14 @@ package config
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"time"
 
 	"github.com/yosuke-furukawa/json5/encoding/json5"
+
+	"github.com/openclaw/gogcli/internal/filelock"
 )
 
 type File struct {
@@ -35,14 +36,16 @@ type MCPPolicy struct {
 	AllowWrite bool     `json:"allow_write,omitempty"`
 }
 
-var errConfigLockTimeout = errors.New("acquire config lock timeout")
-
 type ConfigStore struct {
 	layout Layout
+	lock   *filelock.Lock
 }
 
 func NewConfigStore(layout Layout) *ConfigStore {
-	return &ConfigStore{layout: layout}
+	return &ConfigStore{
+		layout: layout,
+		lock:   filelock.Shared(filepath.Join(layout.ConfigDir, "config.lock"), 2*time.Second),
+	}
 }
 
 func (s *ConfigStore) Layout() Layout {
@@ -66,52 +69,14 @@ func (s *ConfigStore) ensureDir() (string, error) {
 	return dir, nil
 }
 
-func (s *ConfigStore) lockPath() (string, error) {
-	dir, err := s.ensureDir()
-	if err != nil {
-		return "", fmt.Errorf("ensure config dir: %w", err)
-	}
-
-	return filepath.Join(dir, "config.lock"), nil
-}
-
-func (s *ConfigStore) acquireLock() (func(), error) {
-	path, err := s.lockPath()
-	if err != nil {
-		return nil, err
-	}
-
-	deadline := time.Now().Add(2 * time.Second)
-
-	for {
-		f, openErr := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600) //nolint:gosec // lock path is computed inside the config dir
-		if openErr == nil {
-			_, _ = fmt.Fprintf(f, "%d\n", os.Getpid())
-			_ = f.Close()
-
-			return func() { _ = os.Remove(path) }, nil
-		}
-
-		if !os.IsExist(openErr) {
-			return nil, fmt.Errorf("acquire config lock: %w", openErr)
-		}
-
-		if time.Now().After(deadline) {
-			return nil, fmt.Errorf("%w: %s", errConfigLockTimeout, path)
-		}
-
-		time.Sleep(10 * time.Millisecond)
-	}
-}
-
 func (s *ConfigStore) Write(cfg File) error {
-	unlock, err := s.acquireLock()
-	if err != nil {
+	if _, err := s.ensureDir(); err != nil {
 		return err
 	}
-	defer unlock()
 
-	return s.write(cfg)
+	return s.lock.WithExclusive(func() error {
+		return s.write(cfg)
+	})
 }
 
 func (s *ConfigStore) write(cfg File) error {
@@ -137,22 +102,22 @@ func (s *ConfigStore) write(cfg File) error {
 }
 
 func (s *ConfigStore) Update(update func(*File) error) error {
-	unlock, err := s.acquireLock()
-	if err != nil {
-		return err
-	}
-	defer unlock()
-
-	cfg, err := s.Read()
-	if err != nil {
+	if _, err := s.ensureDir(); err != nil {
 		return err
 	}
 
-	if err := update(&cfg); err != nil {
-		return err
-	}
+	return s.lock.WithExclusive(func() error {
+		cfg, err := s.Read()
+		if err != nil {
+			return err
+		}
 
-	return s.write(cfg)
+		if err := update(&cfg); err != nil {
+			return err
+		}
+
+		return s.write(cfg)
+	})
 }
 
 // WriteFileAtomic writes data to path via a same-directory temp file and rename.


### PR DESCRIPTION
## Summary

- add `gog slides skip-slide` and `gog slides unskip-slide`
- add `hide-slide` and `unhide-slide` aliases for familiar terminology
- expose each slide's `isSkipped` state in `slides list-slides`
- regenerate command reference pages and the Slides agent skill

The commands use `updateSlideProperties` with an `isSkipped` field mask. Unskipping explicitly serializes `isSkipped: false` rather than allowing Go's zero-value omission to drop it.

## Testing

- `make SHELL="$(command -v bash)" ci`
- focused request, JSON output, validation, and dry-run tests
- live Google Slides verification shown below

### Live Google Slides verification

Run from reviewed head `b6635a5d5ca406984eb60707b8252b7640059fdb` against a temporary three-slide Google Slides presentation created with the CLI. Presentation and slide IDs were redacted after capture; the temporary presentation was moved to Drive trash afterwards.

```console
$ gog slides list-slides <presentation-id> --json
{
  "presentationId": "<presentation-id>",
  "slideCount": 3,
  "slides": [
    {"isSkipped": false, "number": 1, "objectId": "<slide-1-id>"},
    {"isSkipped": false, "number": 2, "objectId": "<target-slide-id>"},
    {"isSkipped": false, "number": 3, "objectId": "<slide-3-id>"}
  ],
  "title": "gogcli PR 1009 live verification"
}

$ gog slides skip-slide <presentation-id> <target-slide-id> --json
{
  "isSkipped": true,
  "presentationId": "<presentation-id>",
  "slideObjectId": "<target-slide-id>"
}

$ gog slides list-slides <presentation-id> --json
{
  "presentationId": "<presentation-id>",
  "slideCount": 3,
  "slides": [
    {"isSkipped": false, "number": 1, "objectId": "<slide-1-id>"},
    {"isSkipped": true,  "number": 2, "objectId": "<target-slide-id>"},
    {"isSkipped": false, "number": 3, "objectId": "<slide-3-id>"}
  ],
  "title": "gogcli PR 1009 live verification"
}

$ gog slides unskip-slide <presentation-id> <target-slide-id> --json
{
  "isSkipped": false,
  "presentationId": "<presentation-id>",
  "slideObjectId": "<target-slide-id>"
}

$ gog slides list-slides <presentation-id> --json
{
  "presentationId": "<presentation-id>",
  "slideCount": 3,
  "slides": [
    {"isSkipped": false, "number": 1, "objectId": "<slide-1-id>"},
    {"isSkipped": false, "number": 2, "objectId": "<target-slide-id>"},
    {"isSkipped": false, "number": 3, "objectId": "<slide-3-id>"}
  ],
  "title": "gogcli PR 1009 live verification"
}
```

Assertions performed on the captured JSON:

- after `skip-slide`, exactly the target slide changed to `isSkipped: true`
- both neighbouring slides remained `isSkipped: false`
- after `unskip-slide`, the target returned to `isSkipped: false`
- the final slide array exactly matched the initial slide array

## User-facing changes

`slides list-slides` adds a `SKIPPED` column to text output and an additive `isSkipped` field to each JSON slide record.