### PR TITLE
feat(auth): add Gmail read-send scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.38.1 - Unreleased
 
+- Auth: add `--gmail-scope read-send` for Gmail read-only access plus sending, and prevent reauthorization from silently restoring previously granted broader scopes.
+
 ## 0.38.0 - 2026-08-25
 
 - Sheets: add the full BigQuery Connected Sheets lifecycle—create, update, refresh, and safely delete data sources—with explicit billing and authorization, protected SQL previews, correct source matching, and reliable extract reads. (#938, #1001) — thanks @ryo-touch.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ gog --readonly calendar events --today --json
 gog --readonly drive audit sharing --parent <folderId> --json
 ```
 
+For a Gmail token that can read messages and send mail without modify or settings access, authorize with `gog auth add you@example.com --services gmail --gmail-scope read-send`.
+
 ## Install
 
 Homebrew is the shortest path on macOS and Linux:

--- a/docs/commands/gog-auth-add.md
+++ b/docs/commands/gog-auth-add.md
@@ -32,7 +32,7 @@ gog auth add <email> [flags]
 | `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
 | `--force-consent` | `bool` |  | Force consent screen to obtain a refresh token |
 | `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
-| `--gmail-scope` | `string` | full | Gmail scope mode: full\|readonly |
+| `--gmail-scope` | `string` | full | Gmail scope mode: full\|readonly\|read-send |
 | `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |

--- a/docs/commands/gog-login.md
+++ b/docs/commands/gog-login.md
@@ -32,7 +32,7 @@ gog login <email> [flags]
 | `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
 | `--force-consent` | `bool` |  | Force consent screen to obtain a refresh token |
 | `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
-| `--gmail-scope` | `string` | full | Gmail scope mode: full\|readonly |
+| `--gmail-scope` | `string` | full | Gmail scope mode: full\|readonly\|read-send |
 | `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -139,13 +139,14 @@ Implementation: `internal/secrets/store.go`.
 - Refresh token issuance:
   - requests `access_type=offline`
   - supports `--force-consent` to force the consent prompt when Google doesn't return a refresh token
-  - uses `include_granted_scopes=true` to support incremental auth re-runs
+  - uses `include_granted_scopes=true` to support incremental auth re-runs for full-scope authorization
+  - omits `include_granted_scopes` for limited scope presets and reauthorization so broader historical grants are not silently restored
 
 Scope selection note:
 
 - The consent screen shows the scopes the CLI requested.
 - Users cannot selectively un-check individual requested scopes in the consent screen; they either approve all requested scopes or cancel.
-- To request fewer scopes, choose fewer services via `gog auth add --services ...` or use `gog auth add --readonly` where applicable.
+- To request fewer scopes, choose fewer services via `gog auth add --services ...`, use `gog auth add --readonly`, or select a limited service preset such as `--gmail-scope readonly|read-send`.
 
 ## Config layout
 
@@ -196,7 +197,7 @@ Flag aliases:
 - `gog auth credentials list`
 - `gog auth credentials remove [<client>|all]`
 - `gog --client <name> auth credentials <credentials.json|->`
-- `gog auth add <email> [--services user|all-user|all|gmail,calendar,chat,classroom,drive,driveactivity,drivelabels,docs,slides,contacts,tasks,sheets,people,forms,sites,meet,photos,photospicker,appscript,analytics,searchconsole,ads,youtube] [--readonly] [--drive-scope full|readonly|file] [--gmail-scope full|readonly] [--extra-scopes CSV] [--manual] [--remote] [--step 1|2] [--auth-url URL] [--listen-addr HOST[:PORT]] [--redirect-host HOST] [--timeout DURATION] [--force-consent]`
+- `gog auth add <email> [--services user|all-user|all|gmail,calendar,chat,classroom,drive,driveactivity,drivelabels,docs,slides,contacts,tasks,sheets,people,forms,sites,meet,photos,photospicker,appscript,analytics,searchconsole,ads,youtube] [--readonly] [--drive-scope full|readonly|file] [--gmail-scope full|readonly|read-send] [--extra-scopes CSV] [--manual] [--remote] [--step 1|2] [--auth-url URL] [--listen-addr HOST[:PORT]] [--redirect-host HOST] [--timeout DURATION] [--force-consent]`
 - `gog auth services [--markdown]`
 - `gog auth manage [--services ...] [--listen-addr HOST[:PORT]] [--redirect-host HOST] [--dry-run]` (interactive browser flow; real execution fails with usage exit code 2 under `--no-input`)
 - `gog auth keep <email> --key <service-account.json>` (Google Keep; Workspace only)

--- a/internal/cmd/auth_add.go
+++ b/internal/cmd/auth_add.go
@@ -29,7 +29,7 @@ type AuthAddCmd struct {
 	ForceConsent bool          `name:"force-consent" help:"Force consent screen to obtain a refresh token"`
 	ServicesCSV  string        `name:"services" help:"Services to authorize: user|all-user or comma-separated ${auth_services}; explicit opt-in: photospicker; all means all default user OAuth services. Workspace service-account-only services: admin, groups, keep" default:"user"`
 	DriveScope   string        `name:"drive-scope" help:"Drive scope mode: full|readonly|file" enum:"full,readonly,file" default:"full"`
-	GmailScope   string        `name:"gmail-scope" help:"Gmail scope mode: full|readonly" enum:"full,readonly" default:"full"`
+	GmailScope   string        `name:"gmail-scope" help:"Gmail scope mode: full|readonly|read-send" enum:"full,readonly,read-send" default:"full"`
 	ExtraScopes  string        `name:"extra-scopes" help:"Comma-separated list of additional OAuth scope URIs to request (appended after service scopes)"`
 }
 
@@ -79,6 +79,14 @@ func parseExtraScopesCSV(raw string) []string {
 	return scopes
 }
 
+func disablesIncludeGrantedScopes(readonly bool, driveScope, gmailScope string) bool {
+	return readonly ||
+		driveScope == "readonly" ||
+		driveScope == strFile ||
+		gmailScope == "readonly" ||
+		gmailScope == "read-send"
+}
+
 func (c *AuthAddCmd) resolvedRedirectURI() (string, error) {
 	redirectURI := strings.TrimSpace(c.RedirectURI)
 	if strings.TrimSpace(c.RedirectHost) != "" && redirectURI != "" {
@@ -117,10 +125,7 @@ func (c *AuthAddCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return usage("cannot combine --readonly with --drive-scope=file (file is write-capable)")
 	}
 	gmailScope := strings.ToLower(strings.TrimSpace(c.GmailScope))
-	disableIncludeGrantedScopes := readonly ||
-		driveScope == "readonly" ||
-		driveScope == strFile ||
-		gmailScope == "readonly"
+	disableIncludeGrantedScopes := disablesIncludeGrantedScopes(readonly, driveScope, gmailScope)
 
 	extraScopes := parseExtraScopesCSV(c.ExtraScopes)
 

--- a/internal/cmd/auth_add_test.go
+++ b/internal/cmd/auth_add_test.go
@@ -577,6 +577,64 @@ func TestAuthAddCmd_GmailScopeReadonly(t *testing.T) {
 	}
 }
 
+func TestAuthAddCmd_GmailScopeReadSend(t *testing.T) {
+	openSecretsStore, authorizeGoogle, ensureKeychainAccess, fetchAuthorizedIdentity := defaultAuthTestOperations()
+	execute := func(args []string) error {
+		return executeWithRuntime(args, runtimeWithAuthTestOperations(
+			openSecretsStore, authorizeGoogle, ensureKeychainAccess, fetchAuthorizedIdentity,
+		))
+	}
+
+	ensureKeychainAccess = func(context.Context) error { return nil }
+	openSecretsStore = func() (secrets.Store, error) { return newMemSecretsStore(), nil }
+
+	var gotOpts googleauth.AuthorizeOptions
+	authorizeGoogle = func(_ context.Context, opts googleauth.AuthorizeOptions) (string, error) {
+		gotOpts = opts
+		gotOpts.Scopes = append([]string(nil), opts.Scopes...)
+		return "rt", nil
+	}
+	fetchAuthorizedIdentity = func(context.Context, string, string, []string, time.Duration) (googleauth.Identity, error) {
+		return googleauth.Identity{Email: "user@example.com"}, nil
+	}
+
+	_ = captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := execute([]string{
+				"auth", "add", "user@example.com",
+				"--services", "gmail", "--gmail-scope", "read-send",
+			}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	for _, want := range []string{
+		"https://www.googleapis.com/auth/gmail.readonly",
+		"https://www.googleapis.com/auth/gmail.send",
+		"openid",
+		"email",
+		"https://www.googleapis.com/auth/userinfo.email",
+	} {
+		if !containsStringInSlice(gotOpts.Scopes, want) {
+			t.Fatalf("missing %q in %v", want, gotOpts.Scopes)
+		}
+	}
+	for _, unwanted := range []string{
+		"https://mail.google.com/",
+		"https://www.googleapis.com/auth/gmail.modify",
+		"https://www.googleapis.com/auth/gmail.settings.basic",
+		"https://www.googleapis.com/auth/gmail.settings.sharing",
+	} {
+		if containsStringInSlice(gotOpts.Scopes, unwanted) {
+			t.Fatalf("unexpected %q in %v", unwanted, gotOpts.Scopes)
+		}
+	}
+	if !gotOpts.DisableIncludeGrantedScopes {
+		t.Fatal("read-send auth must disable include_granted_scopes")
+	}
+}
+
 func TestAuthAddCmd_DriveScopeReadonly(t *testing.T) {
 	openSecretsStore, authorizeGoogle, ensureKeychainAccess, fetchAuthorizedIdentity := defaultAuthTestOperations()
 	execute := func(args []string) error {

--- a/internal/googleauth/reauth.go
+++ b/internal/googleauth/reauth.go
@@ -157,11 +157,12 @@ func Reauth(ctx context.Context, opts ReauthOptions) (secrets.Token, error) {
 	fmt.Fprintln(stderr, "Re-authorizing…")
 
 	authorizeOpts := AuthorizeOptions{
-		Services:     services,
-		Scopes:       reauthScopes,
-		ForceConsent: true, // Ensure Google returns a new refresh token
-		Timeout:      timeout,
-		Client:       opts.Client,
+		Services:                    services,
+		Scopes:                      reauthScopes,
+		ForceConsent:                true, // Ensure Google returns a new refresh token
+		DisableIncludeGrantedScopes: true, // Reauthorize with exactly the selected/stored scopes.
+		Timeout:                     timeout,
+		Client:                      opts.Client,
 	}
 
 	refreshToken, err := authorizeFn(ctx, authorizeOpts)

--- a/internal/googleauth/reauth_test.go
+++ b/internal/googleauth/reauth_test.go
@@ -228,6 +228,7 @@ func TestReauthRejectsIdentityWithoutEmail(t *testing.T) {
 func TestReauthPreservesStoredScopes(t *testing.T) {
 	var requestedScopes []string
 	var requestedServices []string
+	var disableIncludeGrantedScopes bool
 
 	opts := ReauthOptions{
 		Email:    "user@example.com",
@@ -246,6 +247,7 @@ func TestReauthPreservesStoredScopes(t *testing.T) {
 		Confirm:              func(context.Context, string) (bool, error) { return true, nil },
 		AuthorizeFunc: func(ctx context.Context, authOpts AuthorizeOptions) (string, error) {
 			requestedScopes = authOpts.Scopes
+			disableIncludeGrantedScopes = authOpts.DisableIncludeGrantedScopes
 			requestedServices = make([]string, len(authOpts.Services))
 
 			for i, svc := range authOpts.Services {
@@ -277,6 +279,10 @@ func TestReauthPreservesStoredScopes(t *testing.T) {
 
 	if len(tok.Scopes) != 3 {
 		t.Fatalf("returned token should have 3 scopes, got %d: %v", len(tok.Scopes), tok.Scopes)
+	}
+
+	if !disableIncludeGrantedScopes {
+		t.Fatal("stored-scope reauth must disable include_granted_scopes")
 	}
 }
 

--- a/internal/googleauth/service.go
+++ b/internal/googleauth/service.go
@@ -63,6 +63,7 @@ type GmailScopeMode string
 const (
 	GmailScopeFull     GmailScopeMode = "full"
 	GmailScopeReadonly GmailScopeMode = "readonly"
+	GmailScopeReadSend GmailScopeMode = "read-send"
 )
 
 type ScopeOptions struct {
@@ -571,9 +572,9 @@ func scopesForServiceWithOptions(service Service, opts ScopeOptions) ([]string, 
 
 	gmailScope := strings.TrimSpace(string(opts.GmailScope))
 	switch gmailScope {
-	case "", string(GmailScopeFull), string(GmailScopeReadonly):
+	case "", string(GmailScopeFull), string(GmailScopeReadonly), string(GmailScopeReadSend):
 	default:
-		return nil, fmt.Errorf("%w %q (expected full|readonly)", errInvalidGmailScope, opts.GmailScope)
+		return nil, fmt.Errorf("%w %q (expected full|readonly|read-send)", errInvalidGmailScope, opts.GmailScope)
 	}
 
 	driveScopeValue := func() string {
@@ -595,6 +596,13 @@ func scopesForServiceWithOptions(service Service, opts ScopeOptions) ([]string, 
 	case ServiceGmail:
 		if opts.Readonly || opts.GmailScope == GmailScopeReadonly {
 			return []string{"https://www.googleapis.com/auth/gmail.readonly"}, nil
+		}
+
+		if opts.GmailScope == GmailScopeReadSend {
+			return []string{
+				"https://www.googleapis.com/auth/gmail.readonly",
+				"https://www.googleapis.com/auth/gmail.send",
+			}, nil
 		}
 
 		return Scopes(service)

--- a/internal/googleauth/service_test.go
+++ b/internal/googleauth/service_test.go
@@ -335,6 +335,32 @@ func TestScopesForManageWithOptions_GmailScopeReadonly(t *testing.T) {
 	}
 }
 
+func TestScopesForManageWithOptions_GmailScopeReadSend(t *testing.T) {
+	scopes, err := ScopesForManageWithOptions([]Service{ServiceGmail}, ScopeOptions{
+		GmailScope: GmailScopeReadSend,
+	})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	want := []string{
+		"https://www.googleapis.com/auth/gmail.readonly",
+		"https://www.googleapis.com/auth/gmail.send",
+		"openid",
+		"email",
+		"https://www.googleapis.com/auth/userinfo.email",
+	}
+	if len(scopes) != len(want) {
+		t.Fatalf("scopes = %v, want exactly %v", scopes, want)
+	}
+
+	for _, scope := range want {
+		if !containsScope(scopes, scope) {
+			t.Fatalf("missing %q in %v", scope, scopes)
+		}
+	}
+}
+
 func TestScopes_ServiceKeep_DefaultIsReadonly(t *testing.T) {
 	scopes, err := Scopes(ServiceKeep)
 	if err != nil {


### PR DESCRIPTION
## Summary
- add `--gmail-scope read-send` requesting exactly Gmail readonly + send access
- retain mandatory OpenID identity scopes
- disable incremental authorization for limited-scope auth and automatic reauthorization, including stored-token scope paths
- preserve existing `full` and `readonly` behavior

## Why
Clients that search and send mail should not need Gmail modify/settings permissions. This preset provides least-privilege read-and-send authorization and ensures reauthorization does not silently retain broader prior grants.

## Tests
- `make ci`
- lint: 0 issues
- all Go and Node tests passed
- 728 command pages generated; docs build, link tests, and coverage passed
- regression coverage includes CLI parsing, exact scope selection, limited-scope incremental-auth behavior, and stored-scope reauthorization

## User-facing changes
`gog auth add --services gmail --gmail-scope read-send` now requests Gmail read and send access without Gmail modify/settings scopes.