### PR TITLE
feat(appscript): add pull, deployments, and versions

### DIFF
--- a/.agents/skills/gog-appscript/SKILL.md
+++ b/.agents/skills/gog-appscript/SKILL.md
@@ -30,8 +30,11 @@ gog --readonly --account user@example.com appscript --help
 | --- | --- |
 | `content` | Get Apps Script project content |
 | `create` | Create an Apps Script project |
+| `deployments` | List deployments |
 | `get` | Get Apps Script project metadata |
+| `pull` | Pull an Apps Script project into a local directory |
 | `run` | Run a deployed Apps Script function |
+| `versions` | List versions |
 
 Run `gog appscript <command> --help` for flags and `gog schema appscript <command> --json`
 for the machine-readable contract. Do not guess command syntax.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Apps Script: add `pull`, `deployments`, and `versions` so a project's source, releases, and cut versions can be read from the CLI.
+
 - Security: remove overflow-prone capacity arithmetic from untrusted-output maps and versioned tracking ciphertext construction while preserving their wire formats.
 - Security: restrict the CI workflow's `GITHUB_TOKEN` to read-only repository contents instead of inheriting broader organization or repository defaults.
 - Security: generate live agent-evaluation session IDs with cryptographically random suffixes while preserving their fixed-width format.

--- a/docs/commands.generated.md
+++ b/docs/commands.generated.md
@@ -34,7 +34,7 @@ Generated from `gog schema --json`.
     - [`gog appscript (script,apps-script) create (new) --title=STRING [flags]`](commands/gog-appscript-create.md) - Create an Apps Script project
     - [`gog appscript (script,apps-script) deployments (list-deployments) <scriptId> [flags]`](commands/gog-appscript-deployments.md) - List deployments
     - [`gog appscript (script,apps-script) get (info,show) <scriptId>`](commands/gog-appscript-get.md) - Get Apps Script project metadata
-    - [`gog appscript (script,apps-script) pull <scriptId> <dir>`](commands/gog-appscript-pull.md) - Pull an Apps Script project into a local directory
+    - [`gog appscript (script,apps-script) pull <scriptId> <dir> [flags]`](commands/gog-appscript-pull.md) - Pull an Apps Script project into a local directory
     - [`gog appscript (script,apps-script) run <scriptId> <function> [flags]`](commands/gog-appscript-run.md) - Run a deployed Apps Script function
     - [`gog appscript (script,apps-script) versions (list-versions) <scriptId> [flags]`](commands/gog-appscript-versions.md) - List versions
   - [`gog auth <command> [flags]`](commands/gog-auth.md) - Auth and credentials

--- a/docs/commands.generated.md
+++ b/docs/commands.generated.md
@@ -32,8 +32,11 @@ Generated from `gog schema --json`.
   - [`gog appscript (script,apps-script) <command> [flags]`](commands/gog-appscript.md) - Google Apps Script
     - [`gog appscript (script,apps-script) content (cat) <scriptId>`](commands/gog-appscript-content.md) - Get Apps Script project content
     - [`gog appscript (script,apps-script) create (new) --title=STRING [flags]`](commands/gog-appscript-create.md) - Create an Apps Script project
+    - [`gog appscript (script,apps-script) deployments (list-deployments) <scriptId> [flags]`](commands/gog-appscript-deployments.md) - List deployments
     - [`gog appscript (script,apps-script) get (info,show) <scriptId>`](commands/gog-appscript-get.md) - Get Apps Script project metadata
+    - [`gog appscript (script,apps-script) pull <scriptId> <dir>`](commands/gog-appscript-pull.md) - Pull an Apps Script project into a local directory
     - [`gog appscript (script,apps-script) run <scriptId> <function> [flags]`](commands/gog-appscript-run.md) - Run a deployed Apps Script function
+    - [`gog appscript (script,apps-script) versions (list-versions) <scriptId> [flags]`](commands/gog-appscript-versions.md) - List versions
   - [`gog auth <command> [flags]`](commands/gog-auth.md) - Auth and credentials
     - [`gog auth add <email> [flags]`](commands/gog-auth-add.md) - Authorize and store a refresh token
     - [`gog auth alias <command>`](commands/gog-auth-alias.md) - Manage account aliases

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -2,7 +2,7 @@
 
 Every `gog` command has a generated docs page. The source of truth is the live CLI schema; run `make docs-commands` after changing command names, flags, help text, aliases, or arguments.
 
-Generated pages: 719.
+Generated pages: 722.
 
 ## Top-level Commands
 
@@ -85,8 +85,11 @@ Generated pages: 719.
   - [gog appscript](gog-appscript.md) - Google Apps Script
     - [gog appscript content](gog-appscript-content.md) - Get Apps Script project content
     - [gog appscript create](gog-appscript-create.md) - Create an Apps Script project
+    - [gog appscript deployments](gog-appscript-deployments.md) - List deployments
     - [gog appscript get](gog-appscript-get.md) - Get Apps Script project metadata
+    - [gog appscript pull](gog-appscript-pull.md) - Pull an Apps Script project into a local directory
     - [gog appscript run](gog-appscript-run.md) - Run a deployed Apps Script function
+    - [gog appscript versions](gog-appscript-versions.md) - List versions
   - [gog auth](gog-auth.md) - Auth and credentials
     - [gog auth add](gog-auth-add.md) - Authorize and store a refresh token
     - [gog auth alias](gog-auth-alias.md) - Manage account aliases

--- a/docs/commands/gog-appscript-deployments.md
+++ b/docs/commands/gog-appscript-deployments.md
@@ -1,28 +1,18 @@
-# `gog appscript`
+# `gog appscript deployments`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Google Apps Script
+List deployments
 
 ## Usage
 
 ```bash
-gog appscript (script,apps-script) <command> [flags]
+gog appscript (script,apps-script) deployments (list-deployments) <scriptId> [flags]
 ```
 
 ## Parent
 
