### PR TITLE
fix(auth): explain Google account requirements before OAuth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Auth: explain Google Account requirements before OAuth while preserving existing services during reauthorization. (#1014)
 - Calendar: add `--no-reminders` to event creation and updates so calendar-default reminders can be explicitly disabled. (#1002)
 - Slides: add skip/unskip commands and expose slide visibility without changing existing plain-text output. (#1009) — thanks @marnunez.
 - Config: serialize concurrent updates with shared platform-native file locks, preventing intermittent access-denied failures on Windows.

--- a/docs/commands.generated.md
+++ b/docs/commands.generated.md
@@ -35,7 +35,7 @@ Generated from `gog schema --json`.
     - [`gog appscript (script,apps-script) get (info,show) <scriptId>`](commands/gog-appscript-get.md) - Get Apps Script project metadata
     - [`gog appscript (script,apps-script) run <scriptId> <function> [flags]`](commands/gog-appscript-run.md) - Run a deployed Apps Script function
   - [`gog auth <command> [flags]`](commands/gog-auth.md) - Auth and credentials
-    - [`gog auth add <email> [flags]`](commands/gog-auth-add.md) - Authorize and store a refresh token
+    - [`gog auth add <email> [flags]`](commands/gog-auth-add.md) - Authorize a Google Account or Google Workspace account and store a refresh token
     - [`gog auth alias <command>`](commands/gog-auth-alias.md) - Manage account aliases
       - [`gog auth alias list`](commands/gog-auth-alias-list.md) - List account aliases
       - [`gog auth alias set <alias> <email>`](commands/gog-auth-alias-set.md) - Set an account alias

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -88,7 +88,7 @@ Generated pages: 721.
     - [gog appscript get](gog-appscript-get.md) - Get Apps Script project metadata
     - [gog appscript run](gog-appscript-run.md) - Run a deployed Apps Script function
   - [gog auth](gog-auth.md) - Auth and credentials
-    - [gog auth add](gog-auth-add.md) - Authorize and store a refresh token
+    - [gog auth add](gog-auth-add.md) - Authorize a Google Account or Google Workspace account and store a refresh token
     - [gog auth alias](gog-auth-alias.md) - Manage account aliases
       - [gog auth alias list](gog-auth-alias-list.md) - List account aliases
       - [gog auth alias set](gog-auth-alias-set.md) - Set an account alias

--- a/docs/commands/gog-auth-add.md
+++ b/docs/commands/gog-auth-add.md
@@ -2,7 +2,7 @@
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Authorize and store a refresh token
+Authorize a Google Account or Google Workspace account and store a refresh token
 
 ## Usage
 

--- a/docs/commands/gog-auth.md
+++ b/docs/commands/gog-auth.md
@@ -16,7 +16,7 @@ gog auth <command> [flags]
 
 ## Subcommands
 
-- [gog auth add](gog-auth-add.md) - Authorize and store a refresh token
+- [gog auth add](gog-auth-add.md) - Authorize a Google Account or Google Workspace account and store a refresh token
 - [gog auth alias](gog-auth-alias.md) - Manage account aliases
 - [gog auth credentials](gog-auth-credentials.md) - Manage OAuth client credentials
 - [gog auth doctor](gog-auth-doctor.md) - Diagnose auth, keyring, and refresh-token issues

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -88,6 +88,12 @@ refresh token in your OS keyring (Keychain on macOS, Secret Service on Linux,
 Credential Manager on Windows). Headless? Add `--manual` for a paste-the-URL
 flow, or `--remote --step 1`/`--step 2` for fully split server runs.
 
+The address must belong to a personal Google Account or a Google Workspace
+account; an ordinary mailbox outside Google cannot complete Google OAuth. Custom
+domains can still belong to either kind of Google account. If Google rejects
+consent, retry with an explicit `--services` list; preserve any existing
+services when reauthorizing an account.
+
 Installed-app authorization uses S256 PKCE. Complete a manual or remote flow
 with the same `gog` home and client that generated its URL. After upgrading
 from a pre-PKCE release, restart any unfinished flow at step 1.

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -110,7 +110,7 @@ const (
 type AuthCmd struct {
 	Setup       AuthSetupCmd          `cmd:"" name:"setup" help:"Guide Google Cloud, OAuth client, and account setup"`
 	Credentials AuthCredentialsCmd    `cmd:"" name:"credentials" help:"Manage OAuth client credentials"`
-	Add         AuthAddCmd            `cmd:"" name:"add" help:"Authorize and store a refresh token"`
+	Add         AuthAddCmd            `cmd:"" name:"add" help:"Authorize a Google Account or Google Workspace account and store a refresh token"`
 	Import      AuthImportCmd         `cmd:"" name:"import" help:"Import a required refresh token and optional current access token non-interactively"`
 	Services    AuthServicesCmd       `cmd:"" name:"services" help:"List supported auth services and scopes"`
 	List        AuthListCmd           `cmd:"" name:"list" help:"List stored accounts"`

--- a/internal/cmd/auth_add.go
+++ b/internal/cmd/auth_add.go
@@ -16,7 +16,7 @@ import (
 )
 
 type AuthAddCmd struct {
-	Email        string        `arg:"" name:"email" help:"Email"`
+	Email        string        `arg:"" name:"email" help:"Google Account or Google Workspace email (ordinary non-Google mailboxes cannot authorize)"`
 	Manual       bool          `name:"manual" help:"Browserless auth flow (paste redirect URL)"`
 	Remote       bool          `name:"remote" help:"Remote/server-friendly manual flow (print URL, then exchange code)"`
 	Step         int           `name:"step" help:"Remote auth step: 1=print URL, 2=exchange code"`
@@ -32,6 +32,8 @@ type AuthAddCmd struct {
 	GmailScope   string        `name:"gmail-scope" help:"Gmail scope mode: full|readonly" enum:"full,readonly" default:"full"`
 	ExtraScopes  string        `name:"extra-scopes" help:"Comma-separated list of additional OAuth scope URIs to request (appended after service scopes)"`
 }
+
+const googleAccountAuthorizationHint = "Google sign-in requires a Google Account or Google Workspace account; if consent fails, retry with explicit --services and preserve existing services when reauthorizing."
 
 func formatRemoteStep2Instruction(services []googleauth.Service, c *AuthAddCmd, readonly bool) string {
 	parts := []string{"--remote", "--step", "2", "--auth-url", "<redirect-url>"}
@@ -164,6 +166,7 @@ func (c *AuthAddCmd) Run(ctx context.Context, flags *RootFlags) error {
 			if authURL != "" || authCode != "" {
 				return usage("remote step 1 does not accept --auth-url or --auth-code")
 			}
+			u.Err().Println(googleAccountAuthorizationHint)
 			result, manualErr := buildManualAuthURL(ctx, googleauth.AuthorizeOptions{
 				Services:                    services,
 				Scopes:                      scopes,
@@ -225,6 +228,7 @@ func (c *AuthAddCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return fmt.Errorf("keychain access: %w", keychainErr)
 	}
 
+	u.Err().Println(googleAccountAuthorizationHint)
 	refreshToken, err := authorizeGoogleAccount(ctx, googleauth.AuthorizeOptions{
 		Services:                    services,
 		Scopes:                      scopes,

--- a/internal/cmd/auth_add_test.go
+++ b/internal/cmd/auth_add_test.go
@@ -116,6 +116,45 @@ func TestAuthAddCmd_JSON(t *testing.T) {
 	}
 }
 
+func TestAuthAddCmd_ExplainsGoogleAccountRequirementBeforeOAuth(t *testing.T) {
+	providerError := errors.New("provider rejected authorization")
+	authorizationStarted := false
+	runtime := runtimeWithAuthTestOperations(
+		nil,
+		func(context.Context, googleauth.AuthorizeOptions) (string, error) {
+			authorizationStarted = true
+			return "", providerError
+		},
+		func(context.Context) error { return nil },
+		nil,
+	)
+	result := executeWithTestRuntime(t, []string{
+		"--json", "auth", "add", "user@custom-domain.example", "--services", "gmail",
+	}, runtime)
+	if !authorizationStarted || !errors.Is(result.err, providerError) {
+		t.Fatalf("authorizationStarted = %t, err = %v", authorizationStarted, result.err)
+	}
+	for _, want := range []string{
+		"Google Account or Google Workspace account",
+		"--services",
+		"preserve existing services",
+	} {
+		if !strings.Contains(result.stderr, want) {
+			t.Fatalf("stderr = %q, want %q", result.stderr, want)
+		}
+	}
+	if result.stdout != "" {
+		t.Fatalf("authorization guidance leaked into JSON stdout: %q", result.stdout)
+	}
+}
+
+func TestAuthAddCmd_HelpDocumentsGoogleAccountRequirement(t *testing.T) {
+	result := executeWithTestRuntime(t, []string{"auth", "add", "--help"}, nil)
+	if result.err != nil || !strings.Contains(result.stdout, "Google Account or Google Workspace email") {
+		t.Fatalf("auth add help = %q, err = %v", result.stdout, result.err)
+	}
+}
+
 func TestAuthAddCmd_KeychainError(t *testing.T) {
 	t.Setenv("GOG_KEYRING_BACKEND", "keychain")
 
@@ -778,6 +817,9 @@ func TestAuthAddCmd_RemoteStep1_PrintsAuthURL(t *testing.T) {
 	}
 	if !strings.Contains(result.stderr, "Run again with the same root flags and --remote --step 2 --auth-url <redirect-url> --services gmail --readonly") {
 		t.Fatalf("expected step 2 guidance to preserve replay flags, got: %q", result.stderr)
+	}
+	if !strings.Contains(result.stderr, googleAccountAuthorizationHint) {
+		t.Fatalf("expected Google account guidance before remote OAuth, got: %q", result.stderr)
 	}
 }
 

--- a/scripts/gen-command-reference.sh
+++ b/scripts/gen-command-reference.sh
@@ -14,7 +14,7 @@ if [ ! -x "$BIN" ]; then
   make -C "$ROOT_DIR" build >/dev/null
 fi
 
-schema_file="$(mktemp "${TMPDIR:-/tmp}/gog-schema-XXXXXX.json")"
+schema_file="$(mktemp "${TMPDIR:-/tmp}/gog-schema.XXXXXX")"
 schema_config_home="$(mktemp -d "${TMPDIR:-/tmp}/gog-schema-config-XXXXXX")"
 cleanup() {
   rm -f "$schema_file"


### PR DESCRIPTION
Fixes #1014.

Explain that Google OAuth requires a personal Google Account or Google Workspace account before normal and remote authorization. Keep custom-domain accounts valid, write guidance only to stderr, and preserve existing service grants when recommending explicit reauthorization scopes.

Update quickstart and generated auth command documentation. Also fix the documentation generator's predictable BSD/macOS temporary-file template by moving its six random characters to the end.

Verified normal/remote pre-OAuth guidance, custom-domain acceptance, JSON stdout isolation, existing authorization-service preservation, generated command documentation, and the full repository CI gate.
