### PR TITLE
feat(gmail): send prebuilt RFC822 messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.38.1 - Unreleased
 
+- Gmail: add guarded exact-byte RFC822 sending from a file or stdin, with optional thread binding, compose-mode isolation, and content-safe offline dry runs.
+
 ## 0.38.0 - 2026-08-25
 
 - Sheets: add the full BigQuery Connected Sheets lifecycle—create, update, refresh, and safely delete data sources—with explicit billing and authorization, protected SQL previews, correct source matching, and reliable extract reads. (#938, #1001) — thanks @ryo-touch.

--- a/docs/commands/gog-gmail-send.md
+++ b/docs/commands/gog-gmail-send.md
@@ -42,6 +42,7 @@ gog gmail (mail,email) send [flags]
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
 | `--quote` | `bool` |  | Include quoted original message in reply (requires --reply-to-message-id or --thread-id) |
+| `--raw-file` | `string` |  | Send an exact RFC822 message from a file, or '-' for stdin (cannot be combined with compose flags) |
 | `--readonly` | `bool` | false | Block mutating API requests at runtime; auth add also requests read-only OAuth scopes |
 | `--reply-all` | `bool` |  | Auto-populate recipients from original message (requires --reply-to-message-id or --thread-id) |
 | `--reply-to` | `string` |  | Reply-To header address |

--- a/docs/commands/gog-send.md
+++ b/docs/commands/gog-send.md
@@ -42,6 +42,7 @@ gog send [flags]
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
 | `--quote` | `bool` |  | Include quoted original message in reply (requires --reply-to-message-id or --thread-id) |
+| `--raw-file` | `string` |  | Send an exact RFC822 message from a file, or '-' for stdin (cannot be combined with compose flags) |
 | `--readonly` | `bool` | false | Block mutating API requests at runtime; auth add also requests read-only OAuth scopes |
 | `--reply-all` | `bool` |  | Auto-populate recipients from original message (requires --reply-to-message-id or --thread-id) |
 | `--reply-to` | `string` |  | Reply-To header address |

--- a/docs/gmail-workflows.md
+++ b/docs/gmail-workflows.md
@@ -68,6 +68,24 @@ For account-specific send blocking, use the no-send config commands:
 - [`gog config no-send list`](commands/gog-config-no-send-list.md)
 - [`gog config no-send remove`](commands/gog-config-no-send-remove.md)
 
+### Send an exact RFC822 message
+
+Use raw mode when a trusted caller has already constructed and approved the
+complete message, including its headers and MIME body:
+
+```bash
+gog gmail send --raw-file approved.eml
+cat approved.eml | gog gmail send --raw-file - --thread-id <threadId>
+```
+
+Raw mode sends the input bytes unchanged. It cannot be combined with compose,
+reply, attachment, signature, or tracking flags; `--thread-id` is the only
+optional message setting. The normal read-only and no-send policies still
+apply. A dry-run validates the RFC822 structure without authentication and
+reports only the source, byte count, SHA-256 digest, and optional thread ID.
+
+Command page: [`gog gmail send`](commands/gog-gmail-send.md).
+
 ## Import an RFC822 Message
 
 Import one existing RFC822/EML message from a file or stdin:

--- a/internal/cmd/gmail_send.go
+++ b/internal/cmd/gmail_send.go
@@ -1,14 +1,21 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/base64"
 	"errors"
 	"fmt"
+	"io"
+	"net/mail"
 	"os"
 	"strings"
 
 	"google.golang.org/api/gmail/v1"
 
+	"github.com/openclaw/gogcli/internal/config"
+	"github.com/openclaw/gogcli/internal/googleapi"
 	"github.com/openclaw/gogcli/internal/mailmime"
 	"github.com/openclaw/gogcli/internal/tracking"
 	"github.com/openclaw/gogcli/internal/ui"
@@ -23,6 +30,7 @@ type GmailSendCmd struct {
 	BodyFile                string   `name:"body-file" help:"Body file path (plain text; '-' for stdin)"`
 	BodyHTML                string   `name:"body-html" help:"Body (HTML; optional)"`
 	BodyHTMLFile            string   `name:"body-html-file" help:"HTML body file path ('-' for stdin)"`
+	RawFile                 string   `name:"raw-file" help:"Send an exact RFC822 message from a file, or '-' for stdin (cannot be combined with compose flags)"`
 	ReplyToMessageID        string   `name:"reply-to-message-id" aliases:"in-reply-to" help:"Reply to Gmail message ID (sets In-Reply-To/References and thread)"`
 	ThreadID                string   `name:"thread-id" help:"Reply within a Gmail thread (uses latest message for headers)"`
 	ReplyAll                bool     `name:"reply-all" help:"Auto-populate recipients from original message (requires --reply-to-message-id or --thread-id)"`
@@ -68,6 +76,9 @@ type sendMessageOptions struct {
 }
 
 func (c *GmailSendCmd) Run(ctx context.Context, flags *RootFlags) error {
+	if strings.TrimSpace(c.RawFile) != "" {
+		return c.runRaw(ctx, flags)
+	}
 	u := ui.FromContext(ctx)
 
 	replyToMessageID := normalizeGmailMessageID(c.ReplyToMessageID)
@@ -235,6 +246,124 @@ func (c *GmailSendCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	return writeSendResults(ctx, u, from.header, results, attachmentMetadata)
+}
+
+type gmailRawSendPlan struct {
+	Source   string `json:"source"`
+	Bytes    int    `json:"bytes"`
+	SHA256   string `json:"sha256"`
+	ThreadID string `json:"thread_id,omitempty"`
+}
+
+func (c *GmailSendCmd) runRaw(ctx context.Context, flags *RootFlags) error {
+	if conflict := c.rawModeConflict(); conflict != "" {
+		return usagef("--raw-file cannot be combined with %s", conflict)
+	}
+	raw, plan, err := readRawSendInput(ctx, c.RawFile, c.ThreadID)
+	if err != nil {
+		return err
+	}
+	if dryRunErr := dryRunExit(ctx, flags, "gmail.send", plan); dryRunErr != nil {
+		return dryRunErr
+	}
+	if googleapi.ReadOnly(ctx) {
+		return fmt.Errorf("%w: Gmail sending is disabled", googleapi.ErrReadOnly)
+	}
+	_, svc, err := requireGmailSendService(ctx, flags)
+	if err != nil {
+		return err
+	}
+	message := &gmail.Message{Raw: base64.RawURLEncoding.EncodeToString(raw), ThreadId: plan.ThreadID}
+	sent, err := svc.Users.Messages.Send("me", message).Context(ctx).Do()
+	if err != nil {
+		return err
+	}
+	return writeGmailImportResult(ctx, sent)
+}
+
+func (c *GmailSendCmd) rawModeConflict() string {
+	checks := []struct {
+		set  bool
+		flag string
+	}{
+		{strings.TrimSpace(c.To) != "", "--to"},
+		{strings.TrimSpace(c.Cc) != "", "--cc"},
+		{strings.TrimSpace(c.Bcc) != "", "--bcc"},
+		{strings.TrimSpace(c.Subject) != "", "--subject"},
+		{c.Body != "", "--body"},
+		{strings.TrimSpace(c.BodyFile) != "", "--body-file"},
+		{c.BodyHTML != "", "--body-html"},
+		{strings.TrimSpace(c.BodyHTMLFile) != "", "--body-html-file"},
+		{strings.TrimSpace(c.ReplyToMessageID) != "", "--reply-to-message-id"},
+		{c.ReplyAll, "--reply-all"},
+		{strings.TrimSpace(c.ReplyTo) != "", "--reply-to"},
+		{len(c.Attach) != 0, "--attach"},
+		{strings.TrimSpace(c.From) != "", "--from"},
+		{c.Signature, "--signature"},
+		{strings.TrimSpace(c.SignatureFrom) != "", "--signature-from"},
+		{strings.TrimSpace(c.SignatureFile) != "", "--signature-file"},
+		{c.Track, "--track"},
+		{c.TrackSplit, "--track-split"},
+		{c.Quote, "--quote"},
+	}
+	for _, check := range checks {
+		if check.set {
+			return check.flag
+		}
+	}
+	return ""
+}
+
+func readRawSendInput(ctx context.Context, source, threadID string) ([]byte, gmailRawSendPlan, error) {
+	source = strings.TrimSpace(source)
+	var raw []byte
+	var err error
+	if source == "-" {
+		raw, err = io.ReadAll(stdinReader(ctx))
+	} else {
+		var path string
+		path, err = config.ExpandPath(source)
+		if err == nil {
+			raw, err = os.ReadFile(path) //nolint:gosec // explicit user-provided message path
+		}
+	}
+	if err != nil {
+		return nil, gmailRawSendPlan{}, err
+	}
+	if len(raw) == 0 {
+		return nil, gmailRawSendPlan{}, usage("RFC822 input is empty")
+	}
+	if !bytes.Contains(raw, []byte("\r\n\r\n")) && !bytes.Contains(raw, []byte("\n\n")) {
+		return nil, gmailRawSendPlan{}, usage("invalid RFC822 input: missing header/body separator")
+	}
+	message, parseErr := mail.ReadMessage(bytes.NewReader(raw))
+	if parseErr != nil {
+		return nil, gmailRawSendPlan{}, usagef("invalid RFC822 input: %v", parseErr)
+	}
+	if strings.TrimSpace(message.Header.Get("From")) == "" {
+		return nil, gmailRawSendPlan{}, usage("invalid RFC822 input: missing From header")
+	}
+	if _, addressErr := mail.ParseAddress(message.Header.Get("From")); addressErr != nil {
+		return nil, gmailRawSendPlan{}, usagef("invalid RFC822 input: invalid From header: %v", addressErr)
+	}
+	if strings.TrimSpace(message.Header.Get("To")) == "" && strings.TrimSpace(message.Header.Get("Cc")) == "" && strings.TrimSpace(message.Header.Get("Bcc")) == "" {
+		return nil, gmailRawSendPlan{}, usage("invalid RFC822 input: missing recipient header")
+	}
+	for _, header := range []string{"To", "Cc", "Bcc"} {
+		value := strings.TrimSpace(message.Header.Get(header))
+		if value == "" {
+			continue
+		}
+		if _, addressErr := mail.ParseAddressList(value); addressErr != nil {
+			return nil, gmailRawSendPlan{}, usagef("invalid RFC822 input: invalid %s header: %v", header, addressErr)
+		}
+	}
+	threadID = strings.TrimSpace(threadID)
+	if strings.ContainsAny(threadID, " \t\r\n") {
+		return nil, gmailRawSendPlan{}, usage("invalid --thread-id")
+	}
+	digest := sha256.Sum256(raw)
+	return raw, gmailRawSendPlan{Source: source, Bytes: len(raw), SHA256: fmt.Sprintf("%x", digest), ThreadID: threadID}, nil
 }
 
 func (c *GmailSendCmd) resolveTrackingConfig(ctx context.Context, account string, toRecipients, ccRecipients, bccRecipients []string, htmlBody string) (*tracking.Config, error) {

--- a/internal/cmd/gmail_send_raw_test.go
+++ b/internal/cmd/gmail_send_raw_test.go
@@ -1,0 +1,173 @@
+package cmd
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/gmail/v1"
+
+	"github.com/openclaw/gogcli/internal/app"
+	"github.com/openclaw/gogcli/internal/googleapi"
+	"github.com/openclaw/gogcli/internal/outfmt"
+)
+
+const testRawSendEML = "From: ScoutWave <scoutwave@example.com>\r\n" +
+	"To: Recipient <recipient@example.com>\r\n" +
+	"Subject: Exact bytes\r\n" +
+	"Message-ID: <stable@example.com>\r\n" +
+	"Content-Type: text/plain; charset=utf-8\r\n\r\n" +
+	"body with trailing bytes\r\n\r\n"
+
+func TestGmailSendRawDryRunIsOfflineAndSafe(t *testing.T) {
+	path := writeRawSendEML(t, testRawSendEML)
+	result := executeWithTestRuntime(t, []string{"--dry-run", "--json", "gmail", "send", "--raw-file", path, "--thread-id", "thread-1"}, &app.Runtime{})
+	if result.err != nil {
+		t.Fatalf("dry-run: %v\nstderr=%s", result.err, result.stderr)
+	}
+	var got struct {
+		Op      string `json:"op"`
+		Request struct {
+			Source   string `json:"source"`
+			Bytes    int    `json:"bytes"`
+			SHA256   string `json:"sha256"`
+			ThreadID string `json:"thread_id"`
+		} `json:"request"`
+	}
+	if err := json.Unmarshal([]byte(result.stdout), &got); err != nil {
+		t.Fatalf("decode: %v\n%s", err, result.stdout)
+	}
+	wantHash := fmt.Sprintf("%x", sha256.Sum256([]byte(testRawSendEML)))
+	if got.Op != "gmail.send" || got.Request.Source != path || got.Request.Bytes != len(testRawSendEML) || got.Request.SHA256 != wantHash || got.Request.ThreadID != "thread-1" {
+		t.Fatalf("unexpected plan: %#v", got)
+	}
+	for _, secret := range []string{"recipient@example.com", "Exact bytes", "body with trailing bytes", "stable@example.com"} {
+		if strings.Contains(result.stdout, secret) {
+			t.Fatalf("dry-run leaked message content %q: %s", secret, result.stdout)
+		}
+	}
+}
+
+func TestGmailSendRawReadsStdinAndPreservesBytes(t *testing.T) {
+	var posted gmail.Message
+	svc, cleanup := newGmailServiceForTest(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/gmail/v1/users/me/messages/send" {
+			http.NotFound(w, r)
+			return
+		}
+		if err := json.NewDecoder(r.Body).Decode(&posted); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]string{"id": "msg-1", "threadId": "thread-1"})
+	})
+	defer cleanup()
+
+	var out bytes.Buffer
+	ctx := newCmdRuntimeIOContext(t, strings.NewReader(testRawSendEML), &out, io.Discard)
+	ctx = outfmt.WithMode(ctx, outfmt.Mode{JSON: true})
+	ctx = withGmailTestService(ctx, svc)
+	err := (&GmailSendCmd{RawFile: "-", ThreadID: "thread-1"}).Run(ctx, &RootFlags{Account: "scoutwave@example.com"})
+	if err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	decoded, err := base64.RawURLEncoding.DecodeString(posted.Raw)
+	if err != nil || string(decoded) != testRawSendEML || posted.ThreadId != "thread-1" {
+		t.Fatalf("raw bytes/thread changed: err=%v thread=%q raw=%q", err, posted.ThreadId, decoded)
+	}
+	if !strings.Contains(out.String(), `"messageId": "msg-1"`) || !strings.Contains(out.String(), `"threadId": "thread-1"`) {
+		t.Fatalf("provider IDs missing: %s", out.String())
+	}
+}
+
+func TestGmailSendRawRejectsInvalidBeforeAuth(t *testing.T) {
+	for name, input := range map[string]string{
+		"empty":             "",
+		"no separator":      "From: a@example.com\r\nTo: b@example.com",
+		"malformed header":  "not a header\r\n\r\nbody",
+		"missing from":      "To: b@example.com\r\n\r\nbody",
+		"missing recipient": "From: a@example.com\r\n\r\nbody",
+		"invalid recipient": "From: a@example.com\r\nTo: not-an-address\r\n\r\nbody",
+	} {
+		t.Run(name, func(t *testing.T) {
+			ctx := newCmdRuntimeIOContext(t, strings.NewReader(input), io.Discard, io.Discard)
+			err := (&GmailSendCmd{RawFile: "-"}).Run(ctx, &RootFlags{})
+			if err == nil || !strings.Contains(err.Error(), "RFC822") {
+				t.Fatalf("error = %v", err)
+			}
+		})
+	}
+}
+
+func TestGmailSendRawAppearsInCommandSchema(t *testing.T) {
+	doc := schemaForCommand(t, "gmail send")
+	flag := schemaFlagByName(t, doc.Command, "raw-file")
+	if flag.Type != "string" || !strings.Contains(flag.Help, "exact RFC822") {
+		t.Fatalf("raw-file schema = %#v", flag)
+	}
+}
+
+func TestGmailSendRawRejectsEveryComposeMode(t *testing.T) {
+	cases := []GmailSendCmd{
+		{To: "a@example.com"},
+		{Cc: "a@example.com"},
+		{Bcc: "a@example.com"},
+		{Subject: "s"},
+		{Body: "b"},
+		{BodyFile: "body.txt"},
+		{BodyHTML: "<b>x</b>"},
+		{BodyHTMLFile: "body.html"},
+		{ReplyToMessageID: "m"},
+		{ReplyAll: true},
+		{ReplyTo: "a@example.com"},
+		{Attach: []string{"a"}},
+		{From: "a@example.com"},
+		{composeSignatureOptions: composeSignatureOptions{Signature: true}},
+		{composeSignatureOptions: composeSignatureOptions{SignatureFrom: "a@example.com"}},
+		{composeSignatureOptions: composeSignatureOptions{SignatureFile: "sig.txt"}},
+		{Track: true},
+		{TrackSplit: true},
+		{Quote: true},
+	}
+	for i := range cases {
+		cases[i].RawFile = "-"
+		ctx := newCmdRuntimeIOContext(t, strings.NewReader(testRawSendEML), io.Discard, io.Discard)
+		if err := cases[i].Run(ctx, &RootFlags{DryRun: true}); err == nil || !strings.Contains(err.Error(), "cannot be combined") {
+			t.Errorf("case %d error = %v", i, err)
+		}
+	}
+}
+
+func TestGmailSendRawSafetyAndAlias(t *testing.T) {
+	path := writeRawSendEML(t, testRawSendEML)
+	blocked := executeWithTestRuntime(t, []string{"--gmail-no-send", "--dry-run", "gmail", "send", "--raw-file", path}, &app.Runtime{})
+	if blocked.err == nil || !strings.Contains(blocked.err.Error(), "no-send") {
+		t.Fatalf("no-send error = %v", blocked.err)
+	}
+	alias := executeWithTestRuntime(t, []string{"--dry-run", "--json", "send", "--raw-file", path}, &app.Runtime{})
+	if alias.err != nil || !strings.Contains(alias.stdout, `"op": "gmail.send"`) {
+		t.Fatalf("alias: err=%v out=%s", alias.err, alias.stdout)
+	}
+	ctx := googleapi.WithReadOnly(newCmdRuntimeIOContext(t, strings.NewReader(testRawSendEML), io.Discard, io.Discard), true)
+	err := (&GmailSendCmd{RawFile: "-"}).Run(ctx, &RootFlags{Account: "a@example.com"})
+	if !errors.Is(err, googleapi.ErrReadOnly) {
+		t.Fatalf("readonly error = %v", err)
+	}
+}
+
+func writeRawSendEML(t *testing.T, contents string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "message.eml")
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}


### PR DESCRIPTION
## Summary
- add `gog gmail send --raw-file <path|->` for exact prebuilt RFC822 messages
- preserve raw bytes and return Gmail provider message/thread IDs through the existing send result
- keep the operation behind existing Gmail send policy, readonly, alias, and safety controls
- reject compose, reply, tracking, signature, and attachment flags in raw mode
- make dry-run offline and content-redacted (source, byte count, SHA-256 only)

## Why
Approval-gated clients need to freeze and authorize one exact MIME message, including a deterministic Message-ID, then reconcile the provider result without rebuilding the message inside the CLI.

## Tests
- `make ci`
- 728 generated command docs verified
- raw-file tests cover exact file/stdin bytes, pre-auth validation, dry-run redaction, conflicting flags, readonly, no-send policy, and alias enforcement

## User-facing changes
`gog gmail send` accepts `--raw-file`; optionally combine it with `--thread-id` for Gmail thread placement.