### PR TITLE
fix(cli): make dry runs safe and config updates atomic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.38.1 - Unreleased
 
+- Backup: honor dry-run for all backup push commands without authenticating, fetching Google data, creating local caches or checkpoints, or changing Git repositories.
+- Auth: make remote authorization dry runs side-effect-free instead of creating OAuth state or exposing authorization URLs.
+- Config: preserve concurrent account aliases, client mappings, and security settings by keeping every configuration update inside its shared file lock.
+
 ## 0.38.0 - 2026-08-25
 
 - Sheets: add the full BigQuery Connected Sheets lifecycle—create, update, refresh, and safely delete data sources—with explicit billing and authorization, protected SQL previews, correct source matching, and reliable extract reads. (#938, #1001) — thanks @ryo-touch.

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -70,6 +70,10 @@ gog backup export --no-pull --out ~/Library/CloudStorage/Dropbox/backup/gog --gm
 Use `--no-push` on `init` or `push` to commit locally without pushing to the
 remote.
 
+`backup push --dry-run` and `backup gmail push --dry-run` validate their options
+and print the intended backup plan without authenticating, contacting Google,
+accessing repositories, creating caches or checkpoints, or writing files.
+
 `status`, `verify`, `cat`, and `export` pull an existing repository or clone the
 configured remote before reading. Use `--no-pull` to read local state directly.
 Read commands never initialize a new Git repository when the repository is

--- a/internal/backup/git.go
+++ b/internal/backup/git.go
@@ -222,7 +222,7 @@ func gitError(args []string, err error, stderr string) error {
 	safeArgs := make([]string, len(args))
 	safeStderr := redactGitURLsInText(strings.TrimSpace(stderr))
 	for i, arg := range args {
-		safeArgs[i] = redactGitURL(arg)
+		safeArgs[i] = RedactGitURL(arg)
 		if safeArgs[i] != arg {
 			safeStderr = strings.ReplaceAll(safeStderr, arg, safeArgs[i])
 		}
@@ -234,10 +234,11 @@ func gitError(args []string, err error, stderr string) error {
 }
 
 func redactGitURLsInText(value string) string {
-	return gitURLPattern.ReplaceAllStringFunc(value, redactGitURL)
+	return gitURLPattern.ReplaceAllStringFunc(value, RedactGitURL)
 }
 
-func redactGitURL(value string) string {
+// RedactGitURL removes credentials, query values, and fragments from Git URLs.
+func RedactGitURL(value string) string {
 	parsed, err := url.Parse(value)
 	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
 		return value

--- a/internal/cmd/auth_add.go
+++ b/internal/cmd/auth_add.go
@@ -151,44 +151,20 @@ func (c *AuthAddCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	manual := c.isManualFlow(authURL, authCode)
-
+	remoteStep := c.Step
 	if c.Remote {
-		step := c.Step
-		if step == 0 {
+		if remoteStep == 0 {
 			if authURL != "" || authCode != "" {
-				step = 2
+				remoteStep = 2
 			} else {
-				step = 1
+				remoteStep = 1
 			}
 		}
-		switch step {
+		switch remoteStep {
 		case 1:
 			if authURL != "" || authCode != "" {
 				return usage("remote step 1 does not accept --auth-url or --auth-code")
 			}
-			u.Err().Println(googleAccountAuthorizationHint)
-			result, manualErr := buildManualAuthURL(ctx, googleauth.AuthorizeOptions{
-				Services:                    services,
-				Scopes:                      scopes,
-				Manual:                      true,
-				ForceConsent:                c.ForceConsent,
-				DisableIncludeGrantedScopes: disableIncludeGrantedScopes,
-				Client:                      client,
-				RedirectURI:                 redirectURI,
-			})
-			if manualErr != nil {
-				return manualErr
-			}
-			if outfmt.IsJSON(ctx) {
-				return outfmt.WriteJSON(ctx, stdoutWriter(ctx), map[string]any{
-					"auth_url":     result.URL,
-					"state_reused": result.StateReused,
-				})
-			}
-			u.Out().Linef("auth_url\t%s", result.URL)
-			u.Out().Linef("state_reused\t%t", result.StateReused)
-			u.Err().Linef("Run again with the same root flags and %s", formatRemoteStep2Instruction(services, c, readonly))
-			return nil
 		case 2:
 			if authCode != "" {
 				return usage("--auth-code is not valid with --remote (state check is mandatory)")
@@ -211,7 +187,7 @@ func (c *AuthAddCmd) Run(ctx context.Context, flags *RootFlags) error {
 		"scopes":        scopes,
 		"manual":        c.Manual,
 		"remote":        c.Remote,
-		"step":          c.Step,
+		"step":          remoteStep,
 		"listen_addr":   strings.TrimSpace(c.ListenAddr),
 		"redirect_host": strings.TrimSpace(c.RedirectHost),
 		"redirect_uri":  redirectURI,
@@ -222,6 +198,32 @@ func (c *AuthAddCmd) Run(ctx context.Context, flags *RootFlags) error {
 		"extra_scopes":  extraScopes,
 	}); dryRunErr != nil {
 		return dryRunErr
+	}
+
+	if c.Remote && remoteStep == 1 {
+		u.Err().Println(googleAccountAuthorizationHint)
+		result, manualErr := buildManualAuthURL(ctx, googleauth.AuthorizeOptions{
+			Services:                    services,
+			Scopes:                      scopes,
+			Manual:                      true,
+			ForceConsent:                c.ForceConsent,
+			DisableIncludeGrantedScopes: disableIncludeGrantedScopes,
+			Client:                      client,
+			RedirectURI:                 redirectURI,
+		})
+		if manualErr != nil {
+			return manualErr
+		}
+		if outfmt.IsJSON(ctx) {
+			return outfmt.WriteJSON(ctx, stdoutWriter(ctx), map[string]any{
+				"auth_url":     result.URL,
+				"state_reused": result.StateReused,
+			})
+		}
+		u.Out().Linef("auth_url\t%s", result.URL)
+		u.Out().Linef("state_reused\t%t", result.StateReused)
+		u.Err().Linef("Run again with the same root flags and %s", formatRemoteStep2Instruction(services, c, readonly))
+		return nil
 	}
 
 	if keychainErr := ensureKeychainAccessIfNeeded(ctx); keychainErr != nil {
@@ -297,14 +299,9 @@ func (c *AuthAddCmd) Run(ctx context.Context, flags *RootFlags) error {
 		if err != nil {
 			return err
 		}
-		cfg, err := configStore.Read()
-		if err != nil {
-			return err
-		}
-		if err := config.SetAccountClient(&cfg, authorizedEmail, client); err != nil {
-			return err
-		}
-		if err := configStore.Write(cfg); err != nil {
+		if err := configStore.Update(func(cfg *config.File) error {
+			return config.SetAccountClient(cfg, authorizedEmail, client)
+		}); err != nil {
 			return err
 		}
 	}

--- a/internal/cmd/auth_add_test.go
+++ b/internal/cmd/auth_add_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -820,6 +821,135 @@ func TestAuthAddCmd_RemoteStep1_PrintsAuthURL(t *testing.T) {
 	}
 	if !strings.Contains(result.stderr, googleAccountAuthorizationHint) {
 		t.Fatalf("expected Google account guidance before remote OAuth, got: %q", result.stderr)
+	}
+}
+
+func TestAuthAddCmd_DryRunSkipsOAuthForEveryFlow(t *testing.T) {
+	const syntheticRedirect = "http://127.0.0.1:55555/oauth2/callback?code=synthetic-code&state=synthetic-state"
+
+	for _, test := range []struct {
+		name   string
+		flags  []string
+		remote bool
+		step   int
+	}{
+		{name: "remote implicit step one", flags: []string{"--remote"}, remote: true, step: 1},
+		{name: "remote explicit step one", flags: []string{"--remote", "--step", "1"}, remote: true, step: 1},
+		{name: "remote implicit step two", flags: []string{"--remote", "--auth-url", syntheticRedirect}, remote: true, step: 2},
+		{name: "remote explicit step two", flags: []string{"--remote", "--step", "2", "--auth-url", syntheticRedirect}, remote: true, step: 2},
+		{name: "manual", flags: []string{"--manual"}},
+		{name: "browser"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			stateDir := t.TempDir()
+			statePath := filepath.Join(stateDir, "oauth-manual-state-synthetic.json")
+			manualCalls, oauthCalls, keychainCalls, storeCalls := 0, 0, 0, 0
+			runtime := &app.Runtime{Auth: app.AuthOperations{
+				ManualAuthURL: func(context.Context, googleauth.AuthorizeOptions) (googleauth.ManualAuthURLResult, error) {
+					manualCalls++
+					if err := os.WriteFile(statePath, []byte("synthetic-pkce-state"), 0o600); err != nil {
+						return googleauth.ManualAuthURLResult{}, err
+					}
+					return googleauth.ManualAuthURLResult{
+						URL: "https://accounts.google.com/o/oauth2/v2/auth?client_id=synthetic-client&state=synthetic-state",
+					}, nil
+				},
+				AuthorizeGoogle: func(context.Context, googleauth.AuthorizeOptions) (string, error) {
+					oauthCalls++
+					return "", errors.New("OAuth must not start during dry-run")
+				},
+				EnsureKeychainAccess: func(context.Context) error {
+					keychainCalls++
+					return errors.New("keychain must not open during dry-run")
+				},
+				OpenSecretsStore: func() (secrets.Store, error) {
+					storeCalls++
+					return nil, errors.New("secrets store must not open during dry-run")
+				},
+			}}
+			args := []string{
+				"--json", "--dry-run", "--no-input", "--home", stateDir,
+				"auth", "add", "synthetic@example.com", "--services", "sheets",
+				"--extra-scopes", "https://www.googleapis.com/auth/bigquery.readonly",
+			}
+			args = append(args, test.flags...)
+			result := executeWithTestRuntime(t, args, runtime)
+			if result.err != nil {
+				t.Fatalf("dry-run: %v", result.err)
+			}
+			if manualCalls != 0 || oauthCalls != 0 || keychainCalls != 0 || storeCalls != 0 {
+				t.Fatalf("dry-run started OAuth side effects: manual=%d oauth=%d keychain=%d store=%d",
+					manualCalls, oauthCalls, keychainCalls, storeCalls)
+			}
+			if _, err := os.Stat(statePath); !os.IsNotExist(err) {
+				t.Fatalf("dry-run created OAuth state: %v", err)
+			}
+			if strings.Contains(result.stdout, "auth_url") || strings.Contains(result.stdout, "synthetic-code") ||
+				strings.Contains(result.stdout, "synthetic-state") || strings.Contains(result.stdout, "accounts.google.com") {
+				t.Fatalf("dry-run disclosed authorization material: %q", result.stdout)
+			}
+			if result.stderr != "" {
+				t.Fatalf("dry-run started authorization guidance: %q", result.stderr)
+			}
+
+			var got struct {
+				DryRun  bool   `json:"dry_run"`
+				Op      string `json:"op"`
+				Request struct {
+					Email  string `json:"email"`
+					Remote bool   `json:"remote"`
+					Step   int    `json:"step"`
+				} `json:"request"`
+			}
+			if err := json.Unmarshal([]byte(result.stdout), &got); err != nil {
+				t.Fatalf("decode safe dry-run JSON: %v\n%s", err, result.stdout)
+			}
+			if !got.DryRun || got.Op != "auth.add" || got.Request.Email != "synthetic@example.com" ||
+				got.Request.Remote != test.remote || got.Request.Step != test.step {
+				t.Fatalf("unexpected dry-run request: %#v", got)
+			}
+		})
+	}
+}
+
+func TestAuthAddCmd_RemoteDryRunPreservesStepValidation(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		flags []string
+		want  string
+	}{
+		{
+			name:  "step one rejects redirect URL",
+			flags: []string{"--remote", "--step", "1", "--auth-url", "http://127.0.0.1/callback?code=synthetic"},
+			want:  "remote step 1 does not accept --auth-url or --auth-code",
+		},
+		{
+			name:  "step two requires redirect URL",
+			flags: []string{"--remote", "--step", "2"},
+			want:  "remote step 2 requires --auth-url",
+		},
+		{
+			name:  "step two rejects unchecked authorization code",
+			flags: []string{"--remote", "--step", "2", "--auth-code", "synthetic"},
+			want:  "--auth-code is not valid with --remote",
+		},
+		{
+			name:  "step requires remote mode",
+			flags: []string{"--step", "1"},
+			want:  "--step requires --remote",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			args := []string{"--json", "--dry-run", "--no-input", "auth", "add", "synthetic@example.com", "--services", "sheets"}
+			args = append(args, test.flags...)
+			result := executeWithTestRuntime(t, args, nil)
+			if result.err == nil || ExitCode(result.err) != 2 || !strings.Contains(result.err.Error(), test.want) {
+				t.Fatalf("error = %v, exit = %d, want usage error containing %q", result.err, ExitCode(result.err), test.want)
+			}
+			if result.stdout != "" {
+				t.Fatalf("invalid dry-run printed authorization material: %q", result.stdout)
+			}
+		})
 	}
 }
 

--- a/internal/cmd/auth_credentials.go
+++ b/internal/cmd/auth_credentials.go
@@ -61,23 +61,26 @@ func (c *AuthCredentialsSetCmd) Run(ctx context.Context, flags *RootFlags) error
 	}
 
 	domains := splitCommaList(c.Domains)
-	var (
-		configStore *config.ConfigStore
-		cfg         config.File
-	)
+	var configStore *config.ConfigStore
+	updateDomains := func(cfg *config.File) error {
+		for _, domain := range domains {
+			if domainErr := config.SetClientDomain(cfg, domain, client); domainErr != nil {
+				return domainErr
+			}
+		}
+		return nil
+	}
 	if len(domains) > 0 {
 		configStore, err = commandConfigStore(ctx)
 		if err != nil {
 			return err
 		}
-		cfg, err = configStore.Read()
-		if err != nil {
-			return err
+		cfg, readErr := configStore.Read()
+		if readErr != nil {
+			return readErr
 		}
-		for _, domain := range domains {
-			if setErr := config.SetClientDomain(&cfg, domain, client); setErr != nil {
-				return setErr
-			}
+		if domainErr := updateDomains(&cfg); domainErr != nil {
+			return domainErr
 		}
 	}
 
@@ -104,7 +107,7 @@ func (c *AuthCredentialsSetCmd) Run(ctx context.Context, flags *RootFlags) error
 		return err
 	}
 	if configStore != nil {
-		if err := configStore.Write(cfg); err != nil {
+		if err := configStore.Update(updateDomains); err != nil {
 			return err
 		}
 	}
@@ -436,26 +439,19 @@ func removeDomainMappings(ctx context.Context, client string) ([]string, error) 
 	if err != nil {
 		return nil, err
 	}
-	cfg, err := configStore.Read()
-	if err != nil {
+	var removed []string
+	if err := configStore.UpdateIfChanged(func(cfg *config.File) (bool, error) {
+		for domain, mapped := range cfg.ClientDomains {
+			normalized, err := config.NormalizeClientNameOrDefault(mapped)
+			if err == nil && normalized == client {
+				removed = append(removed, domain)
+				delete(cfg.ClientDomains, domain)
+			}
+		}
+		return len(removed) > 0, nil
+	}); err != nil {
 		return nil, err
 	}
-	var removed []string
-	for domain, mapped := range cfg.ClientDomains {
-		normalized, nerr := config.NormalizeClientNameOrDefault(mapped)
-		if nerr != nil {
-			continue
-		}
-		if normalized == client {
-			removed = append(removed, domain)
-			delete(cfg.ClientDomains, domain)
-		}
-	}
-	if len(removed) > 0 {
-		sort.Strings(removed)
-		if err := configStore.Write(cfg); err != nil {
-			return nil, err
-		}
-	}
+	sort.Strings(removed)
 	return removed, nil
 }

--- a/internal/cmd/auth_import.go
+++ b/internal/cmd/auth_import.go
@@ -105,14 +105,9 @@ func (c *AuthImportCmd) Run(ctx context.Context, flags *RootFlags) error {
 		if err != nil {
 			return err
 		}
-		cfg, err := configStore.Read()
-		if err != nil {
-			return err
-		}
-		if err := config.SetAccountClient(&cfg, email, client); err != nil {
-			return err
-		}
-		if err := configStore.Write(cfg); err != nil {
+		if err := configStore.Update(func(cfg *config.File) error {
+			return config.SetAccountClient(cfg, email, client)
+		}); err != nil {
 			return err
 		}
 	}

--- a/internal/cmd/auth_keyring.go
+++ b/internal/cmd/auth_keyring.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/openclaw/gogcli/internal/config"
 	"github.com/openclaw/gogcli/internal/outfmt"
 	"github.com/openclaw/gogcli/internal/ui"
 )
@@ -87,12 +88,10 @@ func (c *AuthKeyringCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return dryRunErr
 	}
 
-	cfg, err := store.Read()
-	if err != nil {
-		return err
-	}
-	cfg.KeyringBackend = backend
-	if err := store.Write(cfg); err != nil {
+	if err := store.Update(func(cfg *config.File) error {
+		cfg.KeyringBackend = backend
+		return nil
+	}); err != nil {
 		return err
 	}
 

--- a/internal/cmd/backup.go
+++ b/internal/cmd/backup.go
@@ -66,6 +66,14 @@ func (f backupFlags) options() backup.Options {
 	}
 }
 
+func (f backupFlags) dryRunConfig(ctx context.Context) (backup.Config, error) {
+	opts := f.options()
+	if err := bindBackupConfigStore(ctx, &opts); err != nil {
+		return backup.Config{}, err
+	}
+	return backup.ResolveOptions(opts)
+}
+
 type backupReadFlags struct {
 	Config   string `name:"config" help:"Backup config path" default:""`
 	Repo     string `name:"repo" help:"Local backup repository path"`
@@ -133,7 +141,7 @@ func (c *BackupInitCmd) Run(ctx context.Context, flags *RootFlags) error {
 		}
 		return dryRunExit(ctx, flags, "backup.init", map[string]any{
 			"repo":       cfg.Repo,
-			"remote":     cfg.Remote,
+			"remote":     backup.RedactGitURL(cfg.Remote),
 			"identity":   cfg.Identity,
 			"recipients": cfg.Recipients,
 			"push":       opts.Push,
@@ -190,6 +198,32 @@ func (c *BackupPushCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 	if err := c.validate(); err != nil {
 		return err
+	}
+	if flags != nil && flags.DryRun {
+		builders := c.snapshotBuilders(ctx, flags, backup.Options{})
+		for _, service := range services {
+			if _, ok := builders[strings.ToLower(strings.TrimSpace(service))]; !ok {
+				return usagef("unsupported backup service %q (supported: %s)", service, backupSupportedServicesHelp)
+			}
+		}
+		cfg, err := c.dryRunConfig(ctx)
+		if err != nil {
+			return err
+		}
+		return dryRunExit(ctx, flags, "backup.push", map[string]any{
+			"services":            services,
+			"repo":                cfg.Repo,
+			"remote":              backup.RedactGitURL(cfg.Remote),
+			"identity":            cfg.Identity,
+			"recipients":          cfg.Recipients,
+			"push":                !c.NoPush,
+			"query":               c.Query,
+			"max":                 c.Max,
+			"include_spam_trash":  c.IncludeSpamTrash,
+			"gmail_cache":         c.GmailCache,
+			"gmail_refresh_cache": c.GmailRefreshCache,
+			"gmail_checkpoints":   c.GmailCheckpoints,
+		})
 	}
 	backupOpts := c.options()
 	if err := bindBackupConfigStore(ctx, &backupOpts); err != nil {
@@ -262,6 +296,26 @@ func (c *BackupGmailPushCmd) Run(ctx context.Context, flags *RootFlags) error {
 	ctx = backupCommandContext(ctx, flags)
 	if err := c.validate(); err != nil {
 		return err
+	}
+	if flags != nil && flags.DryRun {
+		cfg, err := c.dryRunConfig(ctx)
+		if err != nil {
+			return err
+		}
+		return dryRunExit(ctx, flags, "backup.gmail.push", map[string]any{
+			"services":            []string{backupServiceGmail},
+			"repo":                cfg.Repo,
+			"remote":              backup.RedactGitURL(cfg.Remote),
+			"identity":            cfg.Identity,
+			"recipients":          cfg.Recipients,
+			"push":                !c.NoPush,
+			"query":               c.Query,
+			"max":                 c.Max,
+			"include_spam_trash":  c.IncludeSpamTrash,
+			"gmail_cache":         c.CacheMessages,
+			"gmail_refresh_cache": c.RefreshCache,
+			"gmail_checkpoints":   c.Checkpoints,
+		})
 	}
 	backupOpts := c.options()
 	if err := bindBackupConfigStore(ctx, &backupOpts); err != nil {

--- a/internal/cmd/backup_cmd_test.go
+++ b/internal/cmd/backup_cmd_test.go
@@ -7,14 +7,221 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"google.golang.org/api/gmail/v1"
+
+	"github.com/openclaw/gogcli/internal/app"
 	"github.com/openclaw/gogcli/internal/backup"
+	"github.com/openclaw/gogcli/internal/secrets"
 )
+
+func syntheticBackupRemote() string {
+	return (&url.URL{
+		Scheme:   "https",
+		User:     url.UserPassword("synthetic-user", "synthetic-password"),
+		Host:     "example.invalid",
+		Path:     "/backup.git",
+		RawQuery: url.Values{"access_token": {"synthetic-query"}}.Encode(),
+		Fragment: "synthetic-fragment",
+	}).String()
+}
+
+func TestBackupPushDryRunDoesNotAuthenticateOrWrite(t *testing.T) {
+	testCases := []struct {
+		name     string
+		command  []string
+		op       string
+		services string
+	}{
+		{
+			name:     "all-service push",
+			command:  []string{"backup", "push", "--services", "gmail,calendar"},
+			op:       "backup.push",
+			services: "gmail,calendar",
+		},
+		{
+			name:     "gmail push",
+			command:  []string{"backup", "gmail", "push"},
+			op:       "backup.gmail.push",
+			services: "gmail",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			dir := t.TempDir()
+			home := filepath.Join(dir, "home")
+			repo := filepath.Join(dir, "repo")
+			identity := filepath.Join(dir, "age.key")
+			remote := syntheticBackupRemote()
+			authCalls := 0
+			gmailCalls := 0
+			runtime := &app.Runtime{
+				Auth: app.AuthOperations{
+					OpenSecretsStore: func() (secrets.Store, error) {
+						authCalls++
+						return nil, errors.New("dry-run opened authentication store")
+					},
+				},
+				Services: app.Services{
+					Gmail: func(context.Context, string) (*gmail.Service, error) {
+						gmailCalls++
+						return nil, errors.New("dry-run created Gmail service")
+					},
+				},
+			}
+			args := []string{
+				"--home", home,
+				"--account", "clawdbot@gmail.com",
+				"--json", "--no-input", "--gmail-no-send", "--readonly", "--dry-run",
+			}
+			args = append(args, testCase.command...)
+			args = append(args,
+				"--repo", repo,
+				"--remote", remote,
+				"--config", filepath.Join(dir, "backup.json"),
+				"--identity", identity,
+				"--recipient", "age1syntheticrecipient",
+				"--query", "newer_than:30d",
+				"--max", "2",
+				"--no-push",
+			)
+			result := executeWithTestRuntime(t, args, runtime)
+			if result.err != nil {
+				t.Fatalf("dry-run failed: %v\n%s", result.err, result.stderr)
+			}
+			if authCalls != 0 || gmailCalls != 0 {
+				t.Fatalf("dry-run touched auth/Gmail: auth=%d gmail=%d", authCalls, gmailCalls)
+			}
+			entries, readErr := os.ReadDir(dir)
+			if readErr != nil {
+				t.Fatalf("read dry-run directory: %v", readErr)
+			}
+			if len(entries) != 0 {
+				t.Fatalf("dry-run created local files or directories: %#v", entries)
+			}
+
+			var payload struct {
+				DryRun  bool   `json:"dry_run"`
+				Op      string `json:"op"`
+				Request struct {
+					Services         []string `json:"services"`
+					Repo             string   `json:"repo"`
+					Remote           string   `json:"remote"`
+					Identity         string   `json:"identity"`
+					Recipients       []string `json:"recipients"`
+					Push             bool     `json:"push"`
+					Query            string   `json:"query"`
+					Max              int64    `json:"max"`
+					IncludeSpamTrash bool     `json:"include_spam_trash"`
+					GmailCache       bool     `json:"gmail_cache"`
+					GmailCheckpoints bool     `json:"gmail_checkpoints"`
+				} `json:"request"`
+			}
+			if decodeErr := json.Unmarshal([]byte(result.stdout), &payload); decodeErr != nil {
+				t.Fatalf("decode dry-run output: %v\n%s", decodeErr, result.stdout)
+			}
+			if !payload.DryRun || payload.Op != testCase.op {
+				t.Fatalf("unexpected dry-run payload: %#v", payload)
+			}
+			request := payload.Request
+			if strings.Join(request.Services, ",") != testCase.services || request.Repo != repo ||
+				request.Remote != "https://redacted@example.invalid/backup.git?access_token=redacted#redacted" ||
+				request.Identity != identity || strings.Join(request.Recipients, ",") != "age1syntheticrecipient" ||
+				request.Push || request.Query != "newer_than:30d" || request.Max != 2 ||
+				!request.IncludeSpamTrash || !request.GmailCache || !request.GmailCheckpoints {
+				t.Fatalf("unexpected dry-run request: %#v", request)
+			}
+			for _, secret := range []string{"synthetic-user", "synthetic-password", "synthetic-query", "synthetic-fragment"} {
+				if strings.Contains(result.stdout, secret) || strings.Contains(result.stderr, secret) {
+					t.Fatalf("dry-run output exposed remote credential %q", secret)
+				}
+			}
+		})
+	}
+}
+
+func TestBackupPushDryRunResolvesDefaultDestinationWithoutWriting(t *testing.T) {
+	userHome, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("resolve user home: %v", err)
+	}
+	for _, command := range [][]string{
+		{"backup", "push", "--services", "gmail"},
+		{"backup", "gmail", "push"},
+	} {
+		t.Run(strings.Join(command, " "), func(t *testing.T) {
+			dir := t.TempDir()
+			args := []string{"--home", filepath.Join(dir, "home"), "--json", "--no-input", "--dry-run"}
+			args = append(args, command...)
+			result := executeWithTestRuntime(t, args, nil)
+			if result.err != nil {
+				t.Fatalf("dry-run failed: %v\n%s", result.err, result.stderr)
+			}
+			var payload struct {
+				Request struct {
+					Repo     string `json:"repo"`
+					Remote   string `json:"remote"`
+					Identity string `json:"identity"`
+					Push     bool   `json:"push"`
+				} `json:"request"`
+			}
+			if decodeErr := json.Unmarshal([]byte(result.stdout), &payload); decodeErr != nil {
+				t.Fatalf("decode dry-run output: %v", decodeErr)
+			}
+			request := payload.Request
+			if request.Repo != filepath.Join(userHome, "Projects", "backup-gog") ||
+				request.Remote != backup.DefaultConfig().Remote ||
+				request.Identity != filepath.Join(userHome, ".gog", "age.key") || !request.Push {
+				t.Fatalf("unexpected default destination: %#v", request)
+			}
+			entries, readErr := os.ReadDir(dir)
+			if readErr != nil || len(entries) != 0 {
+				t.Fatalf("dry-run created local files: entries=%#v err=%v", entries, readErr)
+			}
+		})
+	}
+}
+
+func TestBackupPushDryRunRejectsInvalidServicesWithoutSideEffects(t *testing.T) {
+	dir := t.TempDir()
+	gmailCalls := 0
+	runtime := &app.Runtime{
+		Services: app.Services{
+			Gmail: func(context.Context, string) (*gmail.Service, error) {
+				gmailCalls++
+				return nil, errors.New("dry-run created Gmail service")
+			},
+		},
+	}
+	result := executeWithTestRuntime(t, []string{
+		"--home", filepath.Join(dir, "home"),
+		"--account", "clawdbot@gmail.com",
+		"--json", "--no-input", "--dry-run",
+		"backup", "push", "--services", "gmail,nope",
+		"--repo", filepath.Join(dir, "repo"),
+	}, runtime)
+	if result.err == nil || ExitCode(result.err) != 2 ||
+		!strings.Contains(result.err.Error(), "unsupported backup service") {
+		t.Fatalf("expected unsupported-service usage error, got %v", result.err)
+	}
+	if gmailCalls != 0 {
+		t.Fatalf("dry-run created Gmail service %d times", gmailCalls)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dry-run directory: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("invalid dry-run created local files or directories: %#v", entries)
+	}
+}
 
 func TestBackupInitDryRunDoesNotWriteConfigOrRepo(t *testing.T) {
 	dir := t.TempDir()
@@ -57,6 +264,37 @@ func TestBackupInitDryRunDoesNotWriteConfigOrRepo(t *testing.T) {
 	}
 	if payload.Request["remote"] != "" {
 		t.Fatalf("dry-run --no-push should not use default remote: %#v", payload.Request)
+	}
+}
+
+func TestBackupInitDryRunRedactsRemoteCredentials(t *testing.T) {
+	dir := t.TempDir()
+	remote := syntheticBackupRemote()
+	var stdout bytes.Buffer
+	err := (&BackupInitCmd{
+		backupFlags: backupFlags{
+			Config:   filepath.Join(dir, "backup.json"),
+			Repo:     filepath.Join(dir, "repo"),
+			Remote:   remote,
+			Identity: filepath.Join(dir, "age.key"),
+			NoPush:   true,
+		},
+	}).Run(newCmdRuntimeJSONOutputContext(t, &stdout, io.Discard), &RootFlags{DryRun: true, NoInput: true})
+	var exitErr *ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 0 {
+		t.Fatalf("expected dry-run exit 0, got %#v", err)
+	}
+	for _, secret := range []string{"synthetic-user", "synthetic-password", "synthetic-query", "synthetic-fragment"} {
+		if strings.Contains(stdout.String(), secret) {
+			t.Fatalf("dry-run output exposed remote credential %q", secret)
+		}
+	}
+	if !strings.Contains(stdout.String(), "https://redacted@example.invalid/backup.git?access_token=redacted#redacted") {
+		t.Fatalf("missing redacted destination: %s", stdout.String())
+	}
+	entries, readErr := os.ReadDir(dir)
+	if readErr != nil || len(entries) != 0 {
+		t.Fatalf("dry-run created local files: entries=%#v err=%v", entries, readErr)
 	}
 }
 

--- a/internal/cmd/config_cmd.go
+++ b/internal/cmd/config_cmd.go
@@ -70,17 +70,12 @@ func (c *ConfigSetCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return err
 	}
 
-	cfg, err := store.Read()
-	if err != nil {
-		return err
-	}
-
 	key, err := config.ParseKey(c.Key)
 	if err != nil {
 		return usage(err.Error())
 	}
 
-	if err := config.SetValue(&cfg, key, c.Value); err != nil {
+	if err := config.SetValue(&config.File{}, key, c.Value); err != nil {
 		return usage(err.Error())
 	}
 
@@ -91,7 +86,9 @@ func (c *ConfigSetCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return err
 	}
 
-	if err := store.Write(cfg); err != nil {
+	if err := store.Update(func(cfg *config.File) error {
+		return config.SetValue(cfg, key, c.Value)
+	}); err != nil {
 		return err
 	}
 
@@ -114,17 +111,12 @@ func (c *ConfigUnsetCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return err
 	}
 
-	cfg, err := store.Read()
-	if err != nil {
-		return err
-	}
-
 	key, err := config.ParseKey(c.Key)
 	if err != nil {
 		return usage(err.Error())
 	}
 
-	if err := config.UnsetValue(&cfg, key); err != nil {
+	if err := config.UnsetValue(&config.File{}, key); err != nil {
 		return usage(err.Error())
 	}
 
@@ -134,7 +126,9 @@ func (c *ConfigUnsetCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return err
 	}
 
-	if err := store.Write(cfg); err != nil {
+	if err := store.Update(func(cfg *config.File) error {
+		return config.UnsetValue(cfg, key)
+	}); err != nil {
 		return err
 	}
 

--- a/internal/cmd/config_cmd_test.go
+++ b/internal/cmd/config_cmd_test.go
@@ -1,8 +1,14 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/openclaw/gogcli/internal/app"
@@ -141,6 +147,156 @@ func TestConfigCmd_InvalidInputIsUsageError(t *testing.T) {
 				t.Fatalf("expected %q in error, got %v", tt.want, err)
 			}
 		})
+	}
+}
+
+func TestConfigCmd_ConcurrentMutationsPreserveAliases(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		run  func(context.Context, *RootFlags) error
+	}{
+		{
+			name: "set",
+			run: func(ctx context.Context, flags *RootFlags) error {
+				return (&ConfigSetCmd{Key: "timezone", Value: "America/Los_Angeles"}).Run(ctx, flags)
+			},
+		},
+		{
+			name: "unset",
+			run: func(ctx context.Context, flags *RootFlags) error {
+				return (&ConfigUnsetCmd{Key: "timezone"}).Run(ctx, flags)
+			},
+		},
+		{
+			name: "keyring",
+			run: func(ctx context.Context, flags *RootFlags) error {
+				return (&AuthKeyringCmd{Backend: "file"}).Run(ctx, flags)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			layout := config.Layout{ConfigDir: t.TempDir()}
+			store := config.NewConfigStore(layout)
+			if err := store.Write(config.File{DefaultTimezone: "UTC"}); err != nil {
+				t.Fatalf("write config: %v", err)
+			}
+
+			const aliasCount = 24
+			start := make(chan struct{})
+			errs := make(chan error, aliasCount*2)
+			var wg sync.WaitGroup
+			wg.Add(aliasCount * 2)
+
+			for i := range aliasCount {
+				ctx := withTestRuntime(newCmdOutputContext(t, io.Discard, io.Discard), func(runtime *app.Runtime) {
+					runtime.Config = config.NewConfigStore(layout)
+					runtime.IO = app.IO{Out: io.Discard, Err: io.Discard}
+				})
+				go func() {
+					defer wg.Done()
+					<-start
+
+					errs <- tt.run(ctx, &RootFlags{})
+				}()
+
+				go func() {
+					defer wg.Done()
+					<-start
+
+					alias := fmt.Sprintf("proof-%02d", i)
+					errs <- config.NewConfigStore(layout).SetAccountAlias(alias, "clawdbot@gmail.com")
+				}()
+			}
+
+			close(start)
+			wg.Wait()
+			close(errs)
+
+			for err := range errs {
+				if err != nil {
+					t.Fatalf("concurrent update: %v", err)
+				}
+			}
+
+			cfg, err := store.Read()
+			if err != nil {
+				t.Fatalf("read config: %v", err)
+			}
+			if len(cfg.AccountAliases) != aliasCount {
+				t.Fatalf("retained %d of %d concurrent account aliases: %#v", len(cfg.AccountAliases), aliasCount, cfg.AccountAliases)
+			}
+		})
+	}
+}
+
+func TestConfigCmd_DryRunLeavesConfigAndLockUntouched(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		run  func(context.Context, *RootFlags) error
+	}{
+		{
+			name: "set",
+			run: func(ctx context.Context, flags *RootFlags) error {
+				return (&ConfigSetCmd{Key: "timezone", Value: "UTC"}).Run(ctx, flags)
+			},
+		},
+		{
+			name: "unset",
+			run: func(ctx context.Context, flags *RootFlags) error {
+				return (&ConfigUnsetCmd{Key: "timezone"}).Run(ctx, flags)
+			},
+		},
+		{
+			name: "keyring",
+			run: func(ctx context.Context, flags *RootFlags) error {
+				return (&AuthKeyringCmd{Backend: "file"}).Run(ctx, flags)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			configDir := filepath.Join(t.TempDir(), "config")
+			ctx := withTestRuntime(newCmdOutputContext(t, io.Discard, io.Discard), func(runtime *app.Runtime) {
+				runtime.Config = config.NewConfigStore(config.Layout{ConfigDir: configDir})
+				runtime.IO = app.IO{Out: io.Discard, Err: io.Discard}
+			})
+			if err := tt.run(ctx, &RootFlags{DryRun: true}); err == nil || ExitCode(err) != 0 {
+				t.Fatalf("dry run: %v", err)
+			}
+			if _, err := os.Stat(configDir); !os.IsNotExist(err) {
+				t.Fatalf("dry run touched configuration or lock directory: %v", err)
+			}
+		})
+	}
+}
+
+func TestRemoveDomainMappings_NoMatchLeavesConfigAbsent(t *testing.T) {
+	t.Parallel()
+
+	configDir := filepath.Join(t.TempDir(), "config")
+	ctx := withTestRuntime(newCmdOutputContext(t, io.Discard, io.Discard), func(runtime *app.Runtime) {
+		runtime.Config = config.NewConfigStore(config.Layout{ConfigDir: configDir})
+	})
+	removed, err := removeDomainMappings(ctx, "work")
+	if err != nil {
+		t.Fatalf("remove domain mappings: %v", err)
+	}
+	if len(removed) != 0 {
+		t.Fatalf("removed unexpected domains: %v", removed)
+	}
+	if _, err := os.Stat(filepath.Join(configDir, "config.json")); !os.IsNotExist(err) {
+		t.Fatalf("unchanged domain cleanup created config file: %v", err)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -108,14 +108,25 @@ func (s *ConfigStore) write(cfg File) error {
 }
 
 func (s *ConfigStore) Update(update func(*File) error) error {
+	return s.UpdateIfChanged(func(cfg *File) (bool, error) {
+		return true, update(cfg)
+	})
+}
+
+func (s *ConfigStore) UpdateIfChanged(update func(*File) (bool, error)) error {
 	return s.withLock(func() error {
 		cfg, err := s.Read()
 		if err != nil {
 			return err
 		}
 
-		if err := update(&cfg); err != nil {
+		changed, err := update(&cfg)
+		if err != nil {
 			return err
+		}
+
+		if !changed {
+			return nil
 		}
 
 		return s.write(cfg)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -137,5 +138,43 @@ func TestConfigStoreWriteAndUpdate(t *testing.T) {
 
 	if cfg.KeyringBackend != "file" || cfg.DefaultTimezone != "UTC" {
 		t.Fatalf("config = %#v", cfg)
+	}
+}
+
+func TestConfigStoreUpdateIfChanged(t *testing.T) {
+	t.Parallel()
+
+	store := NewConfigStore(Layout{ConfigDir: filepath.Join(t.TempDir(), "config")})
+	if err := store.UpdateIfChanged(func(*File) (bool, error) {
+		return false, nil
+	}); err != nil {
+		t.Fatalf("unchanged update: %v", err)
+	}
+
+	if _, err := os.Stat(store.Path()); !os.IsNotExist(err) {
+		t.Fatalf("unchanged update created config file: %v", err)
+	}
+
+	if err := store.UpdateIfChanged(func(cfg *File) (bool, error) {
+		cfg.DefaultTimezone = "UTC"
+		return true, nil
+	}); err != nil {
+		t.Fatalf("changed update: %v", err)
+	}
+
+	cfg, err := store.Read()
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+
+	if cfg.DefaultTimezone != "UTC" {
+		t.Fatalf("timezone = %q, want UTC", cfg.DefaultTimezone)
+	}
+
+	wantErr := os.ErrInvalid
+	if err := store.UpdateIfChanged(func(*File) (bool, error) {
+		return true, wantErr
+	}); !errors.Is(err, wantErr) {
+		t.Fatalf("callback error = %v, want %v", err, wantErr)
 	}
 }


### PR DESCRIPTION
## Summary

- honor dry-run before any Google fetch, OAuth flow, local cache, checkpoint, or repository mutation in backup push and remote authorization commands
- resolve effective backup destinations without side effects and redact credentials, query values, and fragments from previewed Git URLs
- make configuration, keyring, alias, account-client, and credential-domain updates share one atomic read-modify-write lock without rewriting unchanged configuration

## Verification

- reproduced silent lost account aliases against the published v0.38.0 binary and retained every alias with the fixed binary under concurrent real CLI processes
- validated both fixed backup push commands and both inferred OAuth remote steps with clawdbot@gmail.com while leaving isolated test directories completely empty
- full repository CI, focused race-detector regressions, independent code review, and hosted pull-request checks
- live Gmail, Calendar, Sheets, Slides, authentication, and local security boundary checks against the signed v0.38.0 release

Apps Script, Gmail draft creation, Google Chat, and positive BigQuery execution remain accurately reported as permission/account limitations rather than fabricated live successes.
