### PR TITLE
fix(auth): stop warning about optional missing config.json in doctor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Security: restrict the CI workflow's `GITHUB_TOKEN` to read-only repository contents instead of inheriting broader organization or repository defaults.
 - Security: generate live agent-evaluation session IDs with cryptographically random suffixes while preserving their fixed-width format.
 - Security: replace docs heading and table-of-contents HTML sanitization regexes with one shared single-pass tag scanner so removed markup cannot reconstruct unsafe tags.
+- Auth: treat missing `config.json` as optional while diagnosing missing OAuth client credentials with client-specific repair commands. (#1015, #1017) — thanks @coeur-de-loup.
 - Security: bound `gmail watch serve` and the local OAuth callback HTTP servers with read, idle, and header-size limits so a slow or oversized request cannot stall the listener.
 
 ## v0.37.0 - 2026-08-14

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -151,7 +151,7 @@ Scope selection note:
 
 - Base config dir: `$(os.UserConfigDir())/gogcli/`
 - Files:
-  - `config.json` (JSON5; comments and trailing commas allowed)
+  - `config.json` (optional preferences; JSON5; comments and trailing commas allowed)
   - `credentials.json` (OAuth client id/secret; default client)
   - `credentials-<client>.json` (OAuth client id/secret; named clients)
 - State:
@@ -201,7 +201,7 @@ Flag aliases:
 - `gog auth manage [--services ...] [--listen-addr HOST[:PORT]] [--redirect-host HOST] [--dry-run]` (interactive browser flow; real execution fails with usage exit code 2 under `--no-input`)
 - `gog auth keep <email> --key <service-account.json>` (Google Keep; Workspace only)
 - `gog auth list`
-- `gog auth doctor [--check]` (diagnose keyring/password drift and refresh-token failures)
+- `gog auth doctor [--check]` (diagnose missing OAuth client credentials, keyring/password drift, and refresh-token failures)
 - `gog auth alias list`
 - `gog auth alias set <alias> <email>`
 - `gog auth alias unset <alias>`

--- a/internal/cmd/auth_cmd_test.go
+++ b/internal/cmd/auth_cmd_test.go
@@ -489,6 +489,39 @@ func TestAuthDoctor_JSON_ReportsForcedKeychainTrust(t *testing.T) {
 	t.Fatalf("missing keychain.trust check: %#v", payload.Checks)
 }
 
+func TestAuthDoctor_JSON_MissingConfigPathIsOptional(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	runtime := runtimeWithAuthStore(newMemSecretsStore())
+	result := executeWithTestRuntime(t, []string{"--json", "auth", "doctor"}, runtime)
+	if result.err != nil {
+		t.Fatalf("Execute: %v", result.err)
+	}
+
+	var payload struct {
+		Status string `json:"status"`
+		Checks []struct {
+			Name   string `json:"name"`
+			Status string `json:"status"`
+			Detail string `json:"detail"`
+			Hint   string `json:"hint"`
+		} `json:"checks"`
+	}
+	if err := json.Unmarshal([]byte(result.stdout), &payload); err != nil {
+		t.Fatalf("json parse: %v\nout=%q", err, result.stdout)
+	}
+	for _, check := range payload.Checks {
+		if check.Name == "config.path" {
+			if check.Status != "ok" || !strings.Contains(check.Detail, "optional") || check.Hint != "" {
+				t.Fatalf("config.path check = %#v, want ok with optional detail and no hint", check)
+			}
+			return
+		}
+	}
+	t.Fatalf("missing config.path check: %#v", payload.Checks)
+}
+
 func TestAuthList_JSON_ReportsUnreadableToken(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())

--- a/internal/cmd/auth_cmd_test.go
+++ b/internal/cmd/auth_cmd_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/openclaw/gogcli/internal/app"
 	"github.com/openclaw/gogcli/internal/config"
+	"github.com/openclaw/gogcli/internal/oauthclient"
 	"github.com/openclaw/gogcli/internal/secrets"
 )
 
