### PR TITLE
fix(sheets): preserve zero coordinates in refresh statuses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.38.2 - Unreleased
 
+- Sheets: preserve zero-valued sheet, row, and column indexes in Connected Sheets refresh status references, keeping A1 anchors identifiable. (#938) — thanks @ryo-touch.
 - Dependencies: prefer Go 1.27 while retaining Go 1.26 compatibility, refresh Google and MCP SDKs, update tracking worker dependencies and Go tooling, and refresh Docker build actions.
 
 ## 0.38.1 - 2026-08-25

--- a/docs/sheets-connected.md
+++ b/docs/sheets-connected.md
@@ -81,7 +81,7 @@ gog --account you@example.com \
 
 Refresh requires writable Sheets authorization plus the explicitly granted `bigquery.readonly` scope. Only the requested source is refreshed; the command never refreshes an entire spreadsheet and never automatically retries a potentially billable execution. Use `--force-refresh` when retrying a source already in an error state. `--readonly` blocks the operation, while `--dry-run` previews it without authentication or network access.
 
-Google starts refreshes asynchronously. JSON preserves the provider's native object references and execution statuses; an immediately `FAILED` status returns a nonzero exit code while retaining its structured JSON output. If Google returns no matching execution reply, the command fails without retrying because the potentially billable refresh may already have started; inspect the source before trying again. Poll `list` or `describe` until `state` is `SUCCEEDED` or `FAILED`.
+Google starts refreshes asynchronously. JSON preserves the provider's native object references and execution statuses, including explicit zero-valued sheet, row, and column indexes in table, pivot-table, and formula coordinates; an immediately `FAILED` status returns a nonzero exit code while retaining its structured JSON output. If Google returns no matching execution reply, the command fails without retrying because the potentially billable refresh may already have started; inspect the source before trying again. Poll `list` or `describe` until `state` is `SUCCEEDED` or `FAILED`.
 
 ## Delete one data source
 

--- a/internal/cmd/sheets_datasource_refresh.go
+++ b/internal/cmd/sheets_datasource_refresh.go
@@ -64,6 +64,7 @@ func (c *SheetsDataSourceRefreshCmd) Run(ctx context.Context, flags *RootFlags) 
 	}
 
 	if outfmt.IsJSON(ctx) {
+		preserveRefreshCoordinates(statuses)
 		if err := outfmt.WriteJSON(ctx, stdoutWriter(ctx), map[string]any{
 			"spreadsheetId": spreadsheetID,
 			"dataSourceId":  dataSourceID,
@@ -76,4 +77,21 @@ func (c *SheetsDataSourceRefreshCmd) Run(ctx context.Context, flags *RootFlags) 
 	}
 
 	return connectedSheetsExecutionError("refresh", failed)
+}
+
+func preserveRefreshCoordinates(statuses []*sheets.RefreshDataSourceObjectExecutionStatus) {
+	for _, status := range statuses {
+		if status == nil || status.Reference == nil {
+			continue
+		}
+		ref := status.Reference
+		for _, coordinate := range []*sheets.GridCoordinate{
+			ref.DataSourceTableAnchorCell, ref.DataSourcePivotTableAnchorCell, ref.DataSourceFormulaCell,
+		} {
+			if coordinate != nil {
+				// SDK omitempty fields otherwise erase A1 and sheet 0 from output.
+				coordinate.ForceSendFields = append(coordinate.ForceSendFields, "SheetId", "RowIndex", "ColumnIndex")
+			}
+		}
+	}
 }

--- a/internal/cmd/sheets_datasource_refresh_test.go
+++ b/internal/cmd/sheets_datasource_refresh_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -101,6 +102,79 @@ func TestSheetsDataSourceRefreshFailedStatusRetainsWrappedJSON(t *testing.T) {
 		got.Statuses[0].DataExecutionStatus.ErrorCode != "ENGINE" ||
 		!strings.Contains(got.Statuses[0].DataExecutionStatus.ErrorMessage, "EXTERNAL_UNTRUSTED_CONTENT") {
 		t.Fatalf("unexpected failed execution status: %#v", got.Statuses)
+	}
+}
+
+func TestSheetsDataSourceRefreshPreservesZeroCoordinates(t *testing.T) {
+	for _, state := range []string{"RUNNING", "FAILED"} {
+		t.Run(state, func(t *testing.T) {
+			references := make([]map[string]any, 0, 17)
+			for _, field := range []string{"dataSourceTableAnchorCell", "dataSourcePivotTableAnchorCell", "dataSourceFormulaCell"} {
+				for _, coordinate := range []map[string]int64{
+					{"sheetId": 0, "rowIndex": 0, "columnIndex": 0},
+					{"sheetId": 0, "rowIndex": 4, "columnIndex": 2},
+					{"sheetId": 12, "rowIndex": 0, "columnIndex": 2},
+					{"sheetId": 12, "rowIndex": 4, "columnIndex": 0},
+					{"sheetId": 12, "rowIndex": 4, "columnIndex": 2},
+				} {
+					references = append(references, map[string]any{field: coordinate})
+				}
+			}
+			references = append(references, map[string]any{"sheetId": "0"}, map[string]any{"chartId": 17})
+			statuses := make([]any, 0, len(references)+2)
+			for _, reference := range references {
+				statuses = append(statuses, map[string]any{
+					"reference": reference, "dataExecutionStatus": map[string]string{"state": state},
+				})
+			}
+			statuses = append(statuses, nil, map[string]any{"dataExecutionStatus": map[string]string{"state": state}})
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				// Use wire JSON, not SDK structs whose marshaler omits zero coordinates.
+				if err := json.NewEncoder(w).Encode(map[string]any{
+					"replies": []any{map[string]any{"refreshDataSource": map[string]any{"statuses": statuses}}},
+				}); err != nil {
+					t.Errorf("encode response: %v", err)
+				}
+			}))
+			defer srv.Close()
+
+			result := executeWithConnectedSheetsWriter(t, []string{
+				"--json", "--account", "a@example.com", "sheets", "datasource", "refresh", "connected1", "ds-query",
+			}, newSheetsServiceFromServer(t, srv))
+			if (result.err != nil) != (state == "FAILED") {
+				t.Fatalf("state %s: unexpected error %v", state, result.err)
+			}
+			var got struct {
+				Statuses []json.RawMessage `json:"statuses"`
+			}
+			if err := json.Unmarshal([]byte(result.stdout), &got); err != nil {
+				t.Fatalf("decode output: %v\n%s", err, result.stdout)
+			}
+			want, err := json.Marshal(statuses)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var wantStatuses []json.RawMessage
+			if err := json.Unmarshal(want, &wantStatuses); err != nil {
+				t.Fatal(err)
+			}
+			if len(got.Statuses) != len(wantStatuses) {
+				t.Fatalf("got %d statuses, want %d", len(got.Statuses), len(wantStatuses))
+			}
+			for i := range wantStatuses {
+				var actual, expected any
+				if err := json.Unmarshal(got.Statuses[i], &actual); err != nil {
+					t.Fatal(err)
+				}
+				if err := json.Unmarshal(wantStatuses[i], &expected); err != nil {
+					t.Fatal(err)
+				}
+				if !reflect.DeepEqual(actual, expected) {
+					t.Errorf("status %d lost provider fields: got %s, want %s", i, got.Statuses[i], wantStatuses[i])
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Connected Sheets refresh results lose the identity of extracts anchored at A1 on sheet 0. The Google Go SDK decodes the coordinates correctly, but its `omitempty` marshaler removes every zero-valued sheet, row, and column index when gog emits JSON. This reproduces the defect reported in the latest comment on #938.

This change preserves all three indexes on present table, pivot-table, and formula coordinates before JSON serialization. It retains the existing provider-shaped reference contract rather than introducing a new A1-string interface or fetching extra spreadsheet metadata. Missing references, native execution statuses, failure exit codes, authorization, and the single-request/no-retry boundary stay unchanged. Documentation and the changelog describe the corrected output.

Proof:

- Added an HTTP-backed command regression that fails on current main and passes with this fix. It checks 15 coordinate references, sheet/chart references, null statuses, and absent references for both RUNNING and FAILED responses.
- All 11 refresh tests passed (24 cases including subtests).
- Built and ran the actual CLI before and after the change against a loopback-only HTTPS Sheets fixture. Each invocation made exactly one batchUpdate request. Before: 3/15 coordinate references survived unchanged in each response; after: 15/15 for both RUNNING and FAILED. Exit codes remained 0 and 1 respectively.
- This is local HTTP/TLS integration proof, not a new Google/BigQuery run. No real credentials, billing resources, global trust-store changes, or external requests were used. The issue already contains the contributor's live reproduction and successful lifecycle validation.
- `make ci` passed: formatting, lint (0 issues), dead-code checks, 42 Go packages, 19 script tests, 4 documentation tests, 728 command pages / 27 feature pages, and generated-skill verification. The first run caught two test-slice preallocation lint warnings; both were corrected before the successful full rerun.
- `make worker-ci` passed: typecheck, Wrangler build dry run, and 15 tests across 3 files.
- Codex autoreview completed without accepted/actionable findings.

Fixes #938 (the remaining refresh-coordinate defect; the requested Connected Sheets lifecycle has already landed).
