### PR TITLE
fix(docs): harden HTML tag stripping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Security: remove overflow-prone capacity arithmetic from untrusted-output maps and versioned tracking ciphertext construction while preserving their wire formats.
 - Security: restrict the CI workflow's `GITHUB_TOKEN` to read-only repository contents instead of inheriting broader organization or repository defaults.
 - Security: generate live agent-evaluation session IDs with cryptographically random suffixes while preserving their fixed-width format.
+- Security: replace docs heading and table-of-contents HTML sanitization regexes with one shared single-pass tag scanner so removed markup cannot reconstruct unsafe tags.
 - Security: bound `gmail watch serve` and the local OAuth callback HTTP servers with read, idle, and header-size limits so a slow or oversized request cannot stall the listener.
 
 ## v0.37.0 - 2026-08-14

--- a/scripts/build-docs-site.mjs
+++ b/scripts/build-docs-site.mjs
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { css, faviconSvg, js, preThemeScript, themeToggleHtml } from "./docs-site-assets.mjs";
+import { stripHtmlTags } from "./html-text.mjs";
 
 const root = process.cwd();
 const docsDir = path.join(root, "docs");
@@ -412,10 +413,7 @@ function tocFromHtml(html) {
   const re = /<h([23]) id="([^"]+)">([\s\S]*?)<\/h[23]>/g;
   let m;
   while ((m = re.exec(html))) {
-    const text = m[3]
-      .replace(/<a class="anchor"[^>]*>.*?<\/a>/, "")
-      .replace(/<[^>]+>/g, "")
-      .trim();
+    const text = stripHtmlTags(m[3]).replace(/^#/, "").trim();
     items.push({ level: Number(m[1]), id: m[2], text });
   }
   if (items.length < 2) return "";

--- a/scripts/check-docs-coverage.mjs
+++ b/scripts/check-docs-coverage.mjs
@@ -4,6 +4,8 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { stripHtmlTags } from "./html-text.mjs";
+
 const root = process.cwd();
 const bin = process.env.GOG_BIN || path.join(root, "bin", "gog");
 const docsDir = path.join(root, "docs");
@@ -215,8 +217,7 @@ export function headingAnchors(markdown) {
 }
 
 function slugifyHeading(text) {
-  return text
-    .replace(/<[^>]*>/g, "")
+  return stripHtmlTags(text)
     .replace(/`/g, "")
     .toLowerCase()
     .replace(/[^\p{L}\p{M}\p{N}\p{Pc}\- ]/gu, "")

--- a/scripts/check-docs-coverage.test.mjs
+++ b/scripts/check-docs-coverage.test.mjs
@@ -16,6 +16,7 @@ test("stripHtmlTags removes nested and unterminated markup in one pass", () => {
   assert.equal(stripHtmlTags("Heading <strong"), "Heading ");
   assert.equal(stripHtmlTags('<span title="1 > 0">Heading</span>'), "Heading");
   assert.equal(stripHtmlTags("1 < 2"), "1 < 2");
+  assert.equal(stripHtmlTags("<<<script>img>"), "img>");
 });
 
 test("headingAnchors ignores headings inside fenced code blocks", () => {

--- a/scripts/check-docs-coverage.test.mjs
+++ b/scripts/check-docs-coverage.test.mjs
@@ -5,6 +5,18 @@ import path from "node:path";
 import test from "node:test";
 
 import { checkMarkdownLinks, headingAnchors } from "./check-docs-coverage.mjs";
+import { stripHtmlTags } from "./html-text.mjs";
+
+test("stripHtmlTags removes nested and unterminated markup in one pass", () => {
+  assert.equal(
+    stripHtmlTags('<a class="anchor" href="#heading">#</a><em>Heading</em>'),
+    "#Heading",
+  );
+  assert.equal(stripHtmlTags("<strong>broken"), "broken");
+  assert.equal(stripHtmlTags("Heading <strong"), "Heading ");
+  assert.equal(stripHtmlTags('<span title="1 > 0">Heading</span>'), "Heading");
+  assert.equal(stripHtmlTags("1 < 2"), "1 < 2");
+});
 
 test("headingAnchors ignores headings inside fenced code blocks", () => {
   const anchors = headingAnchors(`# Real Heading
@@ -34,6 +46,7 @@ test("headingAnchors follows GitHub-style heading slugs", () => {
 ## foo
 ## foo
 ## foo-1
+## <em>HTML Heading</em>
 ## Heading ##
 `);
 
@@ -44,6 +57,7 @@ test("headingAnchors follows GitHub-style heading slugs", () => {
     "foo",
     "foo-1",
     "foo-1-1",
+    "html-heading",
     "heading",
   ]);
 });

--- a/scripts/html-text.mjs
+++ b/scripts/html-text.mjs
@@ -4,7 +4,7 @@ function startsHtmlTag(value, index) {
 }
 
 export function stripHtmlTags(value) {
-  let text = "";
+  const text = [];
   let insideTag = false;
   let quote = "";
 
@@ -12,9 +12,10 @@ export function stripHtmlTags(value) {
     const character = value[index];
     if (!insideTag) {
       if (character === "<" && startsHtmlTag(value, index)) {
+        while (text.at(-1) === "<") text.pop();
         insideTag = true;
       } else {
-        text += character;
+        text.push(character);
       }
       continue;
     }
@@ -26,5 +27,5 @@ export function stripHtmlTags(value) {
       insideTag = false;
     }
   }
-  return text;
+  return text.join("");
 }

--- a/scripts/html-text.mjs
+++ b/scripts/html-text.mjs
@@ -1,0 +1,30 @@
+function startsHtmlTag(value, index) {
+  const next = value[index + 1]?.toLowerCase();
+  return next === "/" || next === "!" || next === "?" || (next >= "a" && next <= "z");
+}
+
+export function stripHtmlTags(value) {
+  let text = "";
+  let insideTag = false;
+  let quote = "";
+
+  for (let index = 0; index < value.length; index += 1) {
+    const character = value[index];
+    if (!insideTag) {
+      if (character === "<" && startsHtmlTag(value, index)) {
+        insideTag = true;
+      } else {
+        text += character;
+      }
+      continue;
+    }
+    if (quote) {
+      if (character === quote) quote = "";
+    } else if (character === '"' || character === "'") {
+      quote = character;
+    } else if (character === ">") {
+      insideTag = false;
+    }
+  }
+  return text;
+}


### PR DESCRIPTION
## Summary

- replace two one-shot HTML-tag-removal regexes with one shared single-pass tag scanner
- preserve literal less-than text while removing complete, unclosed, and unterminated tag-like markup
- keep docs heading anchors and generated table-of-contents text on the same cleanup boundary
- document the security hardening in Unreleased

## Root cause

Both docs scripts removed multi-character HTML tag matches once. CodeQL 2.26.3 correctly treats that pattern as incomplete sanitization because removal can expose another dangerous tag sequence.

`scripts/html-text.mjs` now owns tag removal with a single-pass scanner instead of a replacement regex. It tracks quoted attributes, removes genuinely unterminated tag fragments, prevents discarded tags from rebuilding markup across adjacent `<` boundaries, and preserves ordinary text such as `1 < 2`. Both heading-anchor validation and generated TOC text use that owner, so the invariant cannot drift between the checker and renderer.

## CodeQL

Fixes:

- https://github.com/openclaw/gogcli/security/code-scanning/5
- https://github.com/openclaw/gogcli/security/code-scanning/6

## Validation

- `node --test scripts/check-docs-coverage.test.mjs`
- `node scripts/build-docs-site.mjs`
- rendered TOC probe across `dist/docs-site`
- `make fmt`
- `git diff origin/main...HEAD --check`
- privacy scrub of the complete PR diff

Production scripts: +36/-6 (net +30, shared security invariant with explicit malformed-input and reconstruction handling) | Tests: +15/-0 | Changelog: +1/-0