-- [gog](gog.md)
-
-## Subcommands
-
-- [gog appscript content](gog-appscript-content.md) - Get Apps Script project content
-- [gog appscript create](gog-appscript-create.md) - Create an Apps Script project
-- [gog appscript deployments](gog-appscript-deployments.md) - List deployments
-- [gog appscript get](gog-appscript-get.md) - Get Apps Script project metadata
-- [gog appscript pull](gog-appscript-pull.md) - Pull an Apps Script project into a local directory
-- [gog appscript run](gog-appscript-run.md) - Run a deployed Apps Script function
-- [gog appscript versions](gog-appscript-versions.md) - List versions
+- [gog appscript](gog-appscript.md)
 
 ## Flags
 
@@ -30,18 +20,22 @@ gog appscript (script,apps-script) <command> [flags]
 | --- | --- | --- | --- |
 | `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email, alias, or auto for authenticated Google API commands |
+| `--all`<br>`--all-pages`<br>`--allpages` | `bool` |  | Fetch all pages |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
 | `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
 | `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
 | `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
+| `--fail-empty`<br>`--non-empty`<br>`--require-results` | `bool` |  | Exit with code 3 if no deployments |
 | `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
 | `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
 | `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--max`<br>`--limit` | `int64` | 100 | Max results |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `--page`<br>`--cursor` | `string` |  | Page token |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
 | `--readonly` | `bool` | false | Block mutating API requests at runtime; auth add also requests read-only OAuth scopes |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
@@ -52,5 +46,5 @@ gog appscript (script,apps-script) <command> [flags]
 
 ## See Also
 
-- [gog](gog.md)
+- [gog appscript](gog-appscript.md)
 - [Command index](README.md)

--- a/docs/commands/gog-appscript-pull.md
+++ b/docs/commands/gog-appscript-pull.md
@@ -1,28 +1,18 @@
-# `gog appscript`
+# `gog appscript pull`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Google Apps Script
+Pull an Apps Script project into a local directory
 
 ## Usage
 
 ```bash
-gog appscript (script,apps-script) <command> [flags]
+gog appscript (script,apps-script) pull <scriptId> <dir>
 ```
 
 ## Parent
 
-- [gog](gog.md)
-
-## Subcommands
-
-- [gog appscript content](gog-appscript-content.md) - Get Apps Script project content
-- [gog appscript create](gog-appscript-create.md) - Create an Apps Script project
-- [gog appscript deployments](gog-appscript-deployments.md) - List deployments
-- [gog appscript get](gog-appscript-get.md) - Get Apps Script project metadata
-- [gog appscript pull](gog-appscript-pull.md) - Pull an Apps Script project into a local directory
-- [gog appscript run](gog-appscript-run.md) - Run a deployed Apps Script function
-- [gog appscript versions](gog-appscript-versions.md) - List versions
+- [gog appscript](gog-appscript.md)
 
 ## Flags
 
@@ -52,5 +42,5 @@ gog appscript (script,apps-script) <command> [flags]
 
 ## See Also
 
-- [gog](gog.md)
+- [gog appscript](gog-appscript.md)
 - [Command index](README.md)

--- a/docs/commands/gog-appscript-pull.md
+++ b/docs/commands/gog-appscript-pull.md
@@ -7,7 +7,7 @@ Pull an Apps Script project into a local directory
 ## Usage
 
 ```bash
-gog appscript (script,apps-script) pull <scriptId> <dir>
+gog appscript (script,apps-script) pull <scriptId> <dir> [flags]
 ```
 
 ## Parent
@@ -32,6 +32,7 @@ gog appscript (script,apps-script) pull <scriptId> <dir>
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `--overwrite` | `bool` |  | Overwrite files that already exist in dir |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
 | `--readonly` | `bool` | false | Block mutating API requests at runtime; auth add also requests read-only OAuth scopes |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |

--- a/docs/commands/gog-appscript-versions.md
+++ b/docs/commands/gog-appscript-versions.md
@@ -1,28 +1,18 @@
-# `gog appscript`
+# `gog appscript versions`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Google Apps Script
+List versions
 
 ## Usage
 
 ```bash
-gog appscript (script,apps-script) <command> [flags]
+gog appscript (script,apps-script) versions (list-versions) <scriptId> [flags]
 ```
 
 ## Parent
 
-- [gog](gog.md)
-
-## Subcommands
-
-- [gog appscript content](gog-appscript-content.md) - Get Apps Script project content
-- [gog appscript create](gog-appscript-create.md) - Create an Apps Script project
-- [gog appscript deployments](gog-appscript-deployments.md) - List deployments
-- [gog appscript get](gog-appscript-get.md) - Get Apps Script project metadata
-- [gog appscript pull](gog-appscript-pull.md) - Pull an Apps Script project into a local directory
-- [gog appscript run](gog-appscript-run.md) - Run a deployed Apps Script function
-- [gog appscript versions](gog-appscript-versions.md) - List versions
+- [gog appscript](gog-appscript.md)
 
 ## Flags
 
@@ -30,18 +20,22 @@ gog appscript (script,apps-script) <command> [flags]
 | --- | --- | --- | --- |
 | `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email, alias, or auto for authenticated Google API commands |
+| `--all`<br>`--all-pages`<br>`--allpages` | `bool` |  | Fetch all pages |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
 | `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
 | `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
 | `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
+| `--fail-empty`<br>`--non-empty`<br>`--require-results` | `bool` |  | Exit with code 3 if no versions |
 | `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
 | `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
 | `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--max`<br>`--limit` | `int64` | 100 | Max results |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `--page`<br>`--cursor` | `string` |  | Page token |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
 | `--readonly` | `bool` | false | Block mutating API requests at runtime; auth add also requests read-only OAuth scopes |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
@@ -52,5 +46,5 @@ gog appscript (script,apps-script) <command> [flags]
 
 ## See Also
 
-- [gog](gog.md)
+- [gog appscript](gog-appscript.md)
 - [Command index](README.md)

--- a/internal/cmd/appscript.go
+++ b/internal/cmd/appscript.go
@@ -16,6 +16,10 @@ type AppScriptCmd struct {
 	Content AppScriptContentCmd `cmd:"" name:"content" aliases:"cat" help:"Get Apps Script project content"`
 	Run     AppScriptRunCmd     `cmd:"" name:"run" help:"Run a deployed Apps Script function"`
 	Create  AppScriptCreateCmd  `cmd:"" name:"create" aliases:"new" help:"Create an Apps Script project"`
+
+	Pull        AppScriptPullCmd        `cmd:"" name:"pull" help:"Pull an Apps Script project into a local directory"`
+	Deployments AppScriptDeploymentsCmd `cmd:"" name:"deployments" aliases:"list-deployments" help:"List deployments"`
+	Versions    AppScriptVersionsCmd    `cmd:"" name:"versions" aliases:"list-versions" help:"List versions"`
 }
 
 type AppScriptGetCmd struct {

--- a/internal/cmd/appscript_list.go
+++ b/internal/cmd/appscript_list.go
@@ -1,0 +1,242 @@
+package cmd
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	scriptapi "google.golang.org/api/script/v1"
+
+	"github.com/openclaw/gogcli/internal/outfmt"
+	"github.com/openclaw/gogcli/internal/ui"
+)
+
+type AppScriptDeploymentsCmd struct {
+	ScriptID  string `arg:"" name:"scriptId" help:"Script ID"`
+	Max       int64  `name:"max" aliases:"limit" help:"Max results" default:"100"`
+	Page      string `name:"page" aliases:"cursor" help:"Page token"`
+	All       bool   `name:"all" aliases:"all-pages,allpages" help:"Fetch all pages"`
+	FailEmpty bool   `name:"fail-empty" aliases:"non-empty,require-results" help:"Exit with code 3 if no deployments"`
+}
+
+func (c *AppScriptDeploymentsCmd) Run(ctx context.Context, flags *RootFlags) error {
+	scriptID, svc, err := appScriptListSetup(ctx, flags, c.ScriptID, c.Max)
+	if err != nil {
+		return err
+	}
+
+	return runAppScriptList(ctx, appScriptListRequest[*scriptapi.Deployment]{
+		ScriptID:     scriptID,
+		ItemsKey:     "deployments",
+		EmptyMessage: "No deployments",
+		Page:         c.Page,
+		All:          c.All,
+		FailEmpty:    c.FailEmpty,
+		Columns:      appScriptDeploymentColumns(),
+		Fetch:        appScriptDeploymentPager(ctx, svc, scriptID, c.Max),
+	})
+}
+
+func appScriptDeploymentPager(ctx context.Context, svc *scriptapi.Service, scriptID string, maxResults int64) pageFetchFunc[*scriptapi.Deployment] {
+	return func(pageToken string) ([]*scriptapi.Deployment, string, error) {
+		call := svc.Projects.Deployments.List(scriptID).PageSize(maxResults).Context(ctx)
+		if page := strings.TrimSpace(pageToken); page != "" {
+			call = call.PageToken(page)
+		}
+
+		resp, err := call.Do()
+		if err != nil {
+			return nil, "", err
+		}
+
+		return resp.Deployments, resp.NextPageToken, nil
+	}
+}
+
+func appScriptVersionPager(ctx context.Context, svc *scriptapi.Service, scriptID string, maxResults int64) pageFetchFunc[*scriptapi.Version] {
+	return func(pageToken string) ([]*scriptapi.Version, string, error) {
+		call := svc.Projects.Versions.List(scriptID).PageSize(maxResults).Context(ctx)
+		if page := strings.TrimSpace(pageToken); page != "" {
+			call = call.PageToken(page)
+		}
+
+		resp, err := call.Do()
+		if err != nil {
+			return nil, "", err
+		}
+
+		return resp.Versions, resp.NextPageToken, nil
+	}
+}
+
+// appScriptListSetup applies the validation and service construction the
+// appscript list commands share.
+func appScriptListSetup(ctx context.Context, flags *RootFlags, rawScriptID string, maxResults int64) (string, *scriptapi.Service, error) {
+	scriptID := strings.TrimSpace(normalizeGoogleID(rawScriptID))
+	if scriptID == "" {
+		return "", nil, usage("empty scriptId")
+	}
+
+	if maxResults <= 0 {
+		return "", nil, usage("max must be > 0")
+	}
+
+	svc, err := requireAppScriptService(ctx, flags)
+	if err != nil {
+		return "", nil, err
+	}
+
+	return scriptID, svc, nil
+}
+
+// appScriptListRequest carries everything the two appscript list commands vary:
+// the API call, how their items are named, and how they render.
+type appScriptListRequest[T any] struct {
+	ScriptID     string
+	ItemsKey     string
+	EmptyMessage string
+	Page         string
+	All          bool
+	FailEmpty    bool
+	Columns      []outfmt.Column[T]
+	Fetch        pageFetchFunc[T]
+}
+
+func runAppScriptList[T any](ctx context.Context, req appScriptListRequest[T]) error {
+	u := ui.FromContext(ctx)
+
+	items, nextPageToken, err := loadPagedItems(req.Page, req.All, req.Fetch)
+	if err != nil {
+		return err
+	}
+
+	if items == nil {
+		items = []T{}
+	}
+
+	if outfmt.IsJSON(ctx) {
+		return writePagedJSONResult(ctx, map[string]any{
+			"scriptId":      req.ScriptID,
+			req.ItemsKey:    items,
+			"nextPageToken": nextPageToken,
+		}, len(items), req.FailEmpty)
+	}
+
+	if len(items) == 0 {
+		u.Err().Println(req.EmptyMessage)
+		return failEmptyExit(req.FailEmpty)
+	}
+
+	if err := outfmt.WriteTable(ctx, stdoutWriter(ctx), items, req.Columns); err != nil {
+		return err
+	}
+
+	printNextPageHintWithAll(u, nextPageToken, "--all/--all-pages")
+
+	return nil
+}
+
+func appScriptDeploymentColumns() []outfmt.Column[*scriptapi.Deployment] {
+	return []outfmt.Column[*scriptapi.Deployment]{
+		{Header: "DEPLOYMENT_ID", Value: appScriptDeploymentID},
+		{Header: "VERSION", Value: appScriptDeploymentVersion},
+		{Header: "DESCRIPTION", Value: appScriptDeploymentDescription},
+		{Header: "WEB_APP_URL", Value: appScriptWebAppURL},
+	}
+}
+
+func appScriptDeploymentID(deployment *scriptapi.Deployment) string {
+	if deployment == nil {
+		return ""
+	}
+
+	return deployment.DeploymentId
+}
+
+// appScriptDeploymentVersion reports HEAD for a deployment pinned to the live
+// editor content rather than to a cut version.
+func appScriptDeploymentVersion(deployment *scriptapi.Deployment) string {
+	if deployment == nil || deployment.DeploymentConfig == nil || deployment.DeploymentConfig.VersionNumber == 0 {
+		return "HEAD"
+	}
+
+	return "v" + strconv.FormatInt(deployment.DeploymentConfig.VersionNumber, 10)
+}
+
+func appScriptDeploymentDescription(deployment *scriptapi.Deployment) string {
+	if deployment == nil || deployment.DeploymentConfig == nil {
+		return ""
+	}
+
+	return sanitizeTab(deployment.DeploymentConfig.Description)
+}
+
+func appScriptWebAppURL(deployment *scriptapi.Deployment) string {
+	if deployment == nil {
+		return ""
+	}
+
+	for _, entry := range deployment.EntryPoints {
+		if entry == nil || entry.WebApp == nil {
+			continue
+		}
+
+		if entry.WebApp.Url != "" {
+			return entry.WebApp.Url
+		}
+	}
+
+	return ""
+}
+
+type AppScriptVersionsCmd struct {
+	ScriptID  string `arg:"" name:"scriptId" help:"Script ID"`
+	Max       int64  `name:"max" aliases:"limit" help:"Max results" default:"100"`
+	Page      string `name:"page" aliases:"cursor" help:"Page token"`
+	All       bool   `name:"all" aliases:"all-pages,allpages" help:"Fetch all pages"`
+	FailEmpty bool   `name:"fail-empty" aliases:"non-empty,require-results" help:"Exit with code 3 if no versions"`
+}
+
+func (c *AppScriptVersionsCmd) Run(ctx context.Context, flags *RootFlags) error {
+	scriptID, svc, err := appScriptListSetup(ctx, flags, c.ScriptID, c.Max)
+	if err != nil {
+		return err
+	}
+
+	return runAppScriptList(ctx, appScriptListRequest[*scriptapi.Version]{
+		ScriptID:     scriptID,
+		ItemsKey:     "versions",
+		EmptyMessage: "No versions",
+		Page:         c.Page,
+		All:          c.All,
+		FailEmpty:    c.FailEmpty,
+		Columns:      appScriptVersionColumns(),
+		Fetch:        appScriptVersionPager(ctx, svc, scriptID, c.Max),
+	})
+}
+
+func appScriptVersionColumns() []outfmt.Column[*scriptapi.Version] {
+	return []outfmt.Column[*scriptapi.Version]{
+		{Header: "VERSION", Value: func(version *scriptapi.Version) string {
+			if version == nil {
+				return ""
+			}
+
+			return strconv.FormatInt(version.VersionNumber, 10)
+		}},
+		{Header: "CREATED", Value: func(version *scriptapi.Version) string {
+			if version == nil {
+				return ""
+			}
+
+			return formatDateTime(version.CreateTime)
+		}},
+		{Header: "DESCRIPTION", Value: func(version *scriptapi.Version) string {
+			if version == nil {
+				return ""
+			}
+
+			return sanitizeTab(version.Description)
+		}},
+	}
+}

