### PR TITLE
fix(evals): use secure session identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Security: remove overflow-prone capacity arithmetic from untrusted-output maps and versioned tracking ciphertext construction while preserving their wire formats.
 - Security: restrict the CI workflow's `GITHUB_TOKEN` to read-only repository contents instead of inheriting broader organization or repository defaults.
+- Security: generate live agent-evaluation session IDs with cryptographically random suffixes while preserving their fixed-width format.
 - Security: bound `gmail watch serve` and the local OAuth callback HTTP servers with read, idle, and header-size limits so a slow or oversized request cannot stall the listener.
 
 ## v0.37.0 - 2026-08-14

--- a/scripts/eval-gws-agents.mjs
+++ b/scripts/eval-gws-agents.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { spawn } from "node:child_process";
+import { randomBytes } from "node:crypto";
 import { constants as fsConstants } from "node:fs";
 import { access, chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import net from "node:net";
@@ -554,12 +555,16 @@ export function agentEnvironment(environment, binDirectory) {
   return safe;
 }
 
+export function buildEvalSessionId(cli, now = Date.now(), randomBytesFn = randomBytes) {
+  return `gog-eval-${cli}-${now}-${randomBytesFn(4).toString("hex")}`;
+}
+
 async function runAgent(agent, cli, repetition, fixtures, options, environment) {
   const proxy = await startCliProxy(cli, options, environment);
   const runDirectory = await createRunDirectory(options, proxy.socketPath);
   const prompt = buildPrompt(options.driveName, runDirectory.wrapper);
   const env = agentEnvironment(environment, runDirectory.binDirectory);
-  const sessionId = `gog-eval-${cli}-${Date.now()}-${Math.random().toString(16).slice(2, 10)}`;
+  const sessionId = buildEvalSessionId(cli);
   const command = agent === "codex" ? "codex" : "openclaw";
   const args = agent === "codex"
     ? [

--- a/scripts/eval-gws-agents.test.mjs
+++ b/scripts/eval-gws-agents.test.mjs
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   agentEnvironment,
   allowedAgentArgs,
+  buildEvalSessionId,
   buildPrompt,
   compareAggregates,
   extractJson,
@@ -12,6 +13,19 @@ import {
   parseArgs,
   scoreAnswers,
 } from "./eval-gws-agents.mjs";
+
+test("buildEvalSessionId preserves the historical fixed-width session format", () => {
+  const sessionId = buildEvalSessionId(
+    "gog",
+    1_700_000_000_000,
+    (size) => {
+      assert.equal(size, 4);
+      return Buffer.from("01234567", "hex");
+    },
+  );
+  assert.equal(sessionId, "gog-eval-gog-1700000000000-01234567");
+  assert.match(sessionId, /^gog-eval-gog-\d+-[0-9a-f]{8}$/);
+});
 
 test("parseCodex counts legacy and current tool item types", () => {
   const events = [


### PR DESCRIPTION
## Summary

- replace the predictable `Math.random()` suffix with four cryptographic random bytes
- preserve the existing `gog-eval-<cli>-<timestamp>-<8 lowercase hex>` session ID shape
- cover the exact fixed-width format and random-byte count
- document the security hardening in Unreleased

## Root cause

The live eval harness used `Math.random()` in an OpenClaw session identifier. That identifier selects session state, so predictability crosses a security boundary even though the harness itself is an evaluation tool.

Four bytes from Node's built-in `crypto.randomBytes()` remove the weak generator without adding a dependency. Encoding those bytes as lowercase hex preserves the historical eight-character suffix, so existing OpenClaw session filenames and explicit `--session-id` handling keep the same shape instead of changing to a UUID.

## Compatibility proof

OpenClaw accepts explicit session IDs as trimmed non-empty strings, uses exact string equality for stored-session lookup, and embeds the supplied value into its synthetic explicit-session key. It does not require a UUID or impose a fixed length:

- https://github.com/openclaw/openclaw/blob/e66d7c5cac65fa9391904648eb81861276bc5725/src/agents/command/session.ts#L123-L129
- https://github.com/openclaw/openclaw/blob/e66d7c5cac65fa9391904648eb81861276bc5725/src/agents/command/session.ts#L198-L214
- https://github.com/openclaw/openclaw/blob/e66d7c5cac65fa9391904648eb81861276bc5725/src/agents/command/session.ts#L313-L318

The focused test also proves that the generated ID retains the historical `gog-eval-gog-1700000000000-01234567` shape while sourcing all eight suffix characters from four cryptographic bytes.

## CodeQL

Fixes:

- https://github.com/openclaw/gogcli/security/code-scanning/7

## Validation

- `node --test scripts/eval-gws-agents.test.mjs`
- `make fmt`
- `git diff origin/main...HEAD --check`
- privacy scrub of the complete PR diff

Production LOC: +6/-1 (net +5, security invariant and testable owner boundary) | Tests: +14/-0
