### PR TITLE
fix(cli): keep attachment dry runs safe and redact credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 ## 0.38.1 - Unreleased
 
 - Gmail: send exact prebuilt RFC822 messages with verified sender/account guards, normalized thread IDs, and content-safe offline dry runs. (#1032, #1029) — thanks @higginz777.
+- Gmail: honor attachment-download dry runs for threads and drafts without opening account credentials, fetching messages, or writing files.
 - Auth: add least-privilege Gmail `send` and `read-send` authorization, reject read-only/send conflicts, and preserve narrow Gmail grants during reauthorization. (#1033) — thanks @higginz777.
+- Security: redact authenticated Git remotes and configured API keys from backup/config command output and dry-run previews.
 - Backup: honor dry-run for all backup push commands without authenticating, fetching Google data, creating local caches or checkpoints, or changing Git repositories.
 - Auth: make remote authorization dry runs side-effect-free instead of creating OAuth state or exposing authorization URLs.
 - Config: preserve concurrent account aliases, client mappings, and security settings by keeping every configuration update inside its shared file lock.

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -82,8 +82,9 @@ With `--no-input`, backup Git operations disable credential/UI prompts and SSH
 password prompts; failed read-side clones leave the configured path untouched.
 Pre-created empty repository directories are supported, including mounted
 paths; failed clones clean their partial contents while preserving the directory.
-Git errors redact credentials embedded in remote URLs before printing command
-arguments or captured diagnostics.
+Backup initialization output and Git errors redact credentials embedded in
+remote URLs before printing command arguments, saved destinations, or captured
+diagnostics; the configured remote retains its original authentication data.
 With `--dry-run`, all four read commands print their resolved repository/pull
 plan without cloning, pulling, decrypting, or writing plaintext output.
 

--- a/docs/gmail-workflows.md
+++ b/docs/gmail-workflows.md
@@ -27,6 +27,11 @@ message text for automation. Message JSON remains under the `message` key;
 add `--results-only` to emit that sanitized message directly. Both shapes emit
 the message headers and body once.
 
+Thread and draft attachment downloads honor `--dry-run` before opening account
+credentials, fetching messages, or writing files. Thread downloads keep their
+current-directory default or explicit `--out-dir`; draft downloads retain the
+existing configured attachment directory.
+
 ## Filters
 
 Export filters as Gmail WebUI-compatible XML:

--- a/docs/youtube.md
+++ b/docs/youtube.md
@@ -18,6 +18,9 @@ gog config set youtube_api_key YOUR_API_KEY
 gog yt videos list --chart mostPopular --region US --max 5
 ```
 
+Configuration writes and dry-run previews redact API keys from their output
+while preserving the original stored value.
+
 Account reads use the default `youtube.readonly` scope:
 
 ```bash

--- a/internal/cmd/backup.go
+++ b/internal/cmd/backup.go
@@ -152,17 +152,18 @@ func (c *BackupInitCmd) Run(ctx context.Context, flags *RootFlags) error {
 	if err != nil {
 		return err
 	}
+	remote := backup.RedactGitURL(cfg.Remote)
 	if outfmt.IsJSON(ctx) {
 		return outfmt.WriteJSON(ctx, stdoutWriter(ctx), map[string]any{
 			"repo":      cfg.Repo,
-			"remote":    cfg.Remote,
+			"remote":    remote,
 			"identity":  cfg.Identity,
 			"recipient": recipient,
 		})
 	}
 	u := ui.FromContext(ctx)
 	u.Out().Linef("repo\t%s", cfg.Repo)
-	u.Out().Linef("remote\t%s", cfg.Remote)
+	u.Out().Linef("remote\t%s", remote)
 	u.Out().Linef("identity\t%s", cfg.Identity)
 	u.Out().Linef("recipient\t%s", recipient)
 	return nil

--- a/internal/cmd/backup_cmd_test.go
+++ b/internal/cmd/backup_cmd_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/openclaw/gogcli/internal/app"
 	"github.com/openclaw/gogcli/internal/backup"
+	"github.com/openclaw/gogcli/internal/outfmt"
 	"github.com/openclaw/gogcli/internal/secrets"
 )
 
@@ -329,11 +330,17 @@ func TestBackupInitNoPushUsesLocalRepoWithoutDefaultRemote(t *testing.T) {
 }
 
 func TestBackupInitNoPushPreservesConfiguredRemote(t *testing.T) {
-	for _, remote := range []string{
-		"git@example.com:private/backup.git",
-		"https://github.com/steipete/backup-gog.git",
+	for _, tc := range []struct {
+		name   string
+		remote string
+		json   bool
+	}{
+		{name: "SSH remote", remote: "git@example.com:private/backup.git", json: true},
+		{name: "HTTPS remote", remote: "https://github.com/steipete/backup-gog.git", json: true},
+		{name: "credentialed remote JSON", remote: syntheticBackupRemote(), json: true},
+		{name: "credentialed remote text", remote: syntheticBackupRemote()},
 	} {
-		t.Run(remote, func(t *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
 			dir := t.TempDir()
 			configPath := filepath.Join(dir, "backup.json")
 			repoPath := filepath.Join(dir, "repo")
@@ -347,18 +354,23 @@ func TestBackupInitNoPushPreservesConfiguredRemote(t *testing.T) {
 			store := backupOptionsForCmdTest(t, backup.Options{ConfigPath: configPath}).ConfigStore
 			if err := store.Save(configPath, backup.Config{
 				Repo:     repoPath,
-				Remote:   remote,
+				Remote:   tc.remote,
 				Identity: identityPath,
 			}); err != nil {
 				t.Fatalf("SaveConfig: %v", err)
 			}
 
+			var output bytes.Buffer
+			ctx := newCmdRuntimeOutputContext(t, &output, io.Discard)
+			if tc.json {
+				ctx = outfmt.WithMode(ctx, outfmt.Mode{JSON: true})
+			}
 			err := (&BackupInitCmd{
 				backupFlags: backupFlags{
 					Config: configPath,
 					NoPush: true,
 				},
-			}).Run(newCmdRuntimeJSONOutputContext(t, io.Discard, io.Discard), &RootFlags{NoInput: true})
+			}).Run(ctx, &RootFlags{NoInput: true})
 			if err != nil {
 				t.Fatalf("BackupInitCmd.Run: %v", err)
 			}
@@ -366,8 +378,16 @@ func TestBackupInitNoPushPreservesConfiguredRemote(t *testing.T) {
 			if loadErr != nil {
 				t.Fatalf("LoadConfig: %v", loadErr)
 			}
-			if cfg.Remote != remote {
+			if cfg.Remote != tc.remote {
 				t.Fatalf("--no-push init changed configured remote: %q", cfg.Remote)
+			}
+			if !strings.Contains(output.String(), backup.RedactGitURL(tc.remote)) {
+				t.Fatalf("output omitted sanitized configured remote: %q", output.String())
+			}
+			for _, secret := range []string{"synthetic-user", "synthetic-password", "synthetic-query", "synthetic-fragment"} {
+				if strings.Contains(output.String(), secret) {
+					t.Fatalf("backup init exposed remote credential %q", secret)
+				}
 			}
 		})
 	}

--- a/internal/cmd/config_cmd.go
+++ b/internal/cmd/config_cmd.go
@@ -75,13 +75,21 @@ func (c *ConfigSetCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return usage(err.Error())
 	}
 
-	if err := config.SetValue(&config.File{}, key, c.Value); err != nil {
+	if validationErr := config.SetValue(&config.File{}, key, c.Value); validationErr != nil {
+		return usage(validationErr.Error())
+	}
+	spec, err := config.KeySpecFor(key)
+	if err != nil {
 		return usage(err.Error())
+	}
+	displayValue := c.Value
+	if spec.Sensitive {
+		displayValue = "[REDACTED]"
 	}
 
 	if err := dryRunExit(ctx, flags, "config.set", map[string]any{
 		"key":   key.String(),
-		"value": c.Value,
+		"value": displayValue,
 	}); err != nil {
 		return err
 	}
@@ -93,11 +101,11 @@ func (c *ConfigSetCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		payload := outfmt.KeyValuePayload(key.String(), c.Value)
+		payload := outfmt.KeyValuePayload(key.String(), displayValue)
 		payload["saved"] = true
 		return outfmt.WriteJSON(ctx, stdoutWriter(ctx), payload)
 	}
-	fmt.Fprintf(stdoutWriter(ctx), "Set %s = %s\n", c.Key, c.Value)
+	fmt.Fprintf(stdoutWriter(ctx), "Set %s = %s\n", c.Key, displayValue)
 	return nil
 }
 

--- a/internal/cmd/config_cmd_test.go
+++ b/internal/cmd/config_cmd_test.go
@@ -281,6 +281,67 @@ func TestConfigCmd_DryRunLeavesConfigAndLockUntouched(t *testing.T) {
 	}
 }
 
+func TestConfigSetRedactsSensitiveValues(t *testing.T) {
+	t.Parallel()
+
+	for _, key := range []config.Key{config.KeyYoutubeAPIKey, config.KeyPlacesAPIKey} {
+		for _, tc := range []struct {
+			name   string
+			json   bool
+			dryRun bool
+		}{
+			{name: "JSON preview", json: true, dryRun: true},
+			{name: "plain preview", dryRun: true},
+			{name: "JSON saved", json: true},
+			{name: "plain saved"},
+		} {
+			t.Run(key.String()+" "+tc.name, func(t *testing.T) {
+				t.Parallel()
+
+				configDir := filepath.Join(t.TempDir(), "config")
+				store := config.NewConfigStore(config.Layout{ConfigDir: configDir})
+				runtime := &app.Runtime{Config: store}
+				value := "synthetic-" + key.String() + "-value"
+				args := []string{}
+				if tc.json {
+					args = append(args, "--json")
+				} else {
+					args = append(args, "--plain")
+				}
+				if tc.dryRun {
+					args = append(args, "--dry-run")
+				}
+				args = append(args, "config", "set", key.String(), value)
+				result := executeWithTestRuntime(t, args, runtime)
+				if result.err != nil {
+					t.Fatalf("config set: %v\n%s", result.err, result.stderr)
+				}
+				if strings.Contains(result.stdout, value) || strings.Contains(result.stderr, value) ||
+					!strings.Contains(result.stdout, "[REDACTED]") {
+					t.Fatalf("sensitive value escaped output: stdout=%q stderr=%q", result.stdout, result.stderr)
+				}
+				if tc.dryRun {
+					if _, err := os.Stat(configDir); !os.IsNotExist(err) {
+						t.Fatalf("dry-run created configuration state: %v", err)
+					}
+					return
+				}
+				cfg, err := store.Read()
+				if err != nil {
+					t.Fatalf("read stored config: %v", err)
+				}
+				stored := cfg.YoutubeAPIKey
+				if key == config.KeyPlacesAPIKey {
+					stored = cfg.PlacesAPIKey
+				}
+				if stored != value {
+					t.Fatalf("stored value = %q, want the unchanged original", stored)
+				}
+			})
+		}
+	}
+}
+
 func TestRemoveDomainMappings_NoMatchLeavesConfigAbsent(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cmd/gmail_attachment_dryrun_test.go
+++ b/internal/cmd/gmail_attachment_dryrun_test.go
@@ -1,0 +1,115 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"google.golang.org/api/gmail/v1"
+
+	"github.com/openclaw/gogcli/internal/app"
+	"github.com/openclaw/gogcli/internal/secrets"
+)
+
+func TestGmailAttachmentDownloadDryRunsAvoidAuthenticationAndWrites(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		command []string
+		op      string
+		id      string
+		indexed bool
+		draft   bool
+		custom  bool
+	}{
+		{
+			name:    "thread get defaults to current directory",
+			command: []string{"gmail", "thread", "get", "https://mail.google.com/mail/u/0/#inbox/18abcdef123", "--download"},
+			op:      "gmail.thread.get.download",
+			id:      "18abcdef123",
+		},
+		{
+			name:    "thread attachments preserve explicit indexed destination",
+			command: []string{"gmail", "thread", "attachments", "18abcdef123", "--download", "--use-indexed-attachment-ids"},
+			op:      "gmail.thread.attachments.download",
+			id:      "18abcdef123",
+			indexed: true,
+			custom:  true,
+		},
+		{
+			name:    "draft get preserves configuration destination",
+			command: []string{"gmail", "drafts", "get", "draft-123", "--download", "--use-indexed-attachment-ids"},
+			op:      "gmail.drafts.get.download",
+			id:      "draft-123",
+			indexed: true,
+			draft:   true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			home := filepath.Join(dir, "home")
+			outputDir := "."
+			if tc.custom {
+				outputDir = filepath.Join(dir, "attachments")
+			}
+			if tc.draft {
+				outputDir = filepath.Join(home, "config", "gmail-attachments")
+			}
+			authCalls, gmailCalls := 0, 0
+			runtime := &app.Runtime{
+				Auth: app.AuthOperations{
+					OpenSecretsStore: func() (secrets.Store, error) {
+						authCalls++
+						return nil, errors.New("attachment dry-run opened the keyring")
+					},
+				},
+				Services: app.Services{
+					Gmail: func(context.Context, string) (*gmail.Service, error) {
+						gmailCalls++
+						return nil, errors.New("attachment dry-run created a Gmail client")
+					},
+				},
+			}
+			args := []string{"--home", home, "--json", "--no-input", "--readonly", "--gmail-no-send", "--dry-run"}
+			args = append(args, tc.command...)
+			if tc.custom {
+				args = append(args, "--out-dir", outputDir)
+			}
+			result := executeWithTestRuntime(t, args, runtime)
+			if result.err != nil {
+				t.Fatalf("dry-run: %v\n%s", result.err, result.stderr)
+			}
+			if authCalls != 0 || gmailCalls != 0 {
+				t.Fatalf("dry-run used auth or Gmail: auth=%d gmail=%d", authCalls, gmailCalls)
+			}
+			entries, err := os.ReadDir(dir)
+			if err != nil || len(entries) != 0 {
+				t.Fatalf("dry-run wrote local data: entries=%#v err=%v", entries, err)
+			}
+			var got struct {
+				DryRun  bool   `json:"dry_run"`
+				Op      string `json:"op"`
+				Request struct {
+					ThreadID string `json:"thread_id"`
+					DraftID  string `json:"draft_id"`
+					OutDir   string `json:"out_dir"`
+					Download bool   `json:"download"`
+					Indexed  bool   `json:"use_indexed_attachment_ids"`
+				} `json:"request"`
+			}
+			if err := json.Unmarshal([]byte(result.stdout), &got); err != nil {
+				t.Fatalf("decode dry-run: %v", err)
+			}
+			id := got.Request.ThreadID
+			if tc.draft {
+				id = got.Request.DraftID
+			}
+			if !got.DryRun || got.Op != tc.op || id != tc.id || got.Request.OutDir != outputDir ||
+				!got.Request.Download || got.Request.Indexed != tc.indexed {
+				t.Fatalf("unexpected dry-run plan: %#v", got)
+			}
+		})
+	}
+}

--- a/internal/cmd/gmail_drafts.go
+++ b/internal/cmd/gmail_drafts.go
@@ -114,6 +114,18 @@ func (c *GmailDraftsGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return usage("empty draftId")
 	}
 
+	attachDir := ""
+	if c.Download {
+		layout, err := commandLayout(ctx, config.PathKindConfig)
+		if err != nil {
+			return err
+		}
+		attachDir = layout.GmailAttachmentsDir()
+		if err := attachmentDownloadDryRun(ctx, flags, "gmail.drafts.get.download", "draft_id", draftID, attachDir, c.UseIndexedAttachmentIDs); err != nil {
+			return err
+		}
+	}
+
 	_, svc, err := requireGmailService(ctx, flags)
 	if err != nil {
 		return err
@@ -133,13 +145,8 @@ func (c *GmailDraftsGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 
 	msg := draft.Message
 	attachments := collectAttachments(msg.Payload)
-	attachDir := ""
-	if c.Download && msg.Id != "" && len(attachments) > 0 {
-		layout, layoutErr := commandLayout(ctx, config.PathKindConfig)
-		if layoutErr != nil {
-			return layoutErr
-		}
-		attachDir = layout.GmailAttachmentsDir()
+	if msg.Id == "" || len(attachments) == 0 {
+		attachDir = ""
 	}
 	if outfmt.IsJSON(ctx) {
 		out := map[string]any{"draft": draft}

--- a/internal/cmd/gmail_thread.go
+++ b/internal/cmd/gmail_thread.go
@@ -34,14 +34,27 @@ type GmailThreadGetCmd struct {
 
 func (c *GmailThreadGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 	u := ui.FromContext(ctx)
-	account, err := requireAccount(flags)
-	if err != nil {
-		return err
-	}
 	threadID := strings.TrimSpace(c.ThreadID)
 	threadID = normalizeGmailThreadID(threadID)
 	if threadID == "" {
 		return usage("empty threadId")
+	}
+
+	var attachDir string
+	if c.Download {
+		var err error
+		attachDir, err = resolveGmailThreadAttachmentDir(c.OutputDir.Dir)
+		if err != nil {
+			return err
+		}
+		if err := attachmentDownloadDryRun(ctx, flags, "gmail.thread.get.download", "thread_id", threadID, attachDir, c.UseIndexedAttachmentIDs); err != nil {
+			return err
+		}
+	}
+
+	account, err := requireAccount(flags)
+	if err != nil {
+		return err
 	}
 
 	svc, err := gmailService(ctx, account)
@@ -52,20 +65,6 @@ func (c *GmailThreadGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 	thread, err := svc.Users.Threads.Get("me", threadID).Format("full").Context(ctx).Do()
 	if err != nil {
 		return err
-	}
-
-	var attachDir string
-	if c.Download {
-		if strings.TrimSpace(c.OutputDir.Dir) == "" {
-			// Default: current directory, not gogcli config dir.
-			attachDir = "."
-		} else {
-			expanded, err := config.ExpandPath(c.OutputDir.Dir)
-			if err != nil {
-				return err
-			}
-			attachDir = filepath.Clean(expanded)
-		}
 	}
 
 	if outfmt.IsJSON(ctx) {
@@ -247,14 +246,27 @@ type GmailThreadAttachmentsCmd struct {
 
 func (c *GmailThreadAttachmentsCmd) Run(ctx context.Context, flags *RootFlags) error {
 	u := ui.FromContext(ctx)
-	account, err := requireAccount(flags)
-	if err != nil {
-		return err
-	}
 	threadID := strings.TrimSpace(c.ThreadID)
 	threadID = normalizeGmailThreadID(threadID)
 	if threadID == "" {
 		return usage("empty threadId")
+	}
+
+	var attachDir string
+	if c.Download {
+		var err error
+		attachDir, err = resolveGmailThreadAttachmentDir(c.OutputDir.Dir)
+		if err != nil {
+			return err
+		}
+		if err := attachmentDownloadDryRun(ctx, flags, "gmail.thread.attachments.download", "thread_id", threadID, attachDir, c.UseIndexedAttachmentIDs); err != nil {
+			return err
+		}
+	}
+
+	account, err := requireAccount(flags)
+	if err != nil {
+		return err
 	}
 
 	svc, err := gmailService(ctx, account)
@@ -276,19 +288,6 @@ func (c *GmailThreadAttachmentsCmd) Run(ctx context.Context, flags *RootFlags) e
 		}
 		u.Err().Println("Empty thread")
 		return nil
-	}
-
-	var attachDir string
-	if c.Download {
-		if strings.TrimSpace(c.OutputDir.Dir) == "" {
-			attachDir = "."
-		} else {
-			expanded, err := config.ExpandPath(c.OutputDir.Dir)
-			if err != nil {
-				return err
-			}
-			attachDir = filepath.Clean(expanded)
-		}
 	}
 
 	allAttachments := make([]attachmentDownloadOutput, 0)
@@ -333,6 +332,26 @@ func (c *GmailThreadAttachmentsCmd) Run(ctx context.Context, flags *RootFlags) e
 	}
 	printAttachmentLines(u.Out(), attachmentOutputsFromDownloads(allAttachments))
 	return nil
+}
+
+func resolveGmailThreadAttachmentDir(value string) (string, error) {
+	if strings.TrimSpace(value) == "" {
+		return ".", nil
+	}
+	expanded, err := config.ExpandPath(value)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Clean(expanded), nil
+}
+
+func attachmentDownloadDryRun(ctx context.Context, flags *RootFlags, op, idKey, id, outputDir string, indexed bool) error {
+	return dryRunExit(ctx, flags, op, map[string]any{
+		idKey:                        id,
+		"download":                   true,
+		"out_dir":                    outputDir,
+		"use_indexed_attachment_ids": indexed,
+	})
 }
 
 type GmailURLCmd struct {

--- a/internal/config/keys.go
+++ b/internal/config/keys.go
@@ -24,6 +24,7 @@ type KeySpec struct {
 	Set       func(*File, string) error
 	Unset     func(*File)
 	EmptyHint func() string
+	Sensitive bool
 }
 
 var keyOrder = []Key{
@@ -94,7 +95,8 @@ var keySpecs = map[Key]KeySpec{
 		},
 	},
 	KeyYoutubeAPIKey: {
-		Key: KeyYoutubeAPIKey,
+		Key:       KeyYoutubeAPIKey,
+		Sensitive: true,
 		Get: func(cfg File) string {
 			if v := os.Getenv("GOG_YOUTUBE_API_KEY"); v != "" {
 				return v
@@ -114,7 +116,8 @@ var keySpecs = map[Key]KeySpec{
 		},
 	},
 	KeyPlacesAPIKey: {
-		Key: KeyPlacesAPIKey,
+		Key:       KeyPlacesAPIKey,
+		Sensitive: true,
 		Get: func(cfg File) string {
 			if v := os.Getenv("GOG_PLACES_API_KEY"); v != "" {
 				return v


### PR DESCRIPTION
## Summary

- Honor `--dry-run` before account lookup, Gmail requests, or local writes for thread-get, thread-attachments, and draft-get attachment downloads while preserving their existing output-directory defaults.
- Redact credential-bearing Git remote URLs from successful backup initialization output without changing the configured Git remote.
- Mark supported YouTube and Places API keys as sensitive and redact their values from configuration set previews and success output while preserving the actual stored values.

## Verification

- `make ci` passes, including all Go/Node tests, lint, dead-code checks, 728 generated command pages, docs coverage, and generated agent skills.
- Focused regressions prove all three attachment-download previews avoid keyring access, Gmail client construction, and filesystem writes; existing actual-download tests continue to pass.
- Additional regressions cover JSON/plain output and dry-run/real writes for both API-key settings, plus JSON/plain initialization with synthetic credentialed Git remotes and preserved stored remotes.
- Live tested against the designated Gmail account: fetched a real thread, attachment, and draft; verified all three dry-run plans without credentials or writes; successfully downloaded the real attachment through both thread commands into temporary folders; removed all temporary files afterward.
- Live tested isolated CLI backup initialization and both API-key settings; public output was redacted while the original persisted values remained intact.

No mail was sent, no existing account authorization was changed, and existing default download locations are unchanged.