--- a/internal/cmd/appscript_list_test.go
+++ b/internal/cmd/appscript_list_test.go
@@ -1,0 +1,133 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	scriptapi "google.golang.org/api/script/v1"
+)
+
+func TestAppScriptDeploymentVersion(t *testing.T) {
+	cases := []struct {
+		name       string
+		deployment *scriptapi.Deployment
+		want       string
+	}{
+		{name: "nil deployment", deployment: nil, want: "HEAD"},
+		{name: "no config", deployment: &scriptapi.Deployment{}, want: "HEAD"},
+		{
+			name:       "unversioned config tracks the editor",
+			deployment: &scriptapi.Deployment{DeploymentConfig: &scriptapi.DeploymentConfig{}},
+			want:       "HEAD",
+		},
+		{
+			name:       "versioned",
+			deployment: &scriptapi.Deployment{DeploymentConfig: &scriptapi.DeploymentConfig{VersionNumber: 7}},
+			want:       "v7",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := appScriptDeploymentVersion(tc.deployment); got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAppScriptWebAppURL(t *testing.T) {
+	if got := appScriptWebAppURL(nil); got != "" {
+		t.Fatalf("nil deployment: got %q", got)
+	}
+
+	deployment := &scriptapi.Deployment{
+		EntryPoints: []*scriptapi.EntryPoint{
+			nil,
+			{EntryPointType: "EXECUTION_API"},
+			{WebApp: &scriptapi.GoogleAppsScriptTypeWebAppEntryPoint{Url: "https://example.test/exec"}},
+		},
+	}
+	if got := appScriptWebAppURL(deployment); got != "https://example.test/exec" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestExecute_AppScriptDeployments_AllFetchesEveryPage(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/deployments") {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+
+		if r.URL.Query().Get("pageToken") == "" {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"deployments":   []map[string]any{{"deploymentId": "one"}},
+				"nextPageToken": "page2",
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"deployments": []map[string]any{{"deploymentId": "two"}},
+		})
+	}))
+	defer srv.Close()
+
+	result := executeWithAppScriptTestService(t, []string{
+		"--account", "a@b.com",
+		"appscript", "deployments", "script123", "--all",
+	}, newAppScriptTestService(t, srv))
+	if result.err != nil {
+		t.Fatalf("Execute: %v", result.err)
+	}
+	if !strings.Contains(result.stdout, "DEPLOYMENT_ID") ||
+		!strings.Contains(result.stdout, "one") ||
+		!strings.Contains(result.stdout, "two") {
+		t.Fatalf("expected both pages in out=%q", result.stdout)
+	}
+}
+
+func TestExecute_AppScriptVersions_JSONKeepsNextPageToken(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/versions") {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"versions":      []map[string]any{{"versionNumber": 1, "description": "first"}},
+			"nextPageToken": "page2",
+		})
+	}))
+	defer srv.Close()
+
+	result := executeWithAppScriptTestService(t, []string{
+		"--json", "--account", "a@b.com",
+		"appscript", "versions", "script123",
+	}, newAppScriptTestService(t, srv))
+	if result.err != nil {
+		t.Fatalf("Execute: %v", result.err)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(result.stdout), &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if parsed["nextPageToken"] != "page2" {
+		t.Fatalf("dropped nextPageToken: %#v", parsed)
+	}
+}
+
+func TestExecute_AppScriptVersions_RejectsNonPositiveMax(t *testing.T) {
+	result := executeWithAppScriptTestServiceFactory(t, []string{
+		"--account", "a@b.com",
+		"appscript", "versions", "script123", "--max", "0",
+	}, unexpectedAppScriptTestService(t, "max validation should run before creating the appscript service"))
+	if result.err == nil || !strings.Contains(result.err.Error(), "max must be > 0") {
+		t.Fatalf("unexpected err: %v", result.err)
+	}
+}

--- a/internal/cmd/appscript_pull.go
+++ b/internal/cmd/appscript_pull.go
@@ -22,8 +22,9 @@ var appScriptExtByType = map[string]string{
 }
 
 type AppScriptPullCmd struct {
-	ScriptID string `arg:"" name:"scriptId" help:"Script ID"`
-	Dir      string `arg:"" name:"dir" help:"Local directory to write files into (created if missing)" type:"path"`
+	ScriptID  string `arg:"" name:"scriptId" help:"Script ID"`
+	Dir       string `arg:"" name:"dir" help:"Local directory to write files into (created if missing)" type:"path"`
+	Overwrite bool   `name:"overwrite" help:"Overwrite files that already exist in dir"`
 }
 
 func (c *AppScriptPullCmd) Run(ctx context.Context, flags *RootFlags) error {
@@ -54,10 +55,8 @@ func (c *AppScriptPullCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return err
 	}
 
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		return err
-	}
-
+	// File names come from the API; keep them from escaping dir.
+	targets := make([]*scriptapi.File, 0, len(content.Files))
 	written := make([]string, 0, len(content.Files))
 
 	for _, file := range content.Files {
@@ -65,17 +64,29 @@ func (c *AppScriptPullCmd) Run(ctx context.Context, flags *RootFlags) error {
 			continue
 		}
 
-		// File names come from the API; keep them from escaping dir.
-		name := sanitizeAttachmentFilename(appScriptFileName(file), "")
-		if name == "" {
-			continue
+		if name := sanitizeAttachmentFilename(appScriptFileName(file), ""); name != "" {
+			targets = append(targets, file)
+			written = append(written, name)
 		}
+	}
 
-		if err := writeFileAtomic(filepath.Join(dir, name), []byte(file.Source)); err != nil {
+	// Name every file that would be replaced before replacing any of them, so a
+	// pull into a working directory cannot quietly discard local edits.
+	if !c.Overwrite {
+		if clashes := existingAppScriptTargets(dir, written); len(clashes) > 0 {
+			return usagef("%s already contains %d of these file(s): %s (pass --overwrite to replace them)",
+				dir, len(clashes), strings.Join(clashes, ", "))
+		}
+	}
+
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+
+	for i, file := range targets {
+		if err := writeAppScriptFile(filepath.Join(dir, written[i]), file.Source, c.Overwrite); err != nil {
 			return err
 		}
-
-		written = append(written, name)
 	}
 
 	if outfmt.IsJSON(ctx) {
@@ -95,6 +106,41 @@ func (c *AppScriptPullCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	return nil
+}
+
+// existingAppScriptTargets reports which of names already exist in dir.
+func existingAppScriptTargets(dir string, names []string) []string {
+	var clashes []string
+
+	for _, name := range names {
+		if _, err := os.Lstat(filepath.Join(dir, name)); err == nil {
+			clashes = append(clashes, name)
+		}
+	}
+
+	return clashes
+}
+
+// writeAppScriptFile writes one pulled file through the shared output helper,
+// whose default is O_EXCL -- so the overwrite decision is enforced at open time
+// rather than trusted from the pre-flight check above.
+func writeAppScriptFile(path, source string, overwrite bool) error {
+	f, _, err := openUserOutputFile(path, outputFileOptions{
+		Overwrite: overwrite,
+		FileMode:  0o600,
+		DirMode:   0o700,
+	})
+	if err != nil {
+		return err
+	}
+
+	if _, writeErr := f.WriteString(source); writeErr != nil {
+		_ = f.Close()
+
+		return writeErr
+	}
+
+	return f.Close()
 }
 
 func expandAppScriptDir(dir string) (string, error) {

--- a/internal/cmd/appscript_pull.go
+++ b/internal/cmd/appscript_pull.go
@@ -1,0 +1,112 @@
+package cmd
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+
+	scriptapi "google.golang.org/api/script/v1"
+
+	"github.com/openclaw/gogcli/internal/config"
+	"github.com/openclaw/gogcli/internal/outfmt"
+	"github.com/openclaw/gogcli/internal/ui"
+)
+
+// Apps Script stores a file's extension in its type, not its name: a file named
+// "Code" with type SERVER_JS is Code.gs in the editor.
+var appScriptExtByType = map[string]string{
+	"SERVER_JS": ".gs",
+	"HTML":      ".html",
+	"JSON":      ".json",
+}
+
+type AppScriptPullCmd struct {
+	ScriptID string `arg:"" name:"scriptId" help:"Script ID"`
+	Dir      string `arg:"" name:"dir" help:"Local directory to write files into (created if missing)" type:"path"`
+}
+
+func (c *AppScriptPullCmd) Run(ctx context.Context, flags *RootFlags) error {
+	scriptID := strings.TrimSpace(normalizeGoogleID(c.ScriptID))
+	if scriptID == "" {
+		return usage("empty scriptId")
+	}
+
+	dir, err := expandAppScriptDir(c.Dir)
+	if err != nil {
+		return err
+	}
+
+	if dryRunErr := dryRunExit(ctx, flags, "appscript.pull", map[string]any{
+		"script_id": scriptID,
+		"dir":       dir,
+	}); dryRunErr != nil {
+		return dryRunErr
+	}
+
+	svc, err := requireAppScriptService(ctx, flags)
+	if err != nil {
+		return err
+	}
+
+	content, err := svc.Projects.GetContent(scriptID).Context(ctx).Do()
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+
+	written := make([]string, 0, len(content.Files))
+
+	for _, file := range content.Files {
+		if file == nil {
+			continue
+		}
+
+		// File names come from the API; keep them from escaping dir.
+		name := sanitizeAttachmentFilename(appScriptFileName(file), "")
+		if name == "" {
+			continue
+		}
+
+		if err := writeFileAtomic(filepath.Join(dir, name), []byte(file.Source)); err != nil {
+			return err
+		}
+
+		written = append(written, name)
+	}
+
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(ctx, stdoutWriter(ctx), map[string]any{
+			"pulled": true,
+			"dir":    dir,
+			"files":  written,
+		})
+	}
+
+	u := ui.FromContext(ctx)
+	u.Out().Linef("pulled\ttrue")
+	u.Out().Linef("dir\t%s", dir)
+
+	for _, name := range written {
+		u.Out().Linef("file\t%s", name)
+	}
+
+	return nil
+}
+
+func expandAppScriptDir(dir string) (string, error) {
+	trimmed := strings.TrimSpace(dir)
+	if trimmed == "" {
+		return "", usage("empty dir")
+	}
+
+	return config.ExpandPath(trimmed)
+}
+
+// appScriptFileName renders the editor-visible filename for a project file.
+func appScriptFileName(file *scriptapi.File) string {
+	return file.Name + appScriptExtByType[file.Type]
+}

--- a/internal/cmd/appscript_pull_test.go
+++ b/internal/cmd/appscript_pull_test.go
@@ -11,6 +11,24 @@ import (
 	"testing"
 )
 
+func appScriptPullHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "projects/script123/content") {
+			http.NotFound(w, r)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"scriptId": "script123",
+			"files": []map[string]any{
+				{"name": "Code", "type": "SERVER_JS", "source": "function doGet() {}"},
+				{"name": "appsscript", "type": "JSON", "source": "{}"},
+			},
+		})
+	}
+}
+
 func TestExecute_AppScriptPull_WritesFilesWithPrivatePermissions(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "nested")
 
@@ -54,6 +72,68 @@ func TestExecute_AppScriptPull_WritesFilesWithPrivatePermissions(t *testing.T) {
 	// writable file there.
 	if perm := info.Mode().Perm(); runtime.GOOS != "windows" && perm != 0o600 {
 		t.Fatalf("expected 0600 manifest, got %o", perm)
+	}
+}
+
+// A pull into a working directory must not quietly discard local edits.
+func TestExecute_AppScriptPull_RefusesToOverwriteByDefault(t *testing.T) {
+	dir := t.TempDir()
+	local := filepath.Join(dir, "Code.gs")
+	if err := os.WriteFile(local, []byte("MY LOCAL EDIT"), 0o600); err != nil {
+		t.Fatalf("seed local file: %v", err)
+	}
+
+	srv := httptest.NewServer(appScriptPullHandler())
+	defer srv.Close()
+
+	result := executeWithAppScriptTestService(t, []string{
+		"--account", "a@b.com",
+		"appscript", "pull", "script123", dir,
+	}, newAppScriptTestService(t, srv))
+	if result.err == nil || !strings.Contains(result.err.Error(), "--overwrite") {
+		t.Fatalf("unexpected err: %v", result.err)
+	}
+	if !strings.Contains(result.err.Error(), "Code.gs") {
+		t.Fatalf("error should name the clashing file: %v", result.err)
+	}
+
+	body, err := os.ReadFile(local)
+	if err != nil {
+		t.Fatalf("read local file: %v", err)
+	}
+	if string(body) != "MY LOCAL EDIT" {
+		t.Fatalf("local file was modified: %q", body)
+	}
+	// The refusal has to happen before anything is written, not part-way.
+	if _, err := os.Stat(filepath.Join(dir, "appsscript.json")); !os.IsNotExist(err) {
+		t.Fatalf("no file should have been written: %v", err)
+	}
+}
+
+func TestExecute_AppScriptPull_OverwriteReplacesExistingFiles(t *testing.T) {
+	dir := t.TempDir()
+	local := filepath.Join(dir, "Code.gs")
+	if err := os.WriteFile(local, []byte("MY LOCAL EDIT"), 0o600); err != nil {
+		t.Fatalf("seed local file: %v", err)
+	}
+
+	srv := httptest.NewServer(appScriptPullHandler())
+	defer srv.Close()
+
+	result := executeWithAppScriptTestService(t, []string{
+		"--account", "a@b.com",
+		"appscript", "pull", "script123", dir, "--overwrite",
+	}, newAppScriptTestService(t, srv))
+	if result.err != nil {
+		t.Fatalf("Execute: %v", result.err)
+	}
+
+	body, err := os.ReadFile(local)
+	if err != nil {
+		t.Fatalf("read local file: %v", err)
+	}
+	if string(body) != "function doGet() {}" {
+		t.Fatalf("expected the remote source, got %q", body)
 	}
 }
 

--- a/internal/cmd/appscript_pull_test.go
+++ b/internal/cmd/appscript_pull_test.go
@@ -1,0 +1,91 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestExecute_AppScriptPull_WritesFilesWithPrivatePermissions(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "nested")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "projects/script123/content") {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"scriptId": "script123",
+			"files": []map[string]any{
+				{"name": "Code", "type": "SERVER_JS", "source": "function doGet() {}"},
+				{"name": "appsscript", "type": "JSON", "source": "{}"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	result := executeWithAppScriptTestService(t, []string{
+		"--account", "a@b.com",
+		"appscript", "pull", "script123", dir,
+	}, newAppScriptTestService(t, srv))
+	if result.err != nil {
+		t.Fatalf("Execute: %v", result.err)
+	}
+
+	body, err := os.ReadFile(filepath.Join(dir, "Code.gs"))
+	if err != nil {
+		t.Fatalf("read pulled file: %v", err)
+	}
+	if string(body) != "function doGet() {}" {
+		t.Fatalf("unexpected body: %q", body)
+	}
+
+	info, err := os.Stat(filepath.Join(dir, "appsscript.json"))
+	if err != nil {
+		t.Fatalf("stat manifest: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("expected 0600 manifest, got %o", perm)
+	}
+}
+
+// A server-supplied name must not be able to escape the target directory.
+func TestExecute_AppScriptPull_ContainsTraversalNames(t *testing.T) {
+	base := t.TempDir()
+	dir := filepath.Join(base, "out")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "projects/script123/content") {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"scriptId": "script123",
+			"files": []map[string]any{
+				{"name": "../escaped", "type": "SERVER_JS", "source": "nope"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	result := executeWithAppScriptTestService(t, []string{
+		"--account", "a@b.com",
+		"appscript", "pull", "script123", dir,
+	}, newAppScriptTestService(t, srv))
+	if result.err != nil {
+		t.Fatalf("Execute: %v", result.err)
+	}
+
+	if _, err := os.Stat(filepath.Join(base, "escaped.gs")); !os.IsNotExist(err) {
+		t.Fatalf("file escaped the target directory: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "escaped.gs")); err != nil {
+		t.Fatalf("expected sanitized name inside dir: %v", err)
+	}
+}

--- a/internal/cmd/appscript_pull_test.go
+++ b/internal/cmd/appscript_pull_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -49,7 +50,9 @@ func TestExecute_AppScriptPull_WritesFilesWithPrivatePermissions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("stat manifest: %v", err)
 	}
-	if perm := info.Mode().Perm(); perm != 0o600 {
+	// Windows has no POSIX permission bits, so Go reports 0666 for any
+	// writable file there.
+	if perm := info.Mode().Perm(); runtime.GOOS != "windows" && perm != 0o600 {
 		t.Fatalf("expected 0600 manifest, got %o", perm)
 	}
 }

--- a/internal/cmd/dryrun_e2e_test.go
+++ b/internal/cmd/dryrun_e2e_test.go
@@ -625,6 +625,12 @@ func TestDryRunE2E_CommandsSkipAuthAPIAndFileWrites(t *testing.T) {
 			op:   "appscript.create",
 		},
 		{
+			name:    "appscript pull",
+			args:    []string{"appscript", "pull", "script123", outputPath("appscript-pull")},
+			op:      "appscript.pull",
+			outPath: outputPath("appscript-pull"),
+		},
+		{
 			name: "sheets banding clear all",
 			args: []string{"sheets", "banding", "clear", "sheet123", "--sheet", "Sheet1", "--all"},
 			op:   "sheets.banding.clear",

--- a/internal/cmd/service_helpers.go
+++ b/internal/cmd/service_helpers.go
@@ -11,11 +11,20 @@ import (
 	"google.golang.org/api/driveactivity/v2"
 	"google.golang.org/api/gmail/v1"
 	"google.golang.org/api/meet/v2"
+	scriptapi "google.golang.org/api/script/v1"
 	"google.golang.org/api/sheets/v4"
 )
 
 func requireDocsService(ctx context.Context, flags *RootFlags) (*docs.Service, error) {
 	_, svc, err := requireGoogleService(ctx, flags, docsService)
+	if err != nil {
+		return nil, err
+	}
+	return svc, nil
+}
+
+func requireAppScriptService(ctx context.Context, flags *RootFlags) (*scriptapi.Service, error) {
+	_, svc, err := requireGoogleService(ctx, flags, appScriptService)
 	if err != nil {
 		return nil, err
 	}

--- a/safety-profiles/agent-safe.yaml
+++ b/safety-profiles/agent-safe.yaml
@@ -270,6 +270,9 @@ forms:
 appscript:
   get: true
   content: true
+  pull: true
+  deployments: true
+  versions: true
   run: false
   create: false
 

--- a/safety-profiles/readonly.yaml
+++ b/safety-profiles/readonly.yaml
@@ -275,6 +275,9 @@ forms:
 appscript:
   get: true
   content: true
+  pull: true
+  deployments: true
+  versions: true
   run: false
   create: false
 


### PR DESCRIPTION
Smaller first slice of #1005, which you closed — thank you for the review, both points were right.

This PR is the **read-only** third: `pull`, `deployments`, `versions`. Nothing here can delete anything. `push` (with the reworked non-destructive semantics) and `deploy`/`undeploy` follow as separate PRs once this shape is agreed, rather than all at once.

## What it adds

| Command | Purpose |
|---|---|
| `appscript pull <scriptId> <dir>` | Write project files into a local directory |
| `appscript deployments <scriptId>` | List deployments |
| `appscript versions <scriptId>` | List versions |

## Notes

- **Extension mapping.** Apps Script keeps a file's extension in its `type`, not its `name`, so pull translates `{name: "Code", type: SERVER_JS}` back to `Code.gs`.
- **Names come from the API**, so they go through `sanitizeAttachmentFilename` before being joined to the target directory, and files are written via `writeFileAtomic` (0700 dir / 0600 file) like the other local writers.
- **Pagination** uses `loadPagedItems` / `writePagedJSONResult` / `printNextPageHintWithAll`, so `--max`, `--page`, `--all`, `--fail-empty` behave as elsewhere. It matters for `versions`: the API pages at 50 and every deploy cuts a version, so dropping the token would silently under-report.
- **Safety profiles.** The three leaves are listed as reads in `readonly.yaml` and `agent-safe.yaml` — those allow-lists fail closed, so an unlisted read would be rejected and hidden from help in a baked build.
- `--readonly` needs no per-command code: all three are GETs.

## Live proof

Run against a real Apps Script project on a Workspace account, then the project was trashed. Script and deployment IDs redacted.

```console
$ gog appscript pull <SCRIPT_ID> '~/proof-pull'
pulled  true
dir     /home/<user>/proof-pull
file    Code.gs
file    appsscript.json

$ ls -l ~/proof-pull
-rw-------  138  appsscript.json
-rw-------   83  Code.gs

$ cat ~/proof-pull/Code.gs
function doGet() {
  return HtmlService.createHtmlOutput('<p>gog proof v2</p>');
}
```

`~` is expanded (`config.ExpandPath`), the directory is created 0700, files land 0600, and the content round-trips byte for byte against what the project holds.

```console
$ gog appscript versions <SCRIPT_ID>
VERSION  CREATED           DESCRIPTION
2        2026-08-24 02:32  gog proof deploy 2
1        2026-08-24 02:32  gog proof deploy 1

$ gog appscript deployments <SCRIPT_ID>
DEPLOYMENT_ID     VERSION  DESCRIPTION         WEB_APP_URL
AKfycbxn0o<...>   HEAD                         https://script.google.com/a/macros/<domain>/s/AKfycbxn0o<...>/exec
AKfycbyXGi<...>   v2       gog proof deploy 2  https://script.google.com/a/macros/<domain>/s/AKfycbyXGi<...>/exec
```

The `HEAD` row is Apps Script's always-present dev deployment, which has no `versionNumber` — that is the branch `appScriptDeploymentVersion` renders as `HEAD` rather than `v0`.

### Overwrite safety (added after review)

`pull` refuses to replace files that already exist, unless `--overwrite` is passed:

```console
$ gog appscript pull <SCRIPT_ID> ./work        # first pull, empty dir
pulled  true
dir     ./work
file    Code.gs
file    appsscript.json

$ echo '// MY LOCAL WORK - must survive' > ./work/Code.gs

$ gog appscript pull <SCRIPT_ID> ./work        # default: refuses, writes nothing
./work already contains 2 of these file(s): Code.gs, appsscript.json (pass --overwrite to replace them)
$ echo $?
2
$ cat ./work/Code.gs
// MY LOCAL WORK - must survive

$ gog appscript pull <SCRIPT_ID> ./work --overwrite
pulled  true
dir     ./work
file    Code.gs
file    appsscript.json
$ cat ./work/Code.gs
function doGet() { return HtmlService.createHtmlOutput('<p>remote</p>'); }
```

The refusal names every clashing file and happens before anything is written, so a pull cannot leave the directory half-updated.

## Testing

- `make ci` passes (`fmt-check`, `lint`, `deadcode`, `test`, `docs-check`, `agent-skills-check`).
- Unit tests cover the `HEAD`/versioned/nil deployment-version branches, web-app-URL extraction across entry-point kinds, `--all` fetching every page, `nextPageToken` retention under `--json`, `--max` validation before the service is constructed, pulled-file permissions, and containment of a server-supplied `../` filename.
- `dryrun_e2e_test.go` gains an `appscript pull` row with `outPath`, asserting `--dry-run` touches neither auth nor the filesystem.
- Overwrite regression tests cover both the default refusal (local edit intact, nothing written) and the `--overwrite` replacement.
- Generated docs and agent skills regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

