### PR TITLE
feat(calendar): explicitly disable event reminders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Calendar: add `--no-reminders` to event creation and updates so calendar-default reminders can be explicitly disabled. (#1002)
 - Slides: add skip/unskip commands and expose slide visibility without changing existing plain-text output. (#1009) — thanks @marnunez.
 - Config: serialize concurrent updates with shared platform-native file locks, preventing intermittent access-denied failures on Windows.
 - Calendar: correctly clear custom reminder overrides when restoring calendar defaults. (#1016) — thanks @sorenisanerd.

--- a/docs/commands/gog-calendar-create.md
+++ b/docs/commands/gog-calendar-create.md
@@ -49,6 +49,7 @@ gog calendar (cal) create (add,new) <calendarId> [flags]
 | `--location` | `string` |  | Location |
 | `--location-search` | `string` |  | Resolve a Google Places text search and use the best match as event location |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `--no-reminders` | `bool` |  | Disable all event reminders |
 | `--ooo-auto-decline` | `string` |  | Out of Office auto-decline mode: none, all, new |
 | `--ooo-decline-message` | `string` |  | Out of Office decline message |
 | `--place-id` | `string` |  | Resolve a Google Places ID and use it as event location |

--- a/docs/commands/gog-calendar-update.md
+++ b/docs/commands/gog-calendar-update.md
@@ -50,6 +50,7 @@ gog calendar (cal) update (edit,set) <calendarId> <eventId> [flags]
 | `--location` | `string` |  | New location (set empty to clear) |
 | `--location-search` | `string` |  | Resolve a Google Places text search and use the best match as event location |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `--no-reminders` | `bool` |  | Disable all event reminders |
 | `--ooo-auto-decline` | `string` |  | Out of Office auto-decline mode: none, all, new |
 | `--ooo-decline-message` | `string` |  | Out of Office decline message (set empty to clear) |
 | `--original-start` | `string` |  | Original start time of instance (required for scope=single,future) |
@@ -61,7 +62,7 @@ gog calendar (cal) update (edit,set) <calendarId> <eventId> [flags]
 | `--readonly` | `bool` | false | Block mutating API requests at runtime; auth add also requests read-only OAuth scopes |
 | `--regenerate-meet` | `bool` |  | Replace the event's Google Meet video conference |
 | `--regenerate-zoom` | `bool` |  | Replace the event's Zoom video conference |
-| `--reminder` | `[]string` |  | Custom reminders as method:duration (e.g., popup:30m, email:1d). Can be repeated (max 5). Set empty to clear. |
+| `--reminder` | `[]string` |  | Custom reminders as method:duration (e.g., popup:30m, email:1d). Can be repeated (max 5). Set empty to restore calendar defaults. |
 | `--remove-zoom` | `bool` |  | Remove the event's Zoom video conference |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
 | `--rrule` | `[]string` |  | Recurrence rules (e.g., 'RRULE:FREQ=MONTHLY;BYMONTHDAY=11'). Can be repeated. Set empty to clear. |

--- a/internal/cmd/calendar_build.go
+++ b/internal/cmd/calendar_build.go
@@ -219,7 +219,17 @@ func parseReminder(s string) (string, int64, error) {
 }
 
 //nolint:nilnil // nil return is intentional: nil means "use calendar defaults"
-func buildReminders(reminders []string) (*calendar.EventReminders, error) {
+func buildReminders(reminders []string, noReminders bool) (*calendar.EventReminders, error) {
+	if noReminders {
+		if len(reminders) != 0 {
+			return nil, usage("cannot use both --reminder and --no-reminders")
+		}
+		return &calendar.EventReminders{
+			Overrides:       []*calendar.EventReminder{},
+			ForceSendFields: []string{"UseDefault", "Overrides"},
+		}, nil
+	}
+
 	if len(reminders) == 0 {
 		return nil, nil
 	}

--- a/internal/cmd/calendar_edit.go
+++ b/internal/cmd/calendar_edit.go
@@ -32,7 +32,8 @@ type CalendarCreateCmd struct {
 	Attendees             string   `name:"attendees" help:"Comma-separated attendee emails; modifiers: ;optional, ;resource, ;comment=TEXT"`
 	AllDay                bool     `name:"all-day" help:"All-day event (use date-only in --from/--to)"`
 	Recurrence            []string `name:"rrule" help:"Recurrence rules (e.g., 'RRULE:FREQ=MONTHLY;BYMONTHDAY=11'). Can be repeated." sep:"none"`
-	Reminders             []string `name:"reminder" help:"Custom reminders as method:duration (e.g., popup:30m, email:1d). Can be repeated (max 5)."`
+	Reminders             []string `name:"reminder" xor:"reminders" help:"Custom reminders as method:duration (e.g., popup:30m, email:1d). Can be repeated (max 5)."`
+	NoReminders           bool     `name:"no-reminders" xor:"reminders" help:"Disable all event reminders"`
 	ColorId               string   `name:"event-color" help:"Event color ID (1-11). Use 'gog calendar colors' to see available colors."`
 	Visibility            string   `name:"visibility" help:"Event visibility: default, public, private, confidential"`
 	Transparency          string   `name:"transparency" help:"Show as busy (opaque) or free (transparent). Aliases: busy, free"`
@@ -88,6 +89,7 @@ func calendarCreateInputFromCommand(c *CalendarCreateCmd) calendarCreateInput {
 		AllDay:                c.AllDay,
 		Recurrence:            c.Recurrence,
 		Reminders:             c.Reminders,
+		NoReminders:           c.NoReminders,
 		ColorID:               c.ColorId,
 		Visibility:            c.Visibility,
 		Transparency:          c.Transparency,
@@ -193,7 +195,8 @@ type CalendarUpdateCmd struct {
 	Attachments           []string `name:"attachment" help:"File attachment URL (can be repeated; replaces all; set empty to clear)"`
 	AllDay                bool     `name:"all-day" help:"All-day event (use date-only in --from/--to)"`
 	Recurrence            []string `name:"rrule" help:"Recurrence rules (e.g., 'RRULE:FREQ=MONTHLY;BYMONTHDAY=11'). Can be repeated. Set empty to clear." sep:"none"`
-	Reminders             []string `name:"reminder" help:"Custom reminders as method:duration (e.g., popup:30m, email:1d). Can be repeated (max 5). Set empty to clear."`
+	Reminders             []string `name:"reminder" xor:"reminders" help:"Custom reminders as method:duration (e.g., popup:30m, email:1d). Can be repeated (max 5). Set empty to restore calendar defaults."`
+	NoReminders           bool     `name:"no-reminders" xor:"reminders" help:"Disable all event reminders"`
 	ColorId               string   `name:"event-color" help:"Event color ID (1-11, or empty to clear)"`
 	Visibility            string   `name:"visibility" help:"Event visibility: default, public, private, confidential"`
 	Transparency          string   `name:"transparency" help:"Show as busy (opaque) or free (transparent). Aliases: busy, free"`
@@ -292,6 +295,7 @@ func calendarUpdateInputFromCommand(c *CalendarUpdateCmd) calendarUpdateInput {
 		AllDay:                c.AllDay,
 		Recurrence:            c.Recurrence,
 		Reminders:             c.Reminders,
+		NoReminders:           c.NoReminders,
 		ColorID:               c.ColorId,
 		Visibility:            c.Visibility,
 		Transparency:          c.Transparency,

--- a/internal/cmd/calendar_edit_test.go
+++ b/internal/cmd/calendar_edit_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/alecthomas/kong"
@@ -85,6 +86,54 @@ func TestCalendarUpdatePatchClearsReminders(t *testing.T) {
 	}
 	if !hasForceSendField(patch.ForceSendFields, "Reminders") {
 		t.Fatalf("expected Reminders in ForceSendFields")
+	}
+}
+
+func TestCalendarUpdatePatchDisablesReminders(t *testing.T) {
+	cmd := &CalendarUpdateCmd{}
+	kctx := parseKongContext(t, cmd, []string{"cal1", "evt1", "--no-reminders"})
+
+	patch, changed, err := buildCalendarUpdatePatch(calendarUpdateInputFromCommand(cmd), calendarUpdateFieldsFromKong(kctx))
+	if err != nil {
+		t.Fatalf("buildUpdatePatch: %v", err)
+	}
+	if !changed || patch.Reminders == nil || patch.Reminders.UseDefault || patch.Reminders.Overrides == nil {
+		t.Fatalf("expected explicitly disabled reminders, got changed=%t reminders=%#v", changed, patch.Reminders)
+	}
+	for _, field := range []string{"UseDefault", "Overrides"} {
+		if !hasForceSendField(patch.Reminders.ForceSendFields, field) {
+			t.Fatalf("expected %s in reminders ForceSendFields", field)
+		}
+	}
+}
+
+func TestCalendarReminderFlagsAreMutuallyExclusive(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "create empty reminder",
+			args: []string{"--dry-run", "calendar", "create", "primary", "--summary", "test", "--from", "2030-01-01", "--to", "2030-01-02", "--all-day", "--reminder=", "--no-reminders"},
+		},
+		{
+			name: "update empty reminder",
+			args: []string{"--dry-run", "calendar", "update", "primary", "event", "--reminder=", "--no-reminders"},
+		},
+		{
+			name: "update custom reminder",
+			args: []string{"--dry-run", "calendar", "update", "primary", "event", "--reminder", "popup:30m", "--no-reminders"},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			result := executeWithTestRuntime(t, test.args, nil)
+			if result.err == nil || !strings.Contains(result.err.Error(), "can't be used together") {
+				t.Fatalf("expected conflicting reminder flags, got %v", result.err)
+			}
+			if code := ExitCode(result.err); code != 2 {
+				t.Fatalf("expected usage exit code 2, got %d", code)
+			}
+		})
 	}
 }
 

--- a/internal/cmd/calendar_event_plan.go
+++ b/internal/cmd/calendar_event_plan.go
@@ -42,6 +42,7 @@ type calendarCreateInput struct {
 	AllDay                bool
 	Recurrence            []string
 	Reminders             []string
+	NoReminders           bool
 	ColorID               string
 	Visibility            string
 	Transparency          string
@@ -146,6 +147,7 @@ type calendarUpdateInput struct {
 	AllDay                bool
 	Recurrence            []string
 	Reminders             []string
+	NoReminders           bool
 	ColorID               string
 	Visibility            string
 	Transparency          string
@@ -351,7 +353,7 @@ func buildCalendarCreatePlan(store *config.ConfigStore, input calendarCreateInpu
 	if err != nil {
 		return nil, err
 	}
-	reminders, err := buildReminders(input.Reminders)
+	reminders, err := buildReminders(input.Reminders, input.NoReminders)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cmd/calendar_test.go
+++ b/internal/cmd/calendar_test.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -324,22 +326,22 @@ func TestParseReminder(t *testing.T) {
 }
 
 func TestBuildReminders(t *testing.T) {
-	got, err := buildReminders(nil)
+	got, err := buildReminders(nil, false)
 	if err != nil || got != nil {
 		t.Fatalf("expected (nil, nil), got (%#v, %v)", got, err)
 	}
 
-	got, err = buildReminders([]string{})
+	got, err = buildReminders([]string{}, false)
 	if err != nil || got != nil {
 		t.Fatalf("expected (nil, nil), got (%#v, %v)", got, err)
 	}
 
-	got, err = buildReminders([]string{"", "  "})
+	got, err = buildReminders([]string{"", "  "}, false)
 	if err != nil || got != nil {
 		t.Fatalf("expected (nil, nil), got (%#v, %v)", got, err)
 	}
 
-	got, err = buildReminders([]string{"popup:30m", "email:1d"})
+	got, err = buildReminders([]string{"popup:30m", "email:1d"}, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -356,7 +358,7 @@ func TestBuildReminders(t *testing.T) {
 		t.Fatalf("unexpected override[1]: %#v", got.Overrides[1])
 	}
 
-	got, err = buildReminders([]string{"popup:0m"})
+	got, err = buildReminders([]string{"popup:0m"}, false)
 	if err != nil {
 		t.Fatalf("unexpected error for 0-minute reminder: %v", err)
 	}
@@ -370,7 +372,7 @@ func TestBuildReminders(t *testing.T) {
 		t.Fatalf("expected Minutes to be force-sent for 0-minute reminder, got %#v", got.Overrides[0].ForceSendFields)
 	}
 
-	_, err = buildReminders([]string{"popup:1m", "popup:2m", "popup:3m", "popup:4m", "popup:5m", "popup:6m"})
+	_, err = buildReminders([]string{"popup:1m", "popup:2m", "popup:3m", "popup:4m", "popup:5m", "popup:6m"}, false)
 	if err == nil {
 		t.Fatalf("expected error for >5 reminders")
 	}
@@ -378,12 +380,34 @@ func TestBuildReminders(t *testing.T) {
 		t.Fatalf("expected usage exit code 2, got %d (err=%v)", got, err)
 	}
 
-	_, err = buildReminders([]string{"popup:30m", "invalid"})
+	_, err = buildReminders([]string{"popup:30m", "invalid"}, false)
 	if err == nil {
 		t.Fatalf("expected error for invalid reminder")
 	}
 	if got := ExitCode(err); got != 2 {
 		t.Fatalf("expected usage exit code 2, got %d (err=%v)", got, err)
+	}
+}
+
+func TestBuildRemindersDisabled(t *testing.T) {
+	got, err := buildReminders(nil, true)
+	if err != nil {
+		t.Fatalf("build disabled reminders: %v", err)
+	}
+	encoded, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("marshal disabled reminders: %v", err)
+	}
+	if string(encoded) != `{"overrides":[],"useDefault":false}` {
+		t.Fatalf("disabled reminders payload = %s", encoded)
+	}
+
+	_, err = buildReminders([]string{"popup:30m"}, true)
+	if err == nil || !strings.Contains(err.Error(), "--reminder and --no-reminders") {
+		t.Fatalf("expected mutually exclusive reminder flags, got %v", err)
+	}
+	if got := ExitCode(err); got != 2 {
+		t.Fatalf("expected usage exit code 2, got %d", got)
 	}
 }
 

--- a/internal/cmd/calendar_update_patch_plan.go
+++ b/internal/cmd/calendar_update_patch_plan.go
@@ -256,10 +256,10 @@ func cloneEventDateTime(in *calendar.EventDateTime) *calendar.EventDateTime {
 }
 
 func applyUpdateReminders(input calendarUpdateInput, fields calendarUpdateFields, patch *calendar.Event) (bool, error) {
-	if !fields.Reminders {
+	if !fields.Reminders && !input.NoReminders {
 		return false, nil
 	}
-	reminders, err := buildReminders(input.Reminders)
+	reminders, err := buildReminders(input.Reminders, input.NoReminders)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
Fixes #1002.

Add mutually exclusive `--no-reminders` flags to Calendar event creation and updates. Explicitly send `{"overrides":[],"useDefault":false}` to suppress all reminders while preserving empty `--reminder=` as the separately tested restore-calendar-defaults operation.

Verified against the designated live Google account with a disposable event: create without reminders, set a ten-minute custom reminder, update back to no reminders, restore the account's independently verified thirty-minute calendar default, and delete the event.

Includes exact JSON payload regressions, flag-conflict coverage, generated command documentation, and the full repository CI gate.
