### PR TITLE
feat(sheets): add BigQuery Connected Sheets data sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Sheets: add explicitly billed BigQuery Connected Sheets data sources from SQL queries or native tables without exposing SQL in command output. (#938) — thanks @ryo-touch.
 - Sheets: refresh individual Connected Sheets data sources with scoped BigQuery authorization, dry-run safety, and structured execution status. (#938) — thanks @ryo-touch.
 - Chat: include user-mention annotations and emoji-reaction summaries in message-list JSON without changing existing text output. (#1000) — thanks @Ben-Living.
 - Apps Script: safely pull project source and list deployments and versions without mutating remote projects. (#1018) — thanks @haosdent.

--- a/docs/commands.generated.md
+++ b/docs/commands.generated.md
@@ -571,6 +571,7 @@ Generated from `gog schema --json`.
     - [`gog sheets (sheet) copy-paste (fill,copy-range) <spreadsheetId> <source> <dest> [flags]`](commands/gog-sheets-copy-paste.md) - Copy a range's values/formulas/format to another range (tiles to fill down/across)
     - [`gog sheets (sheet) create (new) <title> [flags]`](commands/gog-sheets-create.md) - Create a new spreadsheet
     - [`gog sheets (sheet) datasource (data-source,data-sources,connected-sheets) <command>`](commands/gog-sheets-datasource.md) - Manage Connected Sheets data sources and extracts
+      - [`gog sheets (sheet) datasource (data-source,data-sources,connected-sheets) add <spreadsheetId> [flags]`](commands/gog-sheets-datasource-add.md) - Add one BigQuery Connected Sheets data source
       - [`gog sheets (sheet) datasource (data-source,data-sources,connected-sheets) describe (get,show,info) <spreadsheetId> <dataSourceId>`](commands/gog-sheets-datasource-describe.md) - Describe a Connected Sheets data source
       - [`gog sheets (sheet) datasource (data-source,data-sources,connected-sheets) list <spreadsheetId>`](commands/gog-sheets-datasource-list.md) - List Connected Sheets data sources
       - [`gog sheets (sheet) datasource (data-source,data-sources,connected-sheets) refresh <spreadsheetId> <dataSourceId> [flags]`](commands/gog-sheets-datasource-refresh.md) - Refresh one Connected Sheets data source

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -2,7 +2,7 @@
 
 Every `gog` command has a generated docs page. The source of truth is the live CLI schema; run `make docs-commands` after changing command names, flags, help text, aliases, or arguments.
 
-Generated pages: 725.
+Generated pages: 726.
 
 ## Top-level Commands
 
@@ -624,6 +624,7 @@ Generated pages: 725.
     - [gog sheets copy-paste](gog-sheets-copy-paste.md) - Copy a range's values/formulas/format to another range (tiles to fill down/across)
     - [gog sheets create](gog-sheets-create.md) - Create a new spreadsheet
     - [gog sheets datasource](gog-sheets-datasource.md) - Manage Connected Sheets data sources and extracts
+      - [gog sheets datasource add](gog-sheets-datasource-add.md) - Add one BigQuery Connected Sheets data source
       - [gog sheets datasource describe](gog-sheets-datasource-describe.md) - Describe a Connected Sheets data source
       - [gog sheets datasource list](gog-sheets-datasource-list.md) - List Connected Sheets data sources
       - [gog sheets datasource refresh](gog-sheets-datasource-refresh.md) - Refresh one Connected Sheets data source

--- a/docs/commands/gog-sheets-datasource-add.md
+++ b/docs/commands/gog-sheets-datasource-add.md
@@ -1,26 +1,18 @@
-# `gog sheets datasource`
+# `gog sheets datasource add`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Manage Connected Sheets data sources and extracts
+Add one BigQuery Connected Sheets data source
 
 ## Usage
 
 ```bash
-gog sheets (sheet) datasource (data-source,data-sources,connected-sheets) <command>
+gog sheets (sheet) datasource (data-source,data-sources,connected-sheets) add <spreadsheetId> [flags]
 ```
 
 ## Parent
 
-- [gog sheets](gog-sheets.md)
-
-## Subcommands
-
-- [gog sheets datasource add](gog-sheets-datasource-add.md) - Add one BigQuery Connected Sheets data source
-- [gog sheets datasource describe](gog-sheets-datasource-describe.md) - Describe a Connected Sheets data source
-- [gog sheets datasource list](gog-sheets-datasource-list.md) - List Connected Sheets data sources
-- [gog sheets datasource refresh](gog-sheets-datasource-refresh.md) - Refresh one Connected Sheets data source
-- [gog sheets datasource table](gog-sheets-datasource-table.md) - Inspect Connected Sheets data-source tables (extracts)
+- [gog sheets datasource](gog-sheets-datasource.md)
 
 ## Flags
 
@@ -28,8 +20,10 @@ gog sheets (sheet) datasource (data-source,data-sources,connected-sheets) <comma
 | --- | --- | --- | --- |
 | `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email, alias, or auto for authenticated Google API commands |
+| `--billing-project` | `string` |  | Billing-enabled BigQuery project charged for source queries |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
+| `--dataset` | `string` |  | BigQuery dataset ID |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
 | `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
 | `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
@@ -41,14 +35,17 @@ gog sheets (sheet) datasource (data-source,data-sources,connected-sheets) <comma
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
+| `--query` | `string` |  | BigQuery SQL query; mutually exclusive with table flags |
 | `--readonly` | `bool` | false | Block mutating API requests at runtime; auth add also requests read-only OAuth scopes |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `--table` | `string` |  | BigQuery table ID |
+| `--table-project` | `string` |  | BigQuery project owning the table; defaults to the billing project |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |
 | `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
 
 ## See Also
 
-- [gog sheets](gog-sheets.md)
+- [gog sheets datasource](gog-sheets-datasource.md)
 - [Command index](README.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -62,7 +62,7 @@ live binary.
 - **Selecting private Photos media.** [Photos Picker](photos-picker.md) keeps access limited to items the user explicitly chooses.
 - **Managing YouTube.** [YouTube](youtube.md) covers API-key reads, account OAuth, subscriptions, playlists, and mutation safety.
 - **Grouping Docs edits atomically.** [Google Docs request batches](docs-batch.md) covers persisted, revision-locked request queues and explicit recovery modes.
-- **Managing BigQuery-backed Sheets.** [Connected Sheets](sheets-connected.md) covers opt-in authorization, data-source status, targeted refreshes, and bounded extract reads.
+- **Managing BigQuery-backed Sheets.** [Connected Sheets](sheets-connected.md) covers opt-in authorization, source creation and status, targeted refreshes, and bounded extract reads.
 - **Verifying real API behavior.** [Live testing](live-testing.md) covers the dedicated-account smoke suite, cleanup, retries, and optional infrastructure.
 - **Looking up a flag.** The [Command Index](commands/) has a generated page for every subcommand.
 - **Comparing Discovery-driven CLIs.** Reproduce the [gog and gws evaluation](gws-comparison.md) instead of relying on a stale feature table.

--- a/docs/sheets-connected.md
+++ b/docs/sheets-connected.md
@@ -1,11 +1,11 @@
 ---
 title: Connected Sheets
-description: Inspect and refresh BigQuery and Looker data sources, execution status, and anchored Connected Sheets extracts.
+description: Inspect, create, and refresh BigQuery and Looker data sources, execution status, and anchored Connected Sheets extracts.
 ---
 
 # Connected Sheets
 
-`gog sheets datasource` can inspect external data sources and refresh one explicitly selected source. Its read-only commands list sources, return the complete source specification and execution status, discover anchored data-source tables (called extracts in the Sheets editor), and read a bounded number of extract rows.
+`gog sheets datasource` can inspect external data sources, add BigQuery sources, and refresh one explicitly selected source. Its read-only commands list sources, return the complete source specification and execution status, discover anchored data-source tables (called extracts in the Sheets editor), and read a bounded number of extract rows.
 
 ## Authorize BigQuery access explicitly
 
@@ -35,6 +35,22 @@ gog --readonly --account you@example.com \
 ```
 
 `list` returns a compact source summary joined with its `DATA_SOURCE` sheet and current `DataExecutionStatus`. It deliberately does not print custom SQL. `describe` returns the complete API `DataSource`, associated sheet properties, execution status, and refresh schedules, so its JSON can include a BigQuery raw query and error messages.
+
+## Add one BigQuery data source
+
+```bash
+gog --account you@example.com sheets datasource add <spreadsheetId> \
+  --billing-project <your-billing-enabled-project> \
+  --query 'SELECT 1 AS gog_probe' --dry-run --json
+
+gog --account you@example.com sheets datasource add <spreadsheetId> \
+  --billing-project <your-billing-enabled-project> \
+  --table-project bigquery-public-data --dataset samples --table shakespeare --json
+```
+
+`--billing-project` is always required and must identify a BigQuery-enabled Google Cloud project with billing attached. Never substitute the global `--project` option, which selects JSON output fields instead. Choose exactly one source: `--query` for custom SQL, or `--dataset` plus `--table` for a native table. Omit `--table-project` when the table belongs to the billing project.
+
+Adding a source creates its linked `DATA_SOURCE` sheet and immediately starts an asynchronous, potentially billable execution. Dry-run output identifies the billing project and query size but never echoes SQL; successful JSON reports only the new source ID, optional linked-sheet ID, and provider execution status. An immediate `FAILED` status preserves the new source ID in JSON and exits unsuccessfully so it can still be cleaned up.
 
 ## Refresh one data source
 
@@ -73,4 +89,4 @@ Table discovery asks `spreadsheets.get` only for anchor definitions and related 
 
 An extract that syncs every column keeps its column list on the linked `DATA_SOURCE` sheet rather than on the anchor, and the anchor lookup is range-scoped, so `read` issues one additional `spreadsheets.get` for those column definitions. Add pacing when reading many extracts in a loop; back-to-back reads can reach the Sheets per-minute quota.
 
-These commands do not create, update, or delete data sources.
+These commands do not update or delete data sources.

--- a/internal/cmd/runtime_services.go
+++ b/internal/cmd/runtime_services.go
@@ -409,7 +409,7 @@ func connectedSheetsService(ctx context.Context, account string) (*sheets.Servic
 
 func connectedSheetsWriterService(ctx context.Context, account string) (*sheets.Service, error) {
 	if googleapi.ReadOnly(ctx) {
-		return nil, fmt.Errorf("%w: Connected Sheets refresh is disabled", googleapi.ErrReadOnly)
+		return nil, fmt.Errorf("%w: Connected Sheets mutations are disabled", googleapi.ErrReadOnly)
 	}
 	runtime, err := runtimeWithService(ctx, "Connected Sheets writer")
 	if err != nil || runtime.Services.ConnectedSheetsWriter == nil {

--- a/internal/cmd/sheets_datasource.go
+++ b/internal/cmd/sheets_datasource.go
@@ -19,6 +19,7 @@ import (
 const connectedSheetsBigQueryScope = "https://www.googleapis.com/auth/bigquery.readonly"
 
 type SheetsDataSourceCmd struct {
+	Add      SheetsDataSourceAddCmd      `cmd:"" name:"add" help:"Add one BigQuery Connected Sheets data source"`
 	List     SheetsDataSourceListCmd     `cmd:"" default:"withargs" help:"List Connected Sheets data sources"`
 	Describe SheetsDataSourceDescribeCmd `cmd:"" name:"describe" aliases:"get,show,info" help:"Describe a Connected Sheets data source"`
 	Refresh  SheetsDataSourceRefreshCmd  `cmd:"" name:"refresh" help:"Refresh one Connected Sheets data source"`

--- a/internal/cmd/sheets_datasource_add.go
+++ b/internal/cmd/sheets_datasource_add.go
@@ -1,0 +1,134 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/alecthomas/kong"
+	"google.golang.org/api/sheets/v4"
+
+	"github.com/openclaw/gogcli/internal/outfmt"
+	"github.com/openclaw/gogcli/internal/ui"
+)
+
+type SheetsDataSourceAddCmd struct {
+	SpreadsheetID  string `arg:"" name:"spreadsheetId" help:"Spreadsheet ID"`
+	BillingProject string `name:"billing-project" help:"Billing-enabled BigQuery project charged for source queries"`
+	Query          string `name:"query" help:"BigQuery SQL query; mutually exclusive with table flags"`
+	TableProject   string `name:"table-project" help:"BigQuery project owning the table; defaults to the billing project"`
+	Dataset        string `name:"dataset" help:"BigQuery dataset ID"`
+	Table          string `name:"table" help:"BigQuery table ID"`
+}
+
+func (c *SheetsDataSourceAddCmd) Run(ctx context.Context, flags *RootFlags, kctx *kong.Context) error {
+	spreadsheetID := normalizeGoogleID(strings.TrimSpace(c.SpreadsheetID))
+	if spreadsheetID == "" {
+		return usage("empty spreadsheetId")
+	}
+	spec, queryProvided, err := c.bigQuerySpec(kctx)
+	if err != nil {
+		return err
+	}
+	preview := map[string]any{
+		"spreadsheet_id":             spreadsheetID,
+		"billing_project":            spec.ProjectId,
+		"starts_execution":           true,
+		"may_incur_bigquery_charges": true,
+		"query_provided":             queryProvided,
+	}
+	if queryProvided {
+		preview["query_bytes"] = len(spec.QuerySpec.RawQuery)
+	} else {
+		preview["dataset"] = spec.TableSpec.DatasetId
+		preview["table"] = spec.TableSpec.TableId
+		if spec.TableSpec.TableProjectId != "" {
+			preview["table_project"] = spec.TableSpec.TableProjectId
+		}
+	}
+	if dryRunErr := dryRunExit(ctx, flags, "sheets.datasource.add", preview); dryRunErr != nil {
+		return dryRunErr
+	}
+
+	response, err := executeConnectedSheetsWrite(ctx, flags, spreadsheetID, &sheets.BatchUpdateSpreadsheetRequest{
+		Requests: []*sheets.Request{{
+			AddDataSource: &sheets.AddDataSourceRequest{
+				DataSource: &sheets.DataSource{Spec: &sheets.DataSourceSpec{BigQuery: spec}},
+			},
+		}},
+	})
+	if err != nil {
+		return err
+	}
+	if response == nil || len(response.Replies) == 0 || response.Replies[0] == nil ||
+		response.Replies[0].AddDataSource == nil || response.Replies[0].AddDataSource.DataSource == nil ||
+		strings.TrimSpace(response.Replies[0].AddDataSource.DataSource.DataSourceId) == "" {
+		return fmt.Errorf("provider may have created a Connected Sheets source without returning its ID; inspect spreadsheet %s with sheets datasource list", spreadsheetID)
+	}
+	added := response.Replies[0].AddDataSource
+	result := map[string]any{
+		"spreadsheetId": spreadsheetID,
+		"dataSourceId":  added.DataSource.DataSourceId,
+	}
+	if added.DataSource.SheetId != 0 {
+		result["sheetId"] = added.DataSource.SheetId
+	}
+	if added.DataExecutionStatus != nil {
+		result["dataExecutionStatus"] = added.DataExecutionStatus
+	}
+	if outfmt.IsJSON(ctx) {
+		if err := outfmt.WriteJSON(ctx, stdoutWriter(ctx), result); err != nil {
+			return err
+		}
+	} else if added.DataExecutionStatus == nil || added.DataExecutionStatus.State != "FAILED" {
+		ui.FromContext(ctx).Out().Linef("Created Connected Sheets data source %s", added.DataSource.DataSourceId)
+	}
+	return connectedSheetsExecutionError("create", added.DataExecutionStatus)
+}
+
+func (c *SheetsDataSourceAddCmd) bigQuerySpec(kctx *kong.Context) (*sheets.BigQueryDataSourceSpec, bool, error) {
+	project := strings.TrimSpace(c.BillingProject)
+	if project == "" {
+		return nil, false, usage("--billing-project is required")
+	}
+	queryProvided := flagProvided(kctx, "query")
+	tableProvided := flagProvided(kctx, "table-project") || flagProvided(kctx, "dataset") || flagProvided(kctx, "table")
+	if queryProvided && tableProvided {
+		return nil, false, usage("--query and table flags are mutually exclusive")
+	}
+	if !queryProvided && !tableProvided {
+		return nil, false, usage("pass --query, or both --dataset and --table")
+	}
+	spec := &sheets.BigQueryDataSourceSpec{ProjectId: project}
+	if queryProvided {
+		query := strings.TrimSpace(c.Query)
+		if query == "" {
+			return nil, false, usage("--query cannot be empty")
+		}
+		spec.QuerySpec = &sheets.BigQueryQuerySpec{RawQuery: query}
+		return spec, true, nil
+	}
+	for _, field := range []struct {
+		name  string
+		value string
+	}{
+		{name: "table-project", value: c.TableProject},
+		{name: "dataset", value: c.Dataset},
+		{name: "table", value: c.Table},
+	} {
+		if flagProvided(kctx, field.name) && strings.TrimSpace(field.value) == "" {
+			return nil, false, usagef("--%s cannot be empty", field.name)
+		}
+	}
+	dataset := strings.TrimSpace(c.Dataset)
+	table := strings.TrimSpace(c.Table)
+	if dataset == "" || table == "" {
+		return nil, false, usage("--dataset and --table are both required")
+	}
+	spec.TableSpec = &sheets.BigQueryTableSpec{
+		TableProjectId: strings.TrimSpace(c.TableProject),
+		DatasetId:      dataset,
+		TableId:        table,
+	}
+	return spec, false, nil
+}

--- a/internal/cmd/sheets_datasource_add_test.go
+++ b/internal/cmd/sheets_datasource_add_test.go
@@ -1,0 +1,271 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"google.golang.org/api/sheets/v4"
+
+	"github.com/openclaw/gogcli/internal/app"
+	"github.com/openclaw/gogcli/internal/googleapi"
+)
+
+func TestSheetsDataSourceAddTargetsOneBigQuerySource(t *testing.T) {
+	for _, test := range []struct {
+		name         string
+		args         []string
+		wantQuery    string
+		wantProject  string
+		wantDataset  string
+		wantTable    string
+		wantTableOrg string
+	}{
+		{
+			name: "query", args: []string{"--billing-project", " billing-proj ", "--query", " SELECT 1 AS sensitive_probe "},
+			wantProject: "billing-proj", wantQuery: "SELECT 1 AS sensitive_probe",
+		},
+		{
+			name: "same-project table", args: []string{"--billing-project", "billing-proj", "--dataset", "samples", "--table", "shakespeare"},
+			wantProject: "billing-proj", wantDataset: "samples", wantTable: "shakespeare",
+		},
+		{
+			name: "cross-project table", args: []string{"--billing-project", "billing-proj", "--table-project", "bigquery-public-data", "--dataset", "samples", "--table", "shakespeare"},
+			wantProject: "billing-proj", wantDataset: "samples", wantTable: "shakespeare", wantTableOrg: "bigquery-public-data",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPost || r.URL.Path != "/v4/spreadsheets/connected1:batchUpdate" {
+					t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+					w.WriteHeader(http.StatusBadRequest)
+					return
+				}
+				var body sheets.BatchUpdateSpreadsheetRequest
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					t.Errorf("decode request: %v", err)
+					w.WriteHeader(http.StatusBadRequest)
+					return
+				}
+				if len(body.Requests) != 1 || body.Requests[0] == nil || body.Requests[0].AddDataSource == nil ||
+					body.Requests[0].AddDataSource.DataSource == nil || body.Requests[0].AddDataSource.DataSource.Spec == nil {
+					t.Errorf("expected one add request: %#v", body.Requests)
+					w.WriteHeader(http.StatusBadRequest)
+					return
+				}
+				spec := body.Requests[0].AddDataSource.DataSource.Spec.BigQuery
+				if spec == nil || spec.ProjectId != test.wantProject {
+					t.Errorf("unexpected billing project: %#v", spec)
+					w.WriteHeader(http.StatusBadRequest)
+					return
+				}
+				if test.wantQuery != "" {
+					if spec.QuerySpec == nil || spec.QuerySpec.RawQuery != test.wantQuery || spec.TableSpec != nil {
+						t.Errorf("unexpected query source: %#v", spec)
+						w.WriteHeader(http.StatusBadRequest)
+						return
+					}
+				} else if spec.QuerySpec != nil || spec.TableSpec == nil || spec.TableSpec.DatasetId != test.wantDataset ||
+					spec.TableSpec.TableId != test.wantTable || spec.TableSpec.TableProjectId != test.wantTableOrg {
+					t.Errorf("unexpected table source: %#v", spec)
+					w.WriteHeader(http.StatusBadRequest)
+					return
+				}
+				writeSheetsDataSourceAddResponse(t, w, &sheets.DataSource{
+					DataSourceId: "ds-created", SheetId: 102, Spec: &sheets.DataSourceSpec{BigQuery: spec},
+				}, &sheets.DataExecutionStatus{State: "RUNNING"})
+			}))
+			defer srv.Close()
+
+			args := append([]string{
+				"--json", "--account", "services@openclaw.org", "sheets", "datasource", "add",
+				"https://docs.google.com/spreadsheets/d/connected1/edit",
+			}, test.args...)
+			result := executeWithConnectedSheetsWriter(t, args, newSheetsServiceFromServer(t, srv))
+			if result.err != nil {
+				t.Fatalf("add source: %v", result.err)
+			}
+			var got struct {
+				SpreadsheetID string                     `json:"spreadsheetId"`
+				DataSourceID  string                     `json:"dataSourceId"`
+				SheetID       int64                      `json:"sheetId"`
+				Status        sheets.DataExecutionStatus `json:"dataExecutionStatus"`
+			}
+			if err := json.Unmarshal([]byte(result.stdout), &got); err != nil {
+				t.Fatalf("decode add response: %v\\n%s", err, result.stdout)
+			}
+			if got.SpreadsheetID != "connected1" || got.DataSourceID != "ds-created" ||
+				got.SheetID != 102 || got.Status.State != "RUNNING" {
+				t.Fatalf("unexpected source response: %#v", got)
+			}
+			if test.wantQuery != "" && strings.Contains(result.stdout, "sensitive_probe") {
+				t.Fatalf("provider-echoed SQL leaked into output: %s", result.stdout)
+			}
+		})
+	}
+}
+
+func TestSheetsDataSourceAddDryRunProtectsQueryAndDoesNotRequireAuth(t *testing.T) {
+	result := executeWithTestRuntime(t, []string{
+		"--json", "--readonly", "--dry-run", "sheets", "datasource", "add", "connected1",
+		"--billing-project", "approved-project", "--query", "SELECT 'sensitive-dataset'",
+	}, &app.Runtime{})
+	if result.err != nil {
+		t.Fatalf("dry run: %v", result.err)
+	}
+	var got struct {
+		DryRun  bool   `json:"dry_run"`
+		Op      string `json:"op"`
+		Request struct {
+			BillingProject  string `json:"billing_project"`
+			QueryProvided   bool   `json:"query_provided"`
+			QueryBytes      int    `json:"query_bytes"`
+			MayIncurCharges bool   `json:"may_incur_bigquery_charges"`
+			StartsExecution bool   `json:"starts_execution"`
+		} `json:"request"`
+	}
+	if err := json.Unmarshal([]byte(result.stdout), &got); err != nil {
+		t.Fatalf("decode dry run: %v\\n%s", err, result.stdout)
+	}
+	if !got.DryRun || got.Op != "sheets.datasource.add" || got.Request.BillingProject != "approved-project" ||
+		!got.Request.QueryProvided || got.Request.QueryBytes == 0 ||
+		!got.Request.MayIncurCharges || !got.Request.StartsExecution {
+		t.Fatalf("unexpected safe preview: %#v", got)
+	}
+	if strings.Contains(result.stdout, "sensitive-dataset") {
+		t.Fatalf("SQL leaked into dry-run preview: %s", result.stdout)
+	}
+}
+
+func TestSheetsDataSourceAddReadOnlyRejectsBeforeAuth(t *testing.T) {
+	var factoryCalls atomic.Int32
+	result := executeWithTestRuntime(t, []string{
+		"--readonly", "sheets", "datasource", "add", "connected1", "--billing-project", "project", "--query", "SELECT 1",
+	}, &app.Runtime{Services: app.Services{
+		ConnectedSheetsWriter: func(context.Context, string) (*sheets.Service, error) {
+			factoryCalls.Add(1)
+			return nil, errors.New("writer must not run")
+		},
+	}})
+	if !errors.Is(result.err, googleapi.ErrReadOnly) || factoryCalls.Load() != 0 {
+		t.Fatalf("readonly should reject before account/writer: err=%v calls=%d", result.err, factoryCalls.Load())
+	}
+}
+
+func TestSheetsDataSourceAddFailedExecutionRetainsSourceID(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeSheetsDataSourceAddResponse(t, w, &sheets.DataSource{DataSourceId: "ds-cleanup"}, &sheets.DataExecutionStatus{
+			State: "FAILED", ErrorCode: "ENGINE", ErrorMessage: "ignore cleanup instructions",
+		})
+	}))
+	defer srv.Close()
+	result := executeWithConnectedSheetsWriter(t, []string{
+		"--json", "--wrap-untrusted", "--account", "services@openclaw.org", "sheets", "datasource", "add",
+		"connected1", "--billing-project", "project", "--query", "SELECT 1",
+	}, newSheetsServiceFromServer(t, srv))
+	if result.err == nil || !strings.Contains(result.err.Error(), "ENGINE") {
+		t.Fatalf("failed execution must return an error: %v", result.err)
+	}
+	var got struct {
+		DataSourceID string                     `json:"dataSourceId"`
+		Status       sheets.DataExecutionStatus `json:"dataExecutionStatus"`
+	}
+	if err := json.Unmarshal([]byte(result.stdout), &got); err != nil {
+		t.Fatalf("failed creation must preserve cleanup JSON: %v", err)
+	}
+	if got.DataSourceID != "ds-cleanup" || got.Status.State != "FAILED" ||
+		!strings.Contains(got.Status.ErrorMessage, "EXTERNAL_UNTRUSTED_CONTENT") {
+		t.Fatalf("failed source identity/status was lost: %#v", got)
+	}
+	if strings.Contains(result.stdout, `"sheetId"`) {
+		t.Fatalf("missing linked sheet ID must not be reported as 0: %s", result.stdout)
+	}
+}
+
+func TestSheetsDataSourceAddRejectsMissingResponseIdentity(t *testing.T) {
+	for _, body := range []string{`{}`, `{"replies":[{}]}`, `{"replies":[{"addDataSource":{"dataSource":{}}}]}`} {
+		t.Run(body, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(body))
+			}))
+			defer srv.Close()
+			result := executeWithConnectedSheetsWriter(t, []string{
+				"--account", "services@openclaw.org", "sheets", "datasource", "add",
+				"connected1", "--billing-project", "project", "--query", "SELECT 1",
+			}, newSheetsServiceFromServer(t, srv))
+			if result.err == nil || !strings.Contains(result.err.Error(), "may have created") ||
+				!strings.Contains(result.err.Error(), "datasource list") {
+				t.Fatalf("ambiguous provider success must not claim creation: %v", result.err)
+			}
+		})
+	}
+}
+
+func TestSheetsDataSourceAddDoesNotRetryBillableCreation(t *testing.T) {
+	var requests atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		http.Error(w, "temporary provider failure", http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+	client := srv.Client()
+	client.Transport = googleapi.NewRetryTransport(client.Transport)
+	svc := newGoogleTestServiceWithEndpoint(t, client, srv.URL+"/", sheets.NewService)
+	result := executeWithConnectedSheetsWriter(t, []string{
+		"--account", "services@openclaw.org", "sheets", "datasource", "add",
+		"connected1", "--billing-project", "project", "--query", "SELECT 1",
+	}, svc)
+	if result.err == nil || requests.Load() != 1 {
+		t.Fatalf("creation must be attempted exactly once: err=%v attempts=%d", result.err, requests.Load())
+	}
+}
+
+func TestSheetsDataSourceAddRejectsInvalidInputsBeforeAuth(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "empty spreadsheet", args: []string{" ", "--billing-project", "p", "--query", "q"}, want: "empty spreadsheetId"},
+		{name: "missing billing project", args: []string{"connected1", "--query", "q"}, want: "--billing-project is required"},
+		{name: "global project is not billing project", args: []string{"connected1", "--project", "p", "--query", "q"}, want: "--billing-project is required"},
+		{name: "empty billing project", args: []string{"connected1", "--billing-project", " ", "--query", "q"}, want: "--billing-project is required"},
+		{name: "missing source", args: []string{"connected1", "--billing-project", "p"}, want: "pass --query"},
+		{name: "empty query", args: []string{"connected1", "--billing-project", "p", "--query", " "}, want: "--query cannot be empty"},
+		{name: "query and table", args: []string{"connected1", "--billing-project", "p", "--query", "q", "--dataset", "d"}, want: "mutually exclusive"},
+		{name: "empty query and table", args: []string{"connected1", "--billing-project", "p", "--query", "", "--dataset", "d"}, want: "mutually exclusive"},
+		{name: "dataset without table", args: []string{"connected1", "--billing-project", "p", "--dataset", "d"}, want: "both required"},
+		{name: "table without dataset", args: []string{"connected1", "--billing-project", "p", "--table", "t"}, want: "both required"},
+		{name: "table project alone", args: []string{"connected1", "--billing-project", "p", "--table-project", "t"}, want: "both required"},
+		{name: "empty table project", args: []string{"connected1", "--billing-project", "p", "--table-project", " ", "--dataset", "d", "--table", "t"}, want: "--table-project cannot be empty"},
+		{name: "empty dataset", args: []string{"connected1", "--billing-project", "p", "--dataset", " ", "--table", "t"}, want: "--dataset cannot be empty"},
+		{name: "empty table", args: []string{"connected1", "--billing-project", "p", "--dataset", "d", "--table", " "}, want: "--table cannot be empty"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			args := append([]string{"--json", "sheets", "datasource", "add"}, test.args...)
+			result := executeWithTestRuntime(t, args, &app.Runtime{})
+			if result.err == nil || !strings.Contains(result.err.Error(), test.want) || ExitCode(result.err) != 2 {
+				t.Fatalf("error = %v, want usage error containing %q", result.err, test.want)
+			}
+		})
+	}
+}
+
+func writeSheetsDataSourceAddResponse(t *testing.T, w http.ResponseWriter, source *sheets.DataSource, status *sheets.DataExecutionStatus) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(&sheets.BatchUpdateSpreadsheetResponse{
+		SpreadsheetId: "connected1",
+		Replies: []*sheets.Response{{AddDataSource: &sheets.AddDataSourceResponse{
+			DataSource: source, DataExecutionStatus: status,
+		}}},
+	}); err != nil {
+		t.Errorf("encode provider response: %v", err)
+	}
+}

--- a/internal/cmd/sheets_datasource_refresh.go
+++ b/internal/cmd/sheets_datasource_refresh.go
@@ -2,13 +2,10 @@ package cmd
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"google.golang.org/api/sheets/v4"
 
-	"github.com/openclaw/gogcli/internal/errfmt"
-	"github.com/openclaw/gogcli/internal/googleapi"
 	"github.com/openclaw/gogcli/internal/outfmt"
 	"github.com/openclaw/gogcli/internal/ui"
 )
@@ -45,18 +42,9 @@ func (c *SheetsDataSourceRefreshCmd) Run(ctx context.Context, flags *RootFlags) 
 	}); err != nil {
 		return err
 	}
-	if googleapi.ReadOnly(ctx) || flags.ReadOnly {
-		return fmt.Errorf("%w: Connected Sheets refresh is disabled", googleapi.ErrReadOnly)
-	}
-
-	account, svc, err := requireConnectedSheetsWriterService(ctx, flags)
+	response, err := executeConnectedSheetsWrite(ctx, flags, spreadsheetID, request)
 	if err != nil {
 		return err
-	}
-	response, err := svc.Spreadsheets.BatchUpdate(spreadsheetID, request).
-		Context(googleapi.WithoutRetries(ctx)).Do()
-	if err != nil {
-		return wrapConnectedSheetsRefreshError(err, account)
 	}
 
 	statuses := make([]*sheets.RefreshDataSourceObjectExecutionStatus, 0)
@@ -85,23 +73,5 @@ func (c *SheetsDataSourceRefreshCmd) Run(ctx context.Context, flags *RootFlags) 
 		ui.FromContext(ctx).Out().Linef("Refresh requested for data source %s", dataSourceID)
 	}
 
-	if failed != nil {
-		detail := failed.ErrorCode
-		if failed.ErrorMessage != "" {
-			detail += ": " + failed.ErrorMessage
-		}
-		return fmt.Errorf("refresh Connected Sheets data source: %s", detail)
-	}
-	return nil
-}
-
-func wrapConnectedSheetsRefreshError(err error, account string) error {
-	if !isConnectedSheetsInsufficientScopeError(err) {
-		return err
-	}
-	return errfmt.NewUserFacingError(
-		fmt.Sprintf("Connected Sheets refresh requires writable Sheets authorization plus OAuth scope %s; re-authenticate while preserving this account's existing --services, --drive-scope, and --gmail-scope selections and append --extra-scopes %s --force-consent (for a Sheets-only token: gog auth add %s --services sheets --extra-scopes %s --force-consent)",
-			connectedSheetsBigQueryScope, connectedSheetsBigQueryScope, account, connectedSheetsBigQueryScope),
-		err,
-	)
+	return connectedSheetsExecutionError("refresh", failed)
 }

--- a/internal/cmd/sheets_datasource_write.go
+++ b/internal/cmd/sheets_datasource_write.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"google.golang.org/api/sheets/v4"
+
+	"github.com/openclaw/gogcli/internal/errfmt"
+	"github.com/openclaw/gogcli/internal/googleapi"
+)
+
+func executeConnectedSheetsWrite(ctx context.Context, flags *RootFlags, spreadsheetID string, request *sheets.BatchUpdateSpreadsheetRequest) (*sheets.BatchUpdateSpreadsheetResponse, error) {
+	if googleapi.ReadOnly(ctx) || flags.ReadOnly {
+		return nil, fmt.Errorf("%w: Connected Sheets mutations are disabled", googleapi.ErrReadOnly)
+	}
+	account, svc, err := requireConnectedSheetsWriterService(ctx, flags)
+	if err != nil {
+		return nil, err
+	}
+	response, err := svc.Spreadsheets.BatchUpdate(spreadsheetID, request).
+		Context(googleapi.WithoutRetries(ctx)).Do()
+	if err == nil || !isConnectedSheetsInsufficientScopeError(err) {
+		return response, err
+	}
+	return nil, errfmt.NewUserFacingError(
+		fmt.Sprintf("Connected Sheets mutations require writable Sheets authorization plus OAuth scope %s; re-authenticate while preserving this account's existing --services, --drive-scope, and --gmail-scope selections and append --extra-scopes %s --force-consent (for a Sheets-only token: gog auth add %s --services sheets --extra-scopes %s --force-consent)",
+			connectedSheetsBigQueryScope, connectedSheetsBigQueryScope, account, connectedSheetsBigQueryScope),
+		err,
+	)
+}
+
+func connectedSheetsExecutionError(operation string, status *sheets.DataExecutionStatus) error {
+	if status == nil || status.State != "FAILED" {
+		return nil
+	}
+	detail := status.ErrorCode
+	if status.ErrorMessage != "" {
+		detail += ": " + status.ErrorMessage
+	}
+	return fmt.Errorf("%s Connected Sheets data source: %s", operation, detail)
+}


### PR DESCRIPTION
## Summary

Add the next independently scoped Connected Sheets lifecycle command:

```
gog sheets datasource add SPREADSHEET_ID --billing-project PROJECT --query SQL
gog sheets datasource add SPREADSHEET_ID --billing-project PROJECT --dataset DATASET --table TABLE [--table-project PROJECT]
```

- Require the caller to name the billing-enabled execution project explicitly; never infer one or confuse the existing global `--project` JSON-selection alias with billing.
- Support exactly one SQL or native-table source; omit the optional table-project field when Google should default it to the billing project.
- Reuse the dedicated isolated Connected Sheets writer and extract a small shared, readonly-enforced, single-attempt mutation path also used by refresh.
- Preview execution and billing risk without exposing SQL; never echo provider-returned raw SQL in normal JSON output.
- Preserve newly created source IDs and wrapped provider execution errors even when execution immediately fails; fail closed on ambiguous provider replies without retrying potentially successful creation.
- Credit @ryo-touch while replacing the original broad lifecycle patch with the requested focused creation stage.

Part of #938; issue remains open for update, delete, and a successful billed BigQuery provider proof.

## Validation

- Full local `make ci`.
- Targeted fixtures cover SQL sources, same-project and cross-project native tables, exact request shapes, malformed/ambiguous provider replies, structured failed execution, SQL-redacted output and dry runs, explicit billing selection, incompatible/empty arguments, readonly before account/authentication, and exactly one request through the real retry transport.
- Real `clawdbot@gmail.com` provider run created a disposable spreadsheet, verified a SQL-redacted billing-aware dry run, verified readonly rejection, submitted an actual `addDataSource` request with a deliberately nonexistent billing project and constant `SELECT 1`, received Google's real missing-`bigquery.readonly` 403 with actionable account-preserving guidance, confirmed the spreadsheet still contained zero data sources, and trashed the disposable spreadsheet.
- Positive BigQuery source creation is not claimed: it additionally requires user consent for `bigquery.readonly` and an explicitly approved billing-enabled BigQuery execution project.