@@ -489,37 +490,131 @@ func TestAuthDoctor_JSON_ReportsForcedKeychainTrust(t *testing.T) {
 	t.Fatalf("missing keychain.trust check: %#v", payload.Checks)
 }
 
-func TestAuthDoctor_JSON_MissingConfigPathIsOptional(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
-
-	runtime := runtimeWithAuthStore(newMemSecretsStore())
-	result := executeWithTestRuntime(t, []string{"--json", "auth", "doctor"}, runtime)
-	if result.err != nil {
-		t.Fatalf("Execute: %v", result.err)
+func TestAuthDoctor_JSON_MissingOptionalConfigIsHealthy(t *testing.T) {
+	t.Setenv("GOG_HOME", t.TempDir())
+	t.Setenv("GOG_KEYRING_BACKEND", "keychain")
+	layout, err := config.NewSystemResolver("").Resolve(config.PathKindConfig, config.PathKindData)
+	if err != nil {
+		t.Fatalf("resolve config layout: %v", err)
 	}
-
+	store := newMemSecretsStore()
+	credentials, err := oauthclient.NewCredentialsStore(config.NewClientCredentialsStore(layout), store)
+	if err != nil {
+		t.Fatalf("create OAuth credentials store: %v", err)
+	}
+	if err := credentials.Write(config.DefaultClientName, config.ClientCredentials{
+		ClientID:     "test-client.apps.googleusercontent.com",
+		ClientSecret: "fixture-client-secret",
+	}, false); err != nil {
+		t.Fatalf("write OAuth credentials: %v", err)
+	}
+	if err := store.SetToken(config.DefaultClientName, "user@example.com", secrets.Token{RefreshToken: "fixture-token"}); err != nil {
+		t.Fatalf("store fixture token: %v", err)
+	}
+	result := executeWithTestRuntime(t, []string{"--json", "auth", "doctor"}, runtimeWithAuthStore(store))
+	if result.err != nil {
+		t.Fatalf("auth doctor: %v", result.err)
+	}
 	var payload struct {
-		Status string `json:"status"`
-		Checks []struct {
-			Name   string `json:"name"`
-			Status string `json:"status"`
-			Detail string `json:"detail"`
-			Hint   string `json:"hint"`
-		} `json:"checks"`
+		Status string            `json:"status"`
+		Checks []authDoctorCheck `json:"checks"`
 	}
 	if err := json.Unmarshal([]byte(result.stdout), &payload); err != nil {
-		t.Fatalf("json parse: %v\nout=%q", err, result.stdout)
+		t.Fatalf("decode auth doctor output: %v", err)
 	}
+	if payload.Status != doctorOK {
+		t.Fatalf("status = %q, checks = %#v", payload.Status, payload.Checks)
+	}
+	foundConfig, foundCredentials := false, false
 	for _, check := range payload.Checks {
-		if check.Name == "config.path" {
-			if check.Status != "ok" || !strings.Contains(check.Detail, "optional") || check.Hint != "" {
-				t.Fatalf("config.path check = %#v, want ok with optional detail and no hint", check)
+		switch check.Name {
+		case "config.path":
+			if check.Status != doctorOK || check.Hint != "" || !strings.Contains(check.Detail, "optional") {
+				t.Fatalf("optional config check = %#v", check)
 			}
-			return
+			foundConfig = true
+		case "credentials.default":
+			if check.Status != doctorOK || check.Hint != "" {
+				t.Fatalf("OAuth credentials check = %#v", check)
+			}
+			foundCredentials = true
 		}
 	}
-	t.Fatalf("missing config.path check: %#v", payload.Checks)
+	if !foundConfig || !foundCredentials {
+		t.Fatalf("missing config or OAuth credentials check: %#v", payload.Checks)
+	}
+	if strings.Contains(result.stdout, "fixture-client-secret") {
+		t.Fatal("auth doctor exposed the OAuth client secret")
+	}
+}
+
+func TestAuthDoctor_JSON_ReportsUnusableOAuthCredentials(t *testing.T) {
+	for _, test := range []struct {
+		name          string
+		client        string
+		writeMetadata bool
+		secondToken   bool
+		wantHint      string
+	}{
+		{name: "missing client metadata", wantHint: "gog auth credentials <credentials.json>"},
+		{name: "missing keyring secret", writeMetadata: true, wantHint: "gog auth credentials <credentials.json>"},
+		{name: "named client with multiple accounts", client: "work", secondToken: true, wantHint: "gog --client work auth credentials <credentials.json>"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("GOG_HOME", t.TempDir())
+			t.Setenv("GOG_KEYRING_BACKEND", "keychain")
+			layout, err := config.NewSystemResolver("").Resolve(config.PathKindConfig, config.PathKindData)
+			if err != nil {
+				t.Fatalf("resolve config layout: %v", err)
+			}
+			client := test.client
+			if client == "" {
+				client = config.DefaultClientName
+			}
+			if test.writeMetadata {
+				if err := config.NewClientCredentialsStore(layout).WriteMetadata(client, config.ClientCredentials{
+					ClientID: "test-client.apps.googleusercontent.com",
+				}); err != nil {
+					t.Fatalf("write OAuth credentials metadata: %v", err)
+				}
+			}
+			store := newMemSecretsStore()
+			if err := store.SetToken(client, "user@example.com", secrets.Token{RefreshToken: "fixture-token"}); err != nil {
+				t.Fatalf("store fixture token: %v", err)
+			}
+			if test.secondToken {
+				if err := store.SetToken(client, "another@example.com", secrets.Token{RefreshToken: "another-fixture-token"}); err != nil {
+					t.Fatalf("store second fixture token: %v", err)
+				}
+			}
+			result := executeWithTestRuntime(t, []string{"--json", "auth", "doctor"}, runtimeWithAuthStore(store))
+			if result.err != nil {
+				t.Fatalf("auth doctor: %v", result.err)
+			}
+			var payload struct {
+				Status string            `json:"status"`
+				Checks []authDoctorCheck `json:"checks"`
+			}
+			if err := json.Unmarshal([]byte(result.stdout), &payload); err != nil {
+				t.Fatalf("decode auth doctor output: %v", err)
+			}
+			if payload.Status != doctorError {
+				t.Fatalf("status = %q, checks = %#v", payload.Status, payload.Checks)
+			}
+			credentialsChecks := 0
+			for _, check := range payload.Checks {
+				if check.Name == "credentials."+client {
+					credentialsChecks++
+					if check.Status != doctorError || !strings.Contains(check.Hint, test.wantHint) {
+						t.Fatalf("OAuth credentials check = %#v", check)
+					}
+				}
+			}
+			if credentialsChecks != 1 {
+				t.Fatalf("expected one OAuth credentials check, got %d: %#v", credentialsChecks, payload.Checks)
+			}
+		})
+	}
 }
 
 func TestAuthList_JSON_ReportsUnreadableToken(t *testing.T) {

--- a/internal/cmd/auth_cmd_test.go
+++ b/internal/cmd/auth_cmd_test.go
@@ -511,7 +511,9 @@ func TestAuthDoctor_JSON_MissingOptionalConfigIsHealthy(t *testing.T) {
 	if err := store.SetToken(config.DefaultClientName, "user@example.com", secrets.Token{RefreshToken: "fixture-token"}); err != nil {
 		t.Fatalf("store fixture token: %v", err)
 	}
-	result := executeWithTestRuntime(t, []string{"--json", "auth", "doctor"}, runtimeWithAuthStore(store))
+	runtime := runtimeWithAuthStore(store)
+	runtime.KeyringOptions.Backend = "keychain"
+	result := executeWithTestRuntime(t, []string{"--json", "auth", "doctor"}, runtime)
 	if result.err != nil {
 		t.Fatalf("auth doctor: %v", result.err)
 	}
@@ -587,7 +589,9 @@ func TestAuthDoctor_JSON_ReportsUnusableOAuthCredentials(t *testing.T) {
 					t.Fatalf("store second fixture token: %v", err)
 				}
 			}
-			result := executeWithTestRuntime(t, []string{"--json", "auth", "doctor"}, runtimeWithAuthStore(store))
+			runtime := runtimeWithAuthStore(store)
+			runtime.KeyringOptions.Backend = "keychain"
+			result := executeWithTestRuntime(t, []string{"--json", "auth", "doctor"}, runtime)
 			if result.err != nil {
 				t.Fatalf("auth doctor: %v", result.err)
 			}

--- a/internal/cmd/auth_doctor.go
+++ b/internal/cmd/auth_doctor.go
@@ -59,7 +59,9 @@ func (c *AuthDoctorCmd) Run(ctx context.Context, _ *RootFlags) error {
 		case exists:
 			add("config.path", doctorOK, configPath, "")
 		default:
-			add("config.path", doctorWarn, configPath+" (missing)", "run `gog auth credentials <credentials.json>` or another config-writing auth command")
+			// config.json is optional (docs/spec.md): it only carries overrides such as
+			// keyring_backend or account_aliases, and auth commands create it on demand.
+			add("config.path", doctorOK, configPath+" (missing; optional)", "")
 		}
 	}
 

--- a/internal/cmd/auth_doctor.go
+++ b/internal/cmd/auth_doctor.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/openclaw/gogcli/internal/app"
+	"github.com/openclaw/gogcli/internal/authclient"
 	"github.com/openclaw/gogcli/internal/config"
 	"github.com/openclaw/gogcli/internal/outfmt"
 	"github.com/openclaw/gogcli/internal/secrets"
@@ -59,9 +60,7 @@ func (c *AuthDoctorCmd) Run(ctx context.Context, _ *RootFlags) error {
 		case exists:
 			add("config.path", doctorOK, configPath, "")
 		default:
-			// config.json is optional (docs/spec.md): it only carries overrides such as
-			// keyring_backend or account_aliases, and auth commands create it on demand.
-			add("config.path", doctorOK, configPath+" (missing; optional)", "")
+			add("config.path", doctorOK, configPath+" (optional; not created)", "")
 		}
 	}
 
@@ -116,6 +115,27 @@ func (c *AuthDoctorCmd) Run(ctx context.Context, _ *RootFlags) error {
 		add("tokens", doctorWarn, "no OAuth tokens stored", "run `gog auth add <email>`")
 	} else {
 		add("tokens", doctorOK, pluralizeCount(len(tokens), "readable OAuth token")+" of "+pluralizeCount(tokenKeys, "stored token account"), "")
+	}
+
+	credentialClients := make(map[string]struct{})
+	for _, tok := range tokens {
+		client := strings.TrimSpace(tok.Client)
+		if client == "" {
+			client = config.DefaultClientName
+		}
+		if _, seen := credentialClients[client]; seen {
+			continue
+		}
+		credentialClients[client] = struct{}{}
+		if _, err := authclient.ReadCredentials(ctx, client); err != nil {
+			command := "gog auth credentials <credentials.json>"
+			if client != config.DefaultClientName {
+				command = "gog --client " + client + " auth credentials <credentials.json>"
+			}
+			add("credentials."+client, doctorError, err.Error(), "run `"+command+"`")
+			continue
+		}
+		add("credentials."+client, doctorOK, "OAuth client credentials available", "")
 	}
 
 	if c.Check {


### PR DESCRIPTION
Fixes #1015

`docs/spec.md` documents `config.json` as optional — it only carries overrides such as `keyring_backend` and `account_aliases`, and auth commands create it on demand. On a fresh install `gog auth doctor` therefore always reported:

```
warn  config.path  .../config.json (missing)
hint  config.path  run `gog auth credentials <credentials.json>` or another config-writing auth command
```

Two problems: the warning fires on every healthy install, and the hint points to a command that writes `credentials.json`, not `config.json`, so following it can never clear the warning.

This reports the check as `ok` with a note that the file is optional. Setup gaps still surface through the existing `tokens` / `keyring.*` checks. Adds a regression test asserting the new behavior on a fresh install.
