### PR TITLE
feat(sheets): safely delete Connected Sheets data sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Sheets: delete individual Connected Sheets data sources with explicit confirmation, linked-sheet impact warnings, and single-attempt safety. (#938) — thanks @ryo-touch.
 - Sheets: update individual BigQuery Connected Sheets sources with precise field masks, source-type verification, and SQL-safe execution previews. (#938) — thanks @ryo-touch.
 - Sheets: add explicitly billed BigQuery Connected Sheets data sources from SQL queries or native tables without exposing SQL in command output. (#938) — thanks @ryo-touch.
 - Sheets: refresh individual Connected Sheets data sources with scoped BigQuery authorization, dry-run safety, and structured execution status. (#938) — thanks @ryo-touch.

--- a/docs/commands.generated.md
+++ b/docs/commands.generated.md
@@ -572,6 +572,7 @@ Generated from `gog schema --json`.
     - [`gog sheets (sheet) create (new) <title> [flags]`](commands/gog-sheets-create.md) - Create a new spreadsheet
     - [`gog sheets (sheet) datasource (data-source,data-sources,connected-sheets) <command>`](commands/gog-sheets-datasource.md) - Manage Connected Sheets data sources and extracts
       - [`gog sheets (sheet) datasource (data-source,data-sources,connected-sheets) add <spreadsheetId> [flags]`](commands/gog-sheets-datasource-add.md) - Add one BigQuery Connected Sheets data source
+      - [`gog sheets (sheet) datasource (data-source,data-sources,connected-sheets) delete (rm,remove) <spreadsheetId> <dataSourceId>`](commands/gog-sheets-datasource-delete.md) - Delete one Connected Sheets data source and its linked sheet
       - [`gog sheets (sheet) datasource (data-source,data-sources,connected-sheets) describe (get,show,info) <spreadsheetId> <dataSourceId>`](commands/gog-sheets-datasource-describe.md) - Describe a Connected Sheets data source
       - [`gog sheets (sheet) datasource (data-source,data-sources,connected-sheets) list <spreadsheetId>`](commands/gog-sheets-datasource-list.md) - List Connected Sheets data sources
       - [`gog sheets (sheet) datasource (data-source,data-sources,connected-sheets) refresh <spreadsheetId> <dataSourceId> [flags]`](commands/gog-sheets-datasource-refresh.md) - Refresh one Connected Sheets data source

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -2,7 +2,7 @@
 
 Every `gog` command has a generated docs page. The source of truth is the live CLI schema; run `make docs-commands` after changing command names, flags, help text, aliases, or arguments.
 
-Generated pages: 727.
+Generated pages: 728.
 
 ## Top-level Commands
 
@@ -625,6 +625,7 @@ Generated pages: 727.
     - [gog sheets create](gog-sheets-create.md) - Create a new spreadsheet
     - [gog sheets datasource](gog-sheets-datasource.md) - Manage Connected Sheets data sources and extracts
       - [gog sheets datasource add](gog-sheets-datasource-add.md) - Add one BigQuery Connected Sheets data source
+      - [gog sheets datasource delete](gog-sheets-datasource-delete.md) - Delete one Connected Sheets data source and its linked sheet
       - [gog sheets datasource describe](gog-sheets-datasource-describe.md) - Describe a Connected Sheets data source
       - [gog sheets datasource list](gog-sheets-datasource-list.md) - List Connected Sheets data sources
       - [gog sheets datasource refresh](gog-sheets-datasource-refresh.md) - Refresh one Connected Sheets data source

--- a/docs/commands/gog-sheets-datasource-delete.md
+++ b/docs/commands/gog-sheets-datasource-delete.md
@@ -1,28 +1,18 @@
-# `gog sheets datasource`
+# `gog sheets datasource delete`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Manage Connected Sheets data sources and extracts
+Delete one Connected Sheets data source and its linked sheet
 
 ## Usage
 
 ```bash
-gog sheets (sheet) datasource (data-source,data-sources,connected-sheets) <command>
+gog sheets (sheet) datasource (data-source,data-sources,connected-sheets) delete (rm,remove) <spreadsheetId> <dataSourceId>
 ```
 
 ## Parent
 
-- [gog sheets](gog-sheets.md)
-
-## Subcommands
-
-- [gog sheets datasource add](gog-sheets-datasource-add.md) - Add one BigQuery Connected Sheets data source
-- [gog sheets datasource delete](gog-sheets-datasource-delete.md) - Delete one Connected Sheets data source and its linked sheet
-- [gog sheets datasource describe](gog-sheets-datasource-describe.md) - Describe a Connected Sheets data source
-- [gog sheets datasource list](gog-sheets-datasource-list.md) - List Connected Sheets data sources
-- [gog sheets datasource refresh](gog-sheets-datasource-refresh.md) - Refresh one Connected Sheets data source
-- [gog sheets datasource table](gog-sheets-datasource-table.md) - Inspect Connected Sheets data-source tables (extracts)
-- [gog sheets datasource update](gog-sheets-datasource-update.md) - Update one BigQuery Connected Sheets data source
+- [gog sheets datasource](gog-sheets-datasource.md)
 
 ## Flags
 
@@ -52,5 +42,5 @@ gog sheets (sheet) datasource (data-source,data-sources,connected-sheets) <comma
 
 ## See Also
 
-- [gog sheets](gog-sheets.md)
+- [gog sheets datasource](gog-sheets-datasource.md)
 - [Command index](README.md)

--- a/docs/sheets-connected.md
+++ b/docs/sheets-connected.md
@@ -1,11 +1,11 @@
 ---
 title: Connected Sheets
-description: Inspect, create, update, and refresh BigQuery and Looker data sources, execution status, and anchored Connected Sheets extracts.
+description: Inspect, create, update, refresh, and safely delete Connected Sheets data sources and extracts.
 ---
 
 # Connected Sheets
 
-`gog sheets datasource` can inspect external data sources, add and update BigQuery sources, and refresh one explicitly selected source. Its read-only commands list sources, return the complete source specification and execution status, discover anchored data-source tables (called extracts in the Sheets editor), and read a bounded number of extract rows.
+`gog sheets datasource` can inspect external data sources, add and update BigQuery sources, and refresh or delete one explicitly selected source. Its read-only commands list sources, return the complete source specification and execution status, discover anchored data-source tables (called extracts in the Sheets editor), and read a bounded number of extract rows.
 
 ## Authorize BigQuery access explicitly
 
@@ -83,6 +83,20 @@ Refresh requires writable Sheets authorization plus the explicitly granted `bigq
 
 Google starts refreshes asynchronously. JSON preserves the provider's native object references and execution statuses; an immediately `FAILED` status returns a nonzero exit code while retaining its structured JSON output. Poll `list` or `describe` until `state` is `SUCCEEDED` or `FAILED`.
 
+## Delete one data source
+
+```bash
+gog --account you@example.com sheets datasource delete \
+  <spreadsheetId> <dataSourceId> --dry-run --json
+
+gog --account you@example.com sheets datasource delete \
+  <spreadsheetId> <dataSourceId> --force --json
+```
+
+Deleting a source also deletes its linked `DATA_SOURCE` sheet and unlinks dependent extracts, charts, and pivot tables; it does not delete those dependent objects. Interactive use asks for confirmation, noninteractive use refuses without `--force`, and `--force` skips only that confirmation. It never bypasses readonly restrictions, authorization checks, explicit targeting, or provider errors.
+
+Dry-run output previews the exact one-source API request and its linked-object impact without authentication, prompts, or network access. The destructive request is never automatically retried.
+
 ## Discover and read extracts
 
 A data-source table has no standalone ID in the Sheets API. Its definition lives only on the table's top-left anchor cell, so the CLI identifies extracts with an A1 anchor that includes the sheet name.
@@ -102,5 +116,3 @@ gog --readonly --account you@example.com \
 Table discovery asks `spreadsheets.get` only for anchor definitions and related sheet metadata. `read` then uses the selected table's configured columns and row limit to construct a bounded `spreadsheets.values.get` request. The default is at most 1,000 data rows plus the header; JSON output reports `truncated: true` when the configured extract can contain more rows. Use `--render FORMULA` or `--render UNFORMATTED_VALUE` when formatted display values are not suitable.
 
 An extract that syncs every column keeps its column list on the linked `DATA_SOURCE` sheet rather than on the anchor, and the anchor lookup is range-scoped, so `read` issues one additional `spreadsheets.get` for those column definitions. Add pacing when reading many extracts in a loop; back-to-back reads can reach the Sheets per-minute quota.
-
-These commands do not delete data sources.

--- a/internal/cmd/sheets_datasource.go
+++ b/internal/cmd/sheets_datasource.go
@@ -20,6 +20,7 @@ const connectedSheetsBigQueryScope = "https://www.googleapis.com/auth/bigquery.r
 
 type SheetsDataSourceCmd struct {
 	Add      SheetsDataSourceAddCmd      `cmd:"" name:"add" help:"Add one BigQuery Connected Sheets data source"`
+	Delete   SheetsDataSourceDeleteCmd   `cmd:"" name:"delete" aliases:"rm,remove" help:"Delete one Connected Sheets data source and its linked sheet"`
 	List     SheetsDataSourceListCmd     `cmd:"" default:"withargs" help:"List Connected Sheets data sources"`
 	Describe SheetsDataSourceDescribeCmd `cmd:"" name:"describe" aliases:"get,show,info" help:"Describe a Connected Sheets data source"`
 	Refresh  SheetsDataSourceRefreshCmd  `cmd:"" name:"refresh" help:"Refresh one Connected Sheets data source"`

--- a/internal/cmd/sheets_datasource_delete.go
+++ b/internal/cmd/sheets_datasource_delete.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"google.golang.org/api/sheets/v4"
+
+	"github.com/openclaw/gogcli/internal/googleapi"
+	"github.com/openclaw/gogcli/internal/outfmt"
+	"github.com/openclaw/gogcli/internal/ui"
+)
+
+type SheetsDataSourceDeleteCmd struct {
+	SpreadsheetID string `arg:"" name:"spreadsheetId" help:"Spreadsheet ID"`
+	DataSourceID  string `arg:"" name:"dataSourceId" help:"Data source ID"`
+}
+
+func (c *SheetsDataSourceDeleteCmd) Run(ctx context.Context, flags *RootFlags) error {
+	spreadsheetID := normalizeGoogleID(strings.TrimSpace(c.SpreadsheetID))
+	dataSourceID := strings.TrimSpace(c.DataSourceID)
+	if spreadsheetID == "" {
+		return usage("empty spreadsheetId")
+	}
+	if dataSourceID == "" {
+		return usage("empty dataSourceId")
+	}
+	request := &sheets.BatchUpdateSpreadsheetRequest{
+		Requests: []*sheets.Request{{
+			DeleteDataSource: &sheets.DeleteDataSourceRequest{DataSourceId: dataSourceID},
+		}},
+	}
+	if err := dryRunExit(ctx, flags, "sheets.datasource.delete", map[string]any{
+		"spreadsheet_id":            spreadsheetID,
+		"data_source_id":            dataSourceID,
+		"deletes_linked_sheet":      true,
+		"unlinks_dependent_objects": true,
+		"batch_update":              request,
+	}); err != nil {
+		return err
+	}
+	if googleapi.ReadOnly(ctx) || flags.ReadOnly {
+		return fmt.Errorf("%w: Connected Sheets deletion is disabled", googleapi.ErrReadOnly)
+	}
+	action := fmt.Sprintf(
+		"delete Connected Sheets data source %s from spreadsheet %s, delete its linked DATA_SOURCE sheet, and unlink dependent extracts, charts, and pivot tables",
+		dataSourceID, spreadsheetID,
+	)
+	if err := confirmDestructiveChecked(ctx, flagsWithoutDryRun(flags), action); err != nil {
+		return err
+	}
+	if _, err := executeConnectedSheetsWrite(ctx, flags, spreadsheetID, request); err != nil {
+		return err
+	}
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(ctx, stdoutWriter(ctx), map[string]any{
+			"spreadsheetId": spreadsheetID,
+			"dataSourceId":  dataSourceID,
+			"deleted":       true,
+		})
+	}
+	ui.FromContext(ctx).Out().Linef("Deleted Connected Sheets data source %s", dataSourceID)
+	return nil
+}

--- a/internal/cmd/sheets_datasource_delete_test.go
+++ b/internal/cmd/sheets_datasource_delete_test.go
@@ -1,0 +1,188 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"google.golang.org/api/sheets/v4"
+
+	"github.com/openclaw/gogcli/internal/app"
+	"github.com/openclaw/gogcli/internal/googleapi"
+)
+
+func TestSheetsDataSourceDeleteRequiresExplicitConfirmation(t *testing.T) {
+	var factoryCalls atomic.Int32
+	result := executeWithTestRuntime(t, []string{
+		"--no-input", "sheets", "datasource", "delete", "connected1", "ds-target",
+	}, &app.Runtime{Services: app.Services{
+		ConnectedSheetsWriter: func(context.Context, string) (*sheets.Service, error) {
+			factoryCalls.Add(1)
+			return nil, errors.New("writer must not run")
+		},
+	}})
+	if result.err == nil || ExitCode(result.err) != 2 || factoryCalls.Load() != 0 {
+		t.Fatalf("noninteractive deletion must refuse before authentication: err=%v calls=%d", result.err, factoryCalls.Load())
+	}
+	for _, want := range []string{"--force", "ds-target", "connected1", "DATA_SOURCE sheet", "unlink dependent", "extracts", "charts", "pivot tables"} {
+		if !strings.Contains(result.err.Error(), want) {
+			t.Errorf("confirmation omitted %q: %v", want, result.err)
+		}
+	}
+}
+
+func TestSheetsDataSourceDeleteTargetsOneSource(t *testing.T) {
+	for _, responseBody := range []string{`{"replies":[{}]}`, `{}`} {
+		t.Run(responseBody, func(t *testing.T) {
+			var requests atomic.Int32
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requests.Add(1)
+				if r.Method != http.MethodPost || r.URL.Path != "/v4/spreadsheets/connected1:batchUpdate" {
+					t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+					w.WriteHeader(http.StatusBadRequest)
+					return
+				}
+				var body sheets.BatchUpdateSpreadsheetRequest
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil || len(body.Requests) != 1 ||
+					body.Requests[0] == nil || body.Requests[0].DeleteDataSource == nil ||
+					body.Requests[0].DeleteDataSource.DataSourceId != "ds-target" {
+					t.Errorf("unexpected destructive request: %#v (%v)", body.Requests, err)
+					w.WriteHeader(http.StatusBadRequest)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(responseBody))
+			}))
+			defer srv.Close()
+			result := executeWithConnectedSheetsWriter(t, []string{
+				"--json", "--force", "--account", "services@openclaw.org",
+				"sheets", "datasource", "delete", "https://docs.google.com/spreadsheets/d/connected1/edit", " ds-target ",
+			}, newSheetsServiceFromServer(t, srv))
+			if result.err != nil {
+				t.Fatalf("delete source: %v", result.err)
+			}
+			var got struct {
+				SpreadsheetID string `json:"spreadsheetId"`
+				DataSourceID  string `json:"dataSourceId"`
+				Deleted       bool   `json:"deleted"`
+			}
+			if err := json.Unmarshal([]byte(result.stdout), &got); err != nil {
+				t.Fatalf("decode deletion result: %v", err)
+			}
+			if got.SpreadsheetID != "connected1" || got.DataSourceID != "ds-target" ||
+				!got.Deleted || requests.Load() != 1 {
+				t.Fatalf("unexpected deletion result/attempts: %#v requests=%d", got, requests.Load())
+			}
+		})
+	}
+}
+
+func TestSheetsDataSourceDeleteDryRunAvoidsConfirmationAndAuthentication(t *testing.T) {
+	result := executeWithTestRuntime(t, []string{
+		"--json", "--readonly", "--dry-run", "--no-input",
+		"sheets", "datasource", "delete", "connected1", "ds-target",
+	}, &app.Runtime{})
+	if result.err != nil {
+		t.Fatalf("offline deletion preview: %v", result.err)
+	}
+	var got struct {
+		DryRun  bool   `json:"dry_run"`
+		Op      string `json:"op"`
+		Request struct {
+			DataSourceID            string                               `json:"data_source_id"`
+			DeletesLinkedSheet      bool                                 `json:"deletes_linked_sheet"`
+			UnlinksDependentObjects bool                                 `json:"unlinks_dependent_objects"`
+			BatchUpdate             sheets.BatchUpdateSpreadsheetRequest `json:"batch_update"`
+		} `json:"request"`
+	}
+	if err := json.Unmarshal([]byte(result.stdout), &got); err != nil {
+		t.Fatalf("decode deletion preview: %v", err)
+	}
+	if !got.DryRun || got.Op != "sheets.datasource.delete" || got.Request.DataSourceID != "ds-target" ||
+		!got.Request.DeletesLinkedSheet || !got.Request.UnlinksDependentObjects ||
+		len(got.Request.BatchUpdate.Requests) != 1 ||
+		got.Request.BatchUpdate.Requests[0].DeleteDataSource.DataSourceId != "ds-target" {
+		t.Fatalf("unexpected destructive preview: %#v", got)
+	}
+}
+
+func TestSheetsDataSourceDeleteForceDoesNotBypassReadOnly(t *testing.T) {
+	var factoryCalls atomic.Int32
+	result := executeWithTestRuntime(t, []string{
+		"--force", "--readonly", "sheets", "datasource", "delete", "connected1", "ds-target",
+	}, &app.Runtime{Services: app.Services{
+		ConnectedSheetsWriter: func(context.Context, string) (*sheets.Service, error) {
+			factoryCalls.Add(1)
+			return nil, errors.New("writer must not run")
+		},
+	}})
+	if !errors.Is(result.err, googleapi.ErrReadOnly) || factoryCalls.Load() != 0 {
+		t.Fatalf("force bypassed readonly guard: err=%v calls=%d", result.err, factoryCalls.Load())
+	}
+}
+
+func TestSheetsDataSourceDeleteDoesNotRetryDestructiveRequest(t *testing.T) {
+	for _, code := range []int{http.StatusTooManyRequests, http.StatusServiceUnavailable} {
+		t.Run(http.StatusText(code), func(t *testing.T) {
+			var requests atomic.Int32
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				requests.Add(1)
+				http.Error(w, "temporary provider failure", code)
+			}))
+			defer srv.Close()
+			client := srv.Client()
+			client.Transport = googleapi.NewRetryTransport(client.Transport)
+			svc := newGoogleTestServiceWithEndpoint(t, client, srv.URL+"/", sheets.NewService)
+			result := executeWithConnectedSheetsWriter(t, []string{
+				"--force", "--account", "services@openclaw.org", "sheets", "datasource", "delete", "connected1", "ds-target",
+			}, svc)
+			if result.err == nil || requests.Load() != 1 || strings.Contains(result.stdout, "deleted") {
+				t.Fatalf("destructive request must never replay or report success: err=%v requests=%d output=%q",
+					result.err, requests.Load(), result.stdout)
+			}
+		})
+	}
+}
+
+func TestSheetsDataSourceDeleteExplainsMissingBigQueryScope(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":{"code":403,"message":"The request scopes are not sufficient for performing this operation. Please include bigquery.readonly scope.","status":"PERMISSION_DENIED"}}`))
+	}))
+	defer srv.Close()
+	result := executeWithConnectedSheetsWriter(t, []string{
+		"--force", "--account", "services@openclaw.org",
+		"sheets", "datasource", "delete", "connected1", "ds-target",
+	}, newSheetsServiceFromServer(t, srv))
+	if result.err == nil || !strings.Contains(result.err.Error(), connectedSheetsBigQueryScope) ||
+		!strings.Contains(result.err.Error(), "--drive-scope") || strings.Contains(result.stdout, "deleted") {
+		t.Fatalf("missing scope must preserve recovery and never report success: err=%v output=%q", result.err, result.stdout)
+	}
+}
+
+func TestSheetsDataSourceDeleteRejectsInvalidIDsBeforeConfirmation(t *testing.T) {
+	for _, test := range []struct {
+		name          string
+		spreadsheetID string
+		dataSourceID  string
+		want          string
+	}{
+		{name: "spreadsheet", spreadsheetID: " ", dataSourceID: "ds-target", want: "empty spreadsheetId"},
+		{name: "source", spreadsheetID: "connected1", dataSourceID: " ", want: "empty dataSourceId"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			result := executeWithTestRuntime(t, []string{
+				"--no-input", "sheets", "datasource", "delete", test.spreadsheetID, test.dataSourceID,
+			}, &app.Runtime{})
+			if result.err == nil || !strings.Contains(result.err.Error(), test.want) || ExitCode(result.err) != 2 {
+				t.Fatalf("invalid IDs must reject before confirmation/auth: %v", result.err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Complete the requested independently staged Connected Sheets lifecycle with `gog sheets datasource delete SPREADSHEET_ID DATA_SOURCE_ID`.

- Target exactly one explicit data source and accurately disclose Google's actual ownership boundary: its linked `DATA_SOURCE` sheet is deleted, while dependent extracts, charts, and pivot tables are unlinked rather than deleted.
- Require interactive destructive confirmation or explicit global `--force`; `--force` skips confirmation only and never bypasses readonly enforcement, authentication, provider failures, or target validation.
- Keep dry runs fully offline and preview the exact provider request plus linked-sheet/dependency impact.
- Reuse the isolated Connected Sheets writer, account-preserving OAuth repair guidance, and single-attempt request transport; a 429 or 503 can never automatically replay a deletion.
- Correctly accept legitimate successful provider responses with empty/no typed reply and never emit `deleted: true` after provider failure.
- Preserve @ryo-touch's contributor attribution and the repository's AST-enforced destructive-command safety contract.

Completes the refresh/add/update/delete implementation requested in #938. Keep the issue open for a successful BigQuery-backed end-to-end proof until a suitably authorized billing-enabled test environment is available.

## Validation

- Full local `make ci`, including the destructive-command dry-run contract.
- Focused tests cover exact source targeting, URL normalization, empty successful replies, typed JSON output, complete blast-radius confirmation, noninteractive refusal before authentication, offline readonly dry-run, `--force` plus readonly refusal, invalid IDs, actionable missing-scope errors, and exactly one real retry-transport attempt for both HTTP 429 and 503.
- Real `clawdbot@gmail.com` provider proof created a disposable spreadsheet, verified its source list was empty, previewed the exact deletion payload/impact, confirmed no-input refusal without `--force`, confirmed `--force` could not override readonly, submitted one actual deletion request for a deliberately nonexistent source, observed Google's real HTTP 400 `The data source ID doesn't exist`, verified the sheet still contained zero sources, and trashed the disposable spreadsheet.
- Positive deletion of an existing BigQuery-backed source remains unclaimed until the account gains the additional `bigquery.readonly` grant and an explicitly approved billing-enabled execution project.
