### PR TITLE
fix(ci): restrict workflow token permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Security: restrict the CI workflow's `GITHUB_TOKEN` to read-only repository contents instead of inheriting broader organization or repository defaults.
 - Security: bound `gmail watch serve` and the local OAuth callback HTTP servers with read, idle, and header-size limits so a slow or oversized request cannot stall the listener.
 
 ## v0.37.0 - 2026-08-14


### PR DESCRIPTION
## Summary

- restrict the CI workflow token to `contents: read`
- keep the permission at workflow scope so all four local jobs inherit one least-privilege contract
- document the security hardening in Unreleased

## Root cause

`.github/workflows/ci.yml` defined no workflow- or job-level permissions, so every job inherited the repository or organization `GITHUB_TOKEN` default. CodeQL 2.26.3 therefore reported all four jobs under `actions/missing-workflow-permissions`.

The workflow only checks out source, restores caches, and runs local build/test commands. No job needs a write-capable repository token. A workflow-level read-only permission is the canonical owner-boundary fix; repeating the same block in four jobs would duplicate policy.

## CodeQL

Fixes:

- https://github.com/openclaw/gogcli/security/code-scanning/1
- https://github.com/openclaw/gogcli/security/code-scanning/2
- https://github.com/openclaw/gogcli/security/code-scanning/3
- https://github.com/openclaw/gogcli/security/code-scanning/4

Source analysis: https://github.com/openclaw/gogcli/actions/runs/32474288910

## Validation

- `actionlint .github/workflows/ci.yml`
- `git diff --check`

Production LOC: +3/-0 | Tests: +0/-0
