### PR TITLE
fix(calendar): clear reminder overrides when restoring defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Calendar: correctly clear custom reminder overrides when restoring calendar defaults. (#1016) — thanks @sorenisanerd.
 - Security: remove overflow-prone capacity arithmetic from untrusted-output maps and versioned tracking ciphertext construction while preserving their wire formats.
 - Security: restrict the CI workflow's `GITHUB_TOKEN` to read-only repository contents instead of inheriting broader organization or repository defaults.
 - Security: generate live agent-evaluation session IDs with cryptographically random suffixes while preserving their fixed-width format.

--- a/internal/cmd/calendar_edit_test.go
+++ b/internal/cmd/calendar_edit_test.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"encoding/json"
 	"io"
-	"strings"
 	"testing"
 
 	"github.com/alecthomas/kong"
@@ -74,29 +73,15 @@ func TestCalendarUpdatePatchClearsReminders(t *testing.T) {
 		t.Fatal("expected patch")
 		return
 	}
-	// Clearing reminders restores calendar defaults and explicitly nulls the
-	// existing override array so PATCH does not retain it.
-	if patch.Reminders == nil {
-		t.Fatalf("expected reminders set, got nil")
-	}
-	if !patch.Reminders.UseDefault {
-		t.Fatalf("expected reminders.UseDefault=true, got false")
-	}
-	if !hasForceSendField(patch.Reminders.NullFields, "Overrides") {
-		t.Fatalf("expected Overrides in NullFields, got %#v", patch.Reminders.NullFields)
-	}
-	if !hasForceSendField(patch.Reminders.ForceSendFields, "UseDefault") {
-		t.Fatalf("expected UseDefault in ForceSendFields, got %#v", patch.Reminders.ForceSendFields)
+	if patch.Reminders == nil || !patch.Reminders.UseDefault {
+		t.Fatalf("expected reminders.UseDefault=true, got %#v", patch.Reminders)
 	}
 	encoded, err := json.Marshal(patch.Reminders)
 	if err != nil {
-		t.Fatalf("marshal reminders: %v", err)
+		t.Fatalf("marshal reminder patch: %v", err)
 	}
-	if !strings.Contains(string(encoded), `"overrides":null`) {
-		t.Fatalf("expected serialized overrides:null, got %s", encoded)
-	}
-	if !strings.Contains(string(encoded), `"useDefault":true`) {
-		t.Fatalf("expected serialized useDefault:true, got %s", encoded)
+	if string(encoded) != `{"overrides":null,"useDefault":true}` {
+		t.Fatalf("restore-default reminder payload = %s", encoded)
 	}
 	if !hasForceSendField(patch.ForceSendFields, "Reminders") {
 		t.Fatalf("expected Reminders in ForceSendFields")

--- a/internal/cmd/calendar_edit_test.go
+++ b/internal/cmd/calendar_edit_test.go
@@ -1,7 +1,9 @@
 package cmd
 
 import (
+	"encoding/json"
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/alecthomas/kong"
@@ -72,8 +74,29 @@ func TestCalendarUpdatePatchClearsReminders(t *testing.T) {
 		t.Fatal("expected patch")
 		return
 	}
-	if patch.Reminders == nil || !patch.Reminders.UseDefault {
-		t.Fatalf("expected reminders.UseDefault=true, got %#v", patch.Reminders)
+	// Clearing reminders restores calendar defaults and explicitly nulls the
+	// existing override array so PATCH does not retain it.
+	if patch.Reminders == nil {
+		t.Fatalf("expected reminders set, got nil")
+	}
+	if !patch.Reminders.UseDefault {
+		t.Fatalf("expected reminders.UseDefault=true, got false")
+	}
+	if !hasForceSendField(patch.Reminders.NullFields, "Overrides") {
+		t.Fatalf("expected Overrides in NullFields, got %#v", patch.Reminders.NullFields)
+	}
+	if !hasForceSendField(patch.Reminders.ForceSendFields, "UseDefault") {
+		t.Fatalf("expected UseDefault in ForceSendFields, got %#v", patch.Reminders.ForceSendFields)
+	}
+	encoded, err := json.Marshal(patch.Reminders)
+	if err != nil {
+		t.Fatalf("marshal reminders: %v", err)
+	}
+	if !strings.Contains(string(encoded), `"overrides":null`) {
+		t.Fatalf("expected serialized overrides:null, got %s", encoded)
+	}
+	if !strings.Contains(string(encoded), `"useDefault":true`) {
+		t.Fatalf("expected serialized useDefault:true, got %s", encoded)
 	}
 	if !hasForceSendField(patch.ForceSendFields, "Reminders") {
 		t.Fatalf("expected Reminders in ForceSendFields")

--- a/internal/cmd/calendar_update_patch_plan.go
+++ b/internal/cmd/calendar_update_patch_plan.go
@@ -264,7 +264,15 @@ func applyUpdateReminders(input calendarUpdateInput, fields calendarUpdateFields
 		return false, err
 	}
 	if reminders == nil {
-		patch.Reminders = &calendar.EventReminders{UseDefault: true}
+		// "Set empty to clear" restores the calendar's default reminders.
+		// A PATCH with only useDefault:true retains existing overrides, which the
+		// Calendar API rejects because overrides cannot coexist with useDefault.
+		// Explicitly nulling Overrides removes the stored overrides instead.
+		patch.Reminders = &calendar.EventReminders{
+			UseDefault:      true,
+			NullFields:      []string{"Overrides"},
+			ForceSendFields: []string{"UseDefault"},
+		}
 		patch.ForceSendFields = append(patch.ForceSendFields, "Reminders")
 	} else {
 		patch.Reminders = reminders

--- a/internal/cmd/calendar_update_patch_plan.go
+++ b/internal/cmd/calendar_update_patch_plan.go
@@ -264,14 +264,10 @@ func applyUpdateReminders(input calendarUpdateInput, fields calendarUpdateFields
 		return false, err
 	}
 	if reminders == nil {
-		// "Set empty to clear" restores the calendar's default reminders.
-		// A PATCH with only useDefault:true retains existing overrides, which the
-		// Calendar API rejects because overrides cannot coexist with useDefault.
-		// Explicitly nulling Overrides removes the stored overrides instead.
+		// PATCH merges omitted fields, so remove old overrides before restoring defaults.
 		patch.Reminders = &calendar.EventReminders{
-			UseDefault:      true,
-			NullFields:      []string{"Overrides"},
-			ForceSendFields: []string{"UseDefault"},
+			UseDefault: true,
+			NullFields: []string{"Overrides"},
 		}
 		patch.ForceSendFields = append(patch.ForceSendFields, "Reminders")
 	} else {


### PR DESCRIPTION
## Summary
- Clear stored reminder overrides when `calendar update --reminder ""` restores calendar defaults.
- Send `overrides: null` together with `useDefault: true` so Calendar PATCH does not retain incompatible overrides.
- Add regression coverage for the serialized reminders payload.
- Fixes the `cannotUseDefaultRemindersAndSpecifyOverride` error when clearing custom reminders.

## Validation
- `make ci`

Live verification evidence:

```
$ CALENDAR='sorenisanerd@gmail.com'
$ SUMMARY='gog PR 1016 reminder regression test'
$ START=$(date -u -d 'tomorrow 20:00' +%Y-%m-%dT%H:%M:%SZ)
$ END=$(date -u -d 'tomorrow 20:15' +%Y-%m-%dT%H:%M:%SZ)
$ bin/gog calendar create "$CALENDAR" \
  --summary "$SUMMARY" --from "$START" --to "$END" \
  --reminder popup:30m --visibility private --transparency transparent \
  --send-updates none --account sorenisanerd@gmail.com \
  --json --results-only
{
  "created": "<TIMESTAMP>",
  "creator": {
    "email": "<ACCOUNT_AND_CALENDAR_ID>",
    "self": true
  },
  "end": {
    "dateTime": "<TIMESTAMP>",
    "timeZone": "UTC"
  },
  "etag": "\"3575059607799518\"",
  "eventType": "default",
  "iCalUID": "<EVENT_ID>@google.com",
  "id": "<EVENT_ID>",
  "kind": "calendar#event",
  "organizer": {
    "email": "<ACCOUNT_AND_CALENDAR_ID>",
    "self": true
  },
  "reminders": {
    "overrides": [
      {
        "method": "popup",
        "minutes": 30
      }
    ]
  },
  "start": {
    "dateTime": "<TIMESTAMP>",
    "timeZone": "UTC"
  },
  "status": "confirmed",
  "summary": "<TEST_EVENT_SUMMARY>",
  "transparency": "transparent",
  "updated": "<TIMESTAMP>",
  "visibility": "private"
}
$ bin/gog calendar raw "$CALENDAR" "$EVENT_ID" \
  --account sorenisanerd@gmail.com
{
  "reminders": {
    "overrides": [
      {
        "method": "popup",
        "minutes": 30
      }
    ]
  },
  "status": "confirmed"
}
$ bin/gog calendar update "$CALENDAR" "$EVENT_ID" \
  --reminder '' --account sorenisanerd@gmail.com \
  --json --results-only
{
  "created": "<TIMESTAMP>",
  "etag": "\"3575059619791742\"",
  "id": "<EVENT_ID>",
  "reminders": {
    "useDefault": true
  },
  "status": "confirmed",
  "summary": "<TEST_EVENT_SUMMARY>",
  "updated": "<TIMESTAMP>"
}
$ bin/gog calendar raw "$CALENDAR" "$EVENT_ID" \
  --account sorenisanerd@gmail.com
{
  "reminders": {
    "useDefault": true
  },
  "status": "confirmed"
}
```