### PR TITLE
fix(security): remove overflow-prone allocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Security: remove overflow-prone capacity arithmetic from untrusted-output maps and versioned tracking ciphertext construction while preserving their wire formats.
 - Security: restrict the CI workflow's `GITHUB_TOKEN` to read-only repository contents instead of inheriting broader organization or repository defaults.
 - Security: bound `gmail watch serve` and the local OAuth callback HTTP servers with read, idle, and header-size limits so a slow or oversized request cannot stall the listener.
 

--- a/internal/outfmt/untrusted.go
+++ b/internal/outfmt/untrusted.go
@@ -168,7 +168,7 @@ func genericJSONValue(v any) (any, error) {
 func wrapUntrustedGenericValue(v any, opts UntrustedWrapOptions, path []string, key string) (any, bool) {
 	switch vv := v.(type) {
 	case map[string]any:
-		out := make(map[string]any, len(vv)+1)
+		out := make(map[string]any, len(vv))
 		wrappedAny := false
 
 		for k, value := range vv {

--- a/internal/tracking/crypto.go
+++ b/internal/tracking/crypto.go
@@ -70,9 +70,7 @@ func encryptPayload(payload *PixelPayload, keyBase64 string, version byte) (stri
 
 	prefix := nonce
 	if version > 0 {
-		prefix = make([]byte, 0, 1+len(nonce)+len(plaintext)+aead.Overhead())
-		prefix = append(prefix, version)
-		prefix = append(prefix, nonce...)
+		prefix = append([]byte{version}, nonce...)
 	}
 
 	ciphertext := aead.Seal(prefix, nonce, plaintext, nil)


### PR DESCRIPTION
## Summary

- remove `len(map)+1` capacity arithmetic from untrusted JSON wrapping
- construct the fixed version/nonce prefix before passing dynamic output sizing to `cipher.AEAD.Seal`
- preserve JSON metadata and versioned tracking ciphertext formats

## Root cause

Two capacity hints combined potentially large input lengths before allocation:

- `make(map[string]any, len(vv)+1)` could overflow the map capacity
- the versioned tracking ciphertext preallocation summed the nonce, plaintext, and GCM overhead in one `int`

Neither optimization is required for correctness. The map can grow once when metadata is needed, and Go's `cipher.AEAD.Seal` owns authenticated-cipher output sizing and enforces its message limit. Removing the duplicate arithmetic is smaller and safer than adding local overflow helpers.

## CodeQL

Fixes:

- https://github.com/openclaw/gogcli/security/code-scanning/8
- https://github.com/openclaw/gogcli/security/code-scanning/9

Source analysis: https://github.com/openclaw/gogcli/actions/runs/32474288910

## Validation

- `go test ./internal/outfmt ./internal/tracking`
- focused untrusted JSON and versioned/legacy ciphertext tests
- `gofmt -d internal/outfmt/untrusted.go internal/tracking/crypto.go`
- `git diff --check`

Production LOC: +2/-4 (net -2) | Tests: +0/-0
