### PR TITLE
fix(download): honor explicit new output directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Gmail: send exact prebuilt RFC822 messages with verified sender/account guards, normalized thread IDs, and content-safe offline dry runs. (#1032, #1029) — thanks @higginz777.
 - Gmail: honor attachment-download dry runs for threads and drafts without opening account credentials, fetching messages, or writing files.
+- Downloads: honor explicit new output directories for Drive, Docs/Sheets/Slides exports, Docs tabs, Photos, and Photos Picker without changing existing defaults or overwrite protections.
 - Auth: add least-privilege Gmail `send` and `read-send` authorization, reject read-only/send conflicts, and preserve narrow Gmail grants during reauthorization. (#1033) — thanks @higginz777.
 - Security: redact authenticated Git remotes and configured API keys from backup/config command output and dry-run previews.
 - Backup: honor dry-run for all backup push commands without authenticating, fetching Google data, creating local caches or checkpoints, or changing Git repositories.

--- a/docs/refactor/exports.md
+++ b/docs/refactor/exports.md
@@ -27,7 +27,7 @@ Exception: `gog docs export --tab <title-or-id>` exports a single Google Docs ta
 - Arg is always the Drive file id (Doc/Sheet/Slides id).
 - Type guard: compare `mimeType` and error with `file is not a <KindLabel> (mimeType="...")`.
 - `--out` defaults to `$(os.UserConfigDir())/gogcli/drive-downloads/` (via `internal/config:EnsureDriveDownloadsDir`).
-- `--out` can be dir or explicit file path (via `internal/cmd/drive_download_helpers.go:resolveDriveDownloadDestPath`).
+- `--out` can be an existing directory, a new directory ending in `/`, or an explicit file path (via `internal/cmd/drive_download_helpers.go:resolveDriveDownloadDestPath`); missing parent directories are created only when writing the download.
 - `--out -` writes export bytes to stdout; JSON mode rejects it to avoid mixing metadata with bytes.
 - Output
   - `--json`: `{ "path": "...", "size": <bytes> }`

--- a/internal/cmd/docs_tab_export.go
+++ b/internal/cmd/docs_tab_export.go
@@ -8,7 +8,6 @@ import (
 	"mime"
 	"net/http"
 	"net/url"
-	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -133,7 +132,7 @@ func tabExportOutPath(outFlag, docID, tabQuery, format, defaultDir string) (stri
 		if err != nil {
 			return "", err
 		}
-		if st, statErr := os.Stat(expanded); statErr == nil && st.IsDir() {
+		if isDirIntent(outFlag, expanded) {
 			return filepath.Join(expanded, defaultBase), nil
 		}
 		return expanded, nil

--- a/internal/cmd/download_directory_test.go
+++ b/internal/cmd/download_directory_test.go
@@ -19,8 +19,7 @@ import (
 )
 
 func TestDownloadResolversHonorNewDirectoryIntent(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	home := setDownloadTestHome(t)
 
 	for _, test := range []struct {
 		name     string
@@ -70,8 +69,7 @@ func TestDownloadResolversHonorNewDirectoryIntent(t *testing.T) {
 }
 
 func TestDriveDownloadAndExportsHonorHomeDirectoryIntent(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	home := setDownloadTestHome(t)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fileID := filepath.Base(r.URL.Path)
 		mimeType := "text/plain"
@@ -135,8 +133,7 @@ func TestDriveDownloadAndExportsHonorHomeDirectoryIntent(t *testing.T) {
 }
 
 func TestPhotosDownloadHonorsHomeDirectoryIntent(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	home := setDownloadTestHome(t)
 	var srv *httptest.Server
 	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
@@ -170,4 +167,12 @@ func TestPhotosDownloadHonorsHomeDirectoryIntent(t *testing.T) {
 	if data, err := os.ReadFile(want); err != nil || string(data) != "photo-proof" {
 		t.Fatalf("downloaded photo = %q, %v", data, err)
 	}
+}
+
+func setDownloadTestHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	return home
 }

--- a/internal/cmd/download_directory_test.go
+++ b/internal/cmd/download_directory_test.go
@@ -1,0 +1,173 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/drive/v3"
+	"google.golang.org/api/option"
+
+	"github.com/openclaw/gogcli/internal/googleapi"
+)
+
+func TestDownloadResolversHonorNewDirectoryIntent(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	for _, test := range []struct {
+		name     string
+		filename string
+		resolve  func(string) (string, error)
+	}{
+		{
+			name: "drive", filename: "file1_report.txt",
+			resolve: func(out string) (string, error) {
+				return resolveDriveDownloadDestPath(&drive.File{Id: "file1", Name: "../report.txt"}, out, "")
+			},
+		},
+		{
+			name: "photos", filename: "report.txt",
+			resolve: func(out string) (string, error) {
+				return resolvePhotosDownloadDestPathParts("photo1", "../report.txt", out, "")
+			},
+		},
+		{
+			name: "docs tab", filename: "doc1_Budget_2026.pdf",
+			resolve: func(out string) (string, error) {
+				return tabExportOutPath(out, "doc1", "Budget 2026", "pdf", "")
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			out := "~/new/" + strings.ReplaceAll(test.name, " ", "-") + "/"
+			got, err := test.resolve(out)
+			if err != nil {
+				t.Fatalf("resolve directory: %v", err)
+			}
+			want := filepath.Join(home, "new", strings.ReplaceAll(test.name, " ", "-"), test.filename)
+			if got != want {
+				t.Fatalf("directory destination = %q, want %q", got, want)
+			}
+			if _, statErr := os.Stat(filepath.Dir(want)); !os.IsNotExist(statErr) {
+				t.Fatalf("resolver created destination directory: %v", statErr)
+			}
+
+			explicitFile := filepath.Join(home, "explicit", test.name)
+			got, err = test.resolve(explicitFile)
+			if err != nil || got != explicitFile {
+				t.Fatalf("explicit file = %q, %v; want %q", got, err, explicitFile)
+			}
+		})
+	}
+}
+
+func TestDriveDownloadAndExportsHonorHomeDirectoryIntent(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fileID := filepath.Base(r.URL.Path)
+		mimeType := "text/plain"
+		if fileID == "doc1" {
+			mimeType = "application/vnd.google-apps.document"
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": fileID, "name": "../report.txt", "mimeType": mimeType})
+	}))
+	defer srv.Close()
+
+	svc, err := drive.NewService(context.Background(), option.WithoutAuthentication(), option.WithHTTPClient(srv.Client()), option.WithEndpoint(srv.URL+"/"))
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	download := func(context.Context, *drive.Service, string) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("proof"))}, nil
+	}
+	export := func(context.Context, *drive.Service, string, string) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("proof"))}, nil
+	}
+
+	for _, test := range []struct {
+		name     string
+		args     []string
+		filename string
+	}{
+		{name: "drive", args: []string{"drive", "download", "file1"}, filename: "file1_report.txt"},
+		{name: "docs", args: []string{"docs", "export", "doc1", "--format", "pdf"}, filename: "doc1_report.pdf"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			args := append([]string{"--json", "--account", "a@example.com"}, test.args...)
+			args = append(args, "--out", "~/nested/"+test.name+"/")
+			result := executeWithDriveTestOperations(t, args, svc, download, export)
+			if result.err != nil {
+				t.Fatalf("download: %v", result.err)
+			}
+			var got struct {
+				Path string `json:"path"`
+				Size int64  `json:"size"`
+			}
+			if err := json.Unmarshal([]byte(result.stdout), &got); err != nil {
+				t.Fatalf("decode result: %v", err)
+			}
+			want := filepath.Join(home, "nested", test.name, test.filename)
+			if got.Path != want || got.Size != 5 {
+				t.Fatalf("download result = %#v, want path %q and size 5", got, want)
+			}
+			data, err := os.ReadFile(want)
+			if err != nil || string(data) != "proof" {
+				t.Fatalf("downloaded data = %q, %v", data, err)
+			}
+			if duplicate := executeWithDriveTestOperations(t, args, svc, download, export); !errors.Is(duplicate.err, os.ErrExist) {
+				t.Fatalf("duplicate download error = %v, want existing-file protection", duplicate.err)
+			}
+			if overwrite := executeWithDriveTestOperations(t, append(args, "--overwrite"), svc, download, export); overwrite.err != nil {
+				t.Fatalf("overwrite download: %v", overwrite.err)
+			}
+		})
+	}
+}
+
+func TestPhotosDownloadHonorsHomeDirectoryIntent(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/mediaItems/photo1":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id": "photo1", "filename": "../photo.jpg", "baseUrl": srv.URL + "/media/photo",
+			})
+		case "/media/photo=d":
+			_, _ = io.WriteString(w, "photo-proof")
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	client := googleapi.NewPhotosClient(srv.Client(), googleapi.WithPhotosBaseURL(srv.URL))
+	result := executeWithPhotosTestServices(t, []string{
+		"--json", "--account", "a@example.com", "photos", "download", "photo1", "--out", "~/photos/new/",
+	}, photosTestServices{Photos: fixedPhotosTestService(client)})
+	if result.err != nil {
+		t.Fatalf("download: %v", result.err)
+	}
+	want := filepath.Join(home, "photos", "new", "photo.jpg")
+	var got struct {
+		Path string `json:"path"`
+	}
+	if err := json.Unmarshal([]byte(result.stdout), &got); err != nil || got.Path != want {
+		t.Fatalf("download output = %q, %v; want path %q", result.stdout, err, want)
+	}
+	if data, err := os.ReadFile(want); err != nil || string(data) != "photo-proof" {
+		t.Fatalf("downloaded photo = %q, %v", data, err)
+	}
+}

