### PR TITLE
fix(sheets): reject ambiguous Connected Sheets refresh replies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Downloads: honor explicit new output directories for Drive, Docs/Sheets/Slides exports, Docs tabs, Photos, and Photos Picker without changing existing defaults or overwrite protections.
 - Auth: add least-privilege Gmail `send` and `read-send` authorization, reject read-only/send conflicts, and preserve narrow Gmail grants during reauthorization. (#1033) — thanks @higginz777.
 - Security: redact authenticated Git remotes and configured API keys from backup/config command output and dry-run previews.
+- Sheets: reject missing Connected Sheets refresh replies without claiming success or retrying a potentially billable execution.
 - Backup: honor dry-run for all backup push commands without authenticating, fetching Google data, creating local caches or checkpoints, or changing Git repositories.
 - Auth: make remote authorization dry runs side-effect-free instead of creating OAuth state or exposing authorization URLs.
 - Config: preserve concurrent account aliases, client mappings, and security settings by keeping every configuration update inside its shared file lock.

--- a/docs/sheets-connected.md
+++ b/docs/sheets-connected.md
@@ -81,7 +81,7 @@ gog --account you@example.com \
 
 Refresh requires writable Sheets authorization plus the explicitly granted `bigquery.readonly` scope. Only the requested source is refreshed; the command never refreshes an entire spreadsheet and never automatically retries a potentially billable execution. Use `--force-refresh` when retrying a source already in an error state. `--readonly` blocks the operation, while `--dry-run` previews it without authentication or network access.
 
-Google starts refreshes asynchronously. JSON preserves the provider's native object references and execution statuses; an immediately `FAILED` status returns a nonzero exit code while retaining its structured JSON output. Poll `list` or `describe` until `state` is `SUCCEEDED` or `FAILED`.
+Google starts refreshes asynchronously. JSON preserves the provider's native object references and execution statuses; an immediately `FAILED` status returns a nonzero exit code while retaining its structured JSON output. If Google returns no matching execution reply, the command fails without retrying because the potentially billable refresh may already have started; inspect the source before trying again. Poll `list` or `describe` until `state` is `SUCCEEDED` or `FAILED`.
 
 ## Delete one data source
 

--- a/internal/cmd/sheets_datasource_refresh.go
+++ b/internal/cmd/sheets_datasource_refresh.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"google.golang.org/api/sheets/v4"
@@ -46,12 +47,13 @@ func (c *SheetsDataSourceRefreshCmd) Run(ctx context.Context, flags *RootFlags) 
 	if err != nil {
 		return err
 	}
-
-	statuses := make([]*sheets.RefreshDataSourceObjectExecutionStatus, 0)
-	if response != nil && len(response.Replies) > 0 && response.Replies[0] != nil &&
-		response.Replies[0].RefreshDataSource != nil {
-		statuses = append(statuses, response.Replies[0].RefreshDataSource.Statuses...)
+	if response == nil || len(response.Replies) == 0 || response.Replies[0] == nil ||
+		response.Replies[0].RefreshDataSource == nil {
+		return fmt.Errorf("provider may have refreshed data source %s without returning its execution reply; inspect it before retrying", dataSourceID)
 	}
+
+	statuses := make([]*sheets.RefreshDataSourceObjectExecutionStatus, 0, len(response.Replies[0].RefreshDataSource.Statuses))
+	statuses = append(statuses, response.Replies[0].RefreshDataSource.Statuses...)
 
 	var failed *sheets.DataExecutionStatus
 	for _, status := range statuses {

--- a/internal/cmd/sheets_datasource_refresh_test.go
+++ b/internal/cmd/sheets_datasource_refresh_test.go
@@ -104,6 +104,63 @@ func TestSheetsDataSourceRefreshFailedStatusRetainsWrappedJSON(t *testing.T) {
 	}
 }
 
+func TestSheetsDataSourceRefreshRejectsMissingExecutionReply(t *testing.T) {
+	for _, body := range []string{
+		`null`,
+		`{}`,
+		`{"replies":[]}`,
+		`{"replies":[null]}`,
+		`{"replies":[{}]}`,
+		`{"replies":[{"updateDataSource":{}}]}`,
+		`{"replies":[{"refreshDataSource":null}]}`,
+	} {
+		t.Run(body, func(t *testing.T) {
+			var requests atomic.Int32
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				requests.Add(1)
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(body))
+			}))
+			defer srv.Close()
+
+			result := executeWithConnectedSheetsWriter(t, []string{
+				"--json", "--account", "services@openclaw.org", "sheets", "datasource", "refresh", "connected1", "ds-query",
+			}, newSheetsServiceFromServer(t, srv))
+			if result.err == nil || !strings.Contains(result.err.Error(), "may have refreshed") ||
+				!strings.Contains(result.err.Error(), "inspect it before retrying") {
+				t.Fatalf("ambiguous refresh must fail with inspection guidance: %v", result.err)
+			}
+			if result.stdout != "" {
+				t.Fatalf("ambiguous refresh reported false success: %q", result.stdout)
+			}
+			if requests.Load() != 1 {
+				t.Fatalf("potentially billable refresh ran %d times, want 1", requests.Load())
+			}
+		})
+	}
+}
+
+func TestSheetsDataSourceRefreshAllowsEmptyExecutionStatuses(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"replies":[{"refreshDataSource":{}}]}`))
+	}))
+	defer srv.Close()
+
+	result := executeWithConnectedSheetsWriter(t, []string{
+		"--json", "--account", "services@openclaw.org", "sheets", "datasource", "refresh", "connected1", "ds-query",
+	}, newSheetsServiceFromServer(t, srv))
+	if result.err != nil {
+		t.Fatalf("provider reply without optional statuses must succeed: %v", result.err)
+	}
+	var got struct {
+		Statuses []json.RawMessage `json:"statuses"`
+	}
+	if err := json.Unmarshal([]byte(result.stdout), &got); err != nil || got.Statuses == nil || len(got.Statuses) != 0 {
+		t.Fatalf("optional execution statuses must remain an empty JSON array: %q, %v", result.stdout, err)
+	}
+}
+
 func TestSheetsDataSourceRefreshDryRunDoesNotRequireAuth(t *testing.T) {
 	result := executeWithTestRuntime(t, []string{
 		"--json", "--readonly", "--dry-run", "sheets", "datasource", "refresh",


### PR DESCRIPTION
## Summary

Fail safely when a Connected Sheets refresh receives HTTP 200 without the matching refresh execution reply.

- Reject null, empty, missing, nil, or wrong-variant batch-update replies before printing misleading success.
- Preserve successful handling of a real refresh reply with no optional execution statuses.
- Explain that the provider may already have started the refresh and that users should inspect the source before retrying.
- Never automatically repeat a potentially billable refresh request.
- Keep the validation inside the refresh-command owner; delete operations legitimately accept empty replies.

## Proof

- Seven distinct malformed HTTP-200 provider fixtures first reproduced false success on current `main`.
- Every malformed response now returns an error, emits no success JSON, and performs exactly one POST.
- An existing refresh reply with omitted optional statuses still succeeds with an empty JSON statuses array; existing running, failed, dry-run, readonly, permission-guidance, and no-retry coverage remains green.
- Full local `make ci` passed, including formatting, lint, every Go package, JavaScript tests, and all 728 generated command pages.
- Independent pre-commit review reported no actionable findings.
- The malformed-provider behavior is proven with the actual pinned Google client and HTTP fixtures. A successful live BigQuery refresh remains intentionally unclaimed because the test account lacks the required explicit BigQuery grant and an approved billing-enabled execution project; #938 stays open.