--- a/internal/cmd/drive_download.go
+++ b/internal/cmd/drive_download.go
@@ -50,7 +50,8 @@ func (c *DriveDownloadCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return formatErr
 	}
 
-	outPathFlag := strings.TrimSpace(c.Output.Path)
+	rawOutPathFlag := strings.TrimSpace(c.Output.Path)
+	outPathFlag := rawOutPathFlag
 	if outPathFlag != "" {
 		expanded, expandErr := config.ExpandPath(outPathFlag)
 		if expandErr != nil {
@@ -104,7 +105,7 @@ func (c *DriveDownloadCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return fileFormatErr
 	}
 
-	destPath, err := resolveDriveDownloadDestPath(meta, outPathFlag, defaultDir)
+	destPath, err := resolveDriveDownloadDestPath(meta, rawOutPathFlag, defaultDir)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/drive_download_helpers.go
+++ b/internal/cmd/drive_download_helpers.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -49,7 +48,7 @@ func resolveDriveDownloadDestPath(meta *drive.File, outPathFlag, defaultDir stri
 		return filepath.Join(defaultDir, defaultName), nil
 	}
 
-	if st, err := os.Stat(destPath); err == nil && st.IsDir() {
+	if isDirIntent(outPathFlag, destPath) {
 		return filepath.Join(destPath, defaultName), nil
 	}
 	return destPath, nil

--- a/internal/cmd/dryrun_e2e_test.go
+++ b/internal/cmd/dryrun_e2e_test.go
@@ -204,6 +204,12 @@ func TestDryRunE2E_CommandsSkipAuthAPIAndFileWrites(t *testing.T) {
 			outPath: outputPath("drive.bin"),
 		},
 		{
+			name:    "drive download new directory",
+			args:    []string{"drive", "download", "file123", "--out", outputPath("new-drive-dir") + string(os.PathSeparator)},
+			op:      "drive.download",
+			outPath: outputPath("new-drive-dir"),
+		},
+		{
 			name: "drive changes watch",
 			args: []string{"drive", "changes", "watch", "--token", "token123", "--webhook-url", "https://example.com/hook", "--channel-id", "channel123"},
 			op:   "drive.changes.watch",
@@ -742,10 +748,22 @@ func TestDryRunE2E_CommandsSkipAuthAPIAndFileWrites(t *testing.T) {
 			outPath: outputPath("photo.jpg"),
 		},
 		{
+			name:    "photos download new directory",
+			args:    []string{"photos", "download", "media123", "--out", outputPath("new-photos-dir") + string(os.PathSeparator)},
+			op:      "photos.download",
+			outPath: outputPath("new-photos-dir"),
+		},
+		{
 			name:    "photos picker download",
 			args:    []string{"photos", "picker", "download", "session123", "media123", "--out", outputPath("picked.jpg")},
 			op:      "photos.picker.download",
 			outPath: outputPath("picked.jpg"),
+		},
+		{
+			name:    "photos picker download new directory",
+			args:    []string{"photos", "picker", "download", "session123", "media123", "--out", outputPath("new-picker-dir") + string(os.PathSeparator)},
+			op:      "photos.picker.download",
+			outPath: outputPath("new-picker-dir"),
 		},
 	}
 

--- a/internal/cmd/export_via_drive.go
+++ b/internal/cmd/export_via_drive.go
@@ -35,7 +35,8 @@ func exportViaDrive(ctx context.Context, flags *RootFlags, opts exportViaDriveOp
 	}
 
 	// Avoid touching auth/keyring and avoid writing files in dry-run mode.
-	outPathFlag = strings.TrimSpace(outPathFlag)
+	rawOutPathFlag := strings.TrimSpace(outPathFlag)
+	outPathFlag = rawOutPathFlag
 	if outPathFlag != "" {
 		expanded, err := config.ExpandPath(outPathFlag)
 		if err != nil {
@@ -100,7 +101,7 @@ func exportViaDrive(ctx context.Context, flags *RootFlags, opts exportViaDriveOp
 		return fmt.Errorf("file is not a %s (mimeType=%q)", label, meta.MimeType)
 	}
 
-	destPath, err := resolveDriveDownloadDestPath(meta, outPathFlag, defaultDownloadsDir)
+	destPath, err := resolveDriveDownloadDestPath(meta, rawOutPathFlag, defaultDownloadsDir)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/gmail_attachment.go
+++ b/internal/cmd/gmail_attachment.go
@@ -222,20 +222,6 @@ func resolveAttachmentDest(messageID, attachmentID, outPathFlag, name, defaultDi
 	return filepath.Join(outPath, filename), nil
 }
 
-func isDirIntent(outPathFlag, expandedOutPath string) bool {
-	// Directory intent:
-	// - existing directory path
-	// - or explicit trailing slash for a (possibly non-existent) directory
-	flag := strings.TrimSpace(outPathFlag)
-	if strings.HasSuffix(flag, string(os.PathSeparator)) || strings.HasSuffix(flag, "/") || strings.HasSuffix(flag, "\\") {
-		return true
-	}
-	if st, statErr := os.Stat(expandedOutPath); statErr == nil && st.IsDir() {
-		return true
-	}
-	return false
-}
-
 func sanitizeAttachmentFilename(name, fallback string) string {
 	// Normalize Windows-style separators too; prevents "..\\..\\x" escapes when treating `--name` as a filename.
 	clean := strings.ReplaceAll(strings.TrimSpace(name), "\\", "/")

--- a/internal/cmd/output_file_helpers.go
+++ b/internal/cmd/output_file_helpers.go
@@ -28,6 +28,15 @@ func outputPathOrStdout(path string) string {
 	return path
 }
 
+func isDirIntent(outPathFlag, expandedOutPath string) bool {
+	flag := strings.TrimSpace(outPathFlag)
+	if strings.HasSuffix(flag, string(os.PathSeparator)) || strings.HasSuffix(flag, "/") || strings.HasSuffix(flag, "\\") {
+		return true
+	}
+	info, err := os.Stat(expandedOutPath)
+	return err == nil && info.IsDir()
+}
+
 func openUserOutputFile(path string, opts outputFileOptions) (*os.File, string, error) {
 	path = strings.TrimSpace(path)
 	if path == "" {

--- a/internal/cmd/photos.go
+++ b/internal/cmd/photos.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -128,7 +127,8 @@ func (c *PhotosDownloadCmd) Run(ctx context.Context, flags *RootFlags) error {
 	if mediaItemID == "" {
 		return usage("empty mediaItemId")
 	}
-	outPathFlag := strings.TrimSpace(c.Out)
+	rawOutPathFlag := strings.TrimSpace(c.Out)
+	outPathFlag := rawOutPathFlag
 	if outPathFlag != "" {
 		var expandErr error
 		outPathFlag, expandErr = config.ExpandPath(outPathFlag)
@@ -197,7 +197,7 @@ func (c *PhotosDownloadCmd) Run(ctx context.Context, flags *RootFlags) error {
 		_, err = io.Copy(stdoutWriter(ctx), resp.Body)
 		return err
 	}
-	dest, err := resolvePhotosDownloadDestPath(item, outPathFlag, defaultDir)
+	dest, err := resolvePhotosDownloadDestPath(item, rawOutPathFlag, defaultDir)
 	if err != nil {
 		return err
 	}
@@ -361,7 +361,7 @@ func resolvePhotosDownloadDestPathParts(itemID string, itemFilename string, outP
 		}
 		return filepath.Join(defaultDir, safeName), nil
 	}
-	if st, err := os.Stat(destPath); err == nil && st.IsDir() {
+	if isDirIntent(outPathFlag, destPath) {
 		return filepath.Join(destPath, safeName), nil
 	}
 	return destPath, nil

--- a/internal/cmd/photos_picker.go
+++ b/internal/cmd/photos_picker.go
@@ -187,7 +187,8 @@ func (c *PhotosPickerDownloadCmd) Run(ctx context.Context, flags *RootFlags) err
 	if mediaItemID == "" {
 		return usage("empty mediaItemId")
 	}
-	outPathFlag := strings.TrimSpace(c.Out)
+	rawOutPathFlag := strings.TrimSpace(c.Out)
+	outPathFlag := rawOutPathFlag
 	if outPathFlag != "" {
 		var expandErr error
 		outPathFlag, expandErr = appconfig.ExpandPath(outPathFlag)
@@ -235,7 +236,7 @@ func (c *PhotosPickerDownloadCmd) Run(ctx context.Context, flags *RootFlags) err
 	if item.MediaFile != nil {
 		filename = item.MediaFile.Filename
 	}
-	dest, err := resolvePhotosDownloadDestPathParts(item.ID, filename, outPathFlag, defaultDir)
+	dest, err := resolvePhotosDownloadDestPathParts(item.ID, filename, rawOutPathFlag, defaultDir)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/photos_picker_test.go
+++ b/internal/cmd/photos_picker_test.go
@@ -163,8 +163,7 @@ func TestPhotosPickerCommandWorkflow(t *testing.T) {
 		t.Fatalf("downloaded = %q", downloaded)
 	}
 
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	home := setDownloadTestHome(t)
 	directoryDownload := runWithPhotosTestServices(t, services, func(ctx context.Context) error {
 		return (&PhotosPickerDownloadCmd{
 			SessionID: "session-1", MediaItemID: "photo-1", Out: "~/picker/nested/",

--- a/internal/cmd/photos_picker_test.go
+++ b/internal/cmd/photos_picker_test.go
@@ -163,6 +163,20 @@ func TestPhotosPickerCommandWorkflow(t *testing.T) {
 		t.Fatalf("downloaded = %q", downloaded)
 	}
 
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	directoryDownload := runWithPhotosTestServices(t, services, func(ctx context.Context) error {
+		return (&PhotosPickerDownloadCmd{
+			SessionID: "session-1", MediaItemID: "photo-1", Out: "~/picker/nested/",
+		}).Run(ctx, flags)
+	})
+	if directoryDownload.err != nil {
+		t.Fatalf("directory download: %v", directoryDownload.err)
+	}
+	if data, err := os.ReadFile(filepath.Join(home, "picker", "nested", "picked.jpg")); err != nil || string(data) != "picked-photo" {
+		t.Fatalf("directory download = %q, %v", data, err)
+	}
+
 	deleteResult := runWithPhotosTestServices(t, services, func(ctx context.Context) error {
 		cmd := &PhotosPickerDeleteCmd{SessionID: "session-1"}
 		return cmd.Run(ctx, flags)


### PR DESCRIPTION
## Summary

Fix output-directory handling consistently across Drive downloads, Docs/Sheets/Slides exports, Docs tab exports, Google Photos, and Photos Picker without changing default download locations.

- Treat an explicit trailing slash as directory intent even when that directory does not exist yet.
- Preserve the original `--out` value across home-directory expansion so quoted `~/new-directory/` still means a directory.
- Reuse the existing Gmail attachment directory-intent helper at the shared output-file boundary; continue creating private directories only during the real write.
- Preserve existing stdout behavior, provider-filename sanitization, export extensions, `0600` files, `0700` directories, and refusal to overwrite without `--overwrite`.
- Cover all affected command families, adversarial provider filenames, overwrite/no-overwrite behavior, and dry runs that must not create directories.

## Proof

- Every new regression first failed against current `main` across Drive, Docs export, Photos, Photos Picker, and Docs tab destination resolution.
- `make ci` passed, including formatting, lint, all Go packages, JavaScript tests, and all 728 generated command pages.
- Independent pre-commit review reported no actionable findings.
- Live Google Drive validation uploaded one disposable copy of the repository's public license, performed an accountless no-write dry run, downloaded into a previously nonexistent nested directory, compared bytes, verified `0600`/`0700` permissions and overwrite refusal, repeated with `--overwrite`, and permanently deleted only the disposable uploaded file.
- Existing default-directory behavior remains unchanged; this does not close or redefine #1022.
