### PR TITLE
fix(gmail): preserve direct access token in watch serve

### DIFF
--- a/docs/watch.md
+++ b/docs/watch.md
@@ -181,6 +181,15 @@ Schema (v1):
 - `--max-bytes`: hard cap on body bytes (default `20000`).
 - If over cap: truncate + set `bodyTruncated=true`.
 
+## Gmail API authentication
+
+`gog gmail watch serve` preserves the selected OAuth client and any direct
+`--access-token` (or `GOG_ACCESS_TOKEN`) when handling incoming push requests.
+Direct-token mode does not require stored OAuth client credentials or a refresh
+token. The token remains static and expires normally; restart the server with a
+fresh token when needed. This is separate from authenticating the push sender
+below.
+
 ## Auth (push)
 
 Preferred:

--- a/internal/cmd/gmail_watch_cmds.go
+++ b/internal/cmd/gmail_watch_cmds.go
@@ -401,11 +401,15 @@ func (c *GmailWatchServeCmd) Run(ctx context.Context, kctx *kong.Context, flags 
 	}
 
 	selectedClient := strings.TrimSpace(flags.Client)
+	directToken := authclient.AccessTokenFromContext(ctx)
 	gmailFactory, err := gmailServiceFactory(ctx)
 	if err != nil {
 		return err
 	}
 	serviceFactory := func(ctx context.Context, account string) (*gmail.Service, error) {
+		if directToken != "" {
+			ctx = authclient.WithAccessToken(ctx, directToken)
+		}
 		if selectedClient != "" {
 			ctx = authclient.WithClient(ctx, selectedClient)
 		}

--- a/internal/cmd/gmail_watch_serve_test.go
+++ b/internal/cmd/gmail_watch_serve_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -16,6 +17,7 @@ import (
 	"google.golang.org/api/idtoken"
 
 	"github.com/openclaw/gogcli/internal/authclient"
+	"github.com/openclaw/gogcli/internal/googleapi"
 )
 
 func TestGmailWatchServeCmd_DryRunDoesNotTouchStateOrListen(t *testing.T) {
@@ -465,6 +467,14 @@ func TestGmailWatchServeCmd_PreservesDirectAccessTokenForRequestContexts(t *test
 	t.Cleanup(func() { listenAndServe = origListen })
 
 	setWatchTestConfigHome(t)
+	gmailAPI := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Errorf("Authorization = %q, want Bearer test-token", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"historyId":"101"}`)
+	}))
+	t.Cleanup(gmailAPI.Close)
 
 	store := newGmailWatchTestStore(t, "a@b.com")
 	updateErr := store.Update(func(s *gmailWatchState) error {
@@ -484,11 +494,18 @@ func TestGmailWatchServeCmd_PreservesDirectAccessTokenForRequestContexts(t *test
 		return nil
 	}
 
-	ctx := withGmailTestServiceFactory(newCmdRuntimeOutputContext(t, io.Discard, io.Discard), func(ctx context.Context, _ string) (*gmail.Service, error) {
+	var serviceCtx context.Context
+	ctx := withGmailTestServiceFactory(newCmdRuntimeOutputContext(t, io.Discard, io.Discard), func(ctx context.Context, account string) (*gmail.Service, error) {
+		serviceCtx = ctx
 		if token := authclient.AccessTokenFromContext(ctx); token != "test-token" {
 			t.Fatalf("expected direct access token, got %q", token)
 		}
-		return &gmail.Service{}, nil
+		svc, err := googleapi.NewGmail(ctx, account)
+		if err != nil {
+			return nil, err
+		}
+		svc.BasePath = gmailAPI.URL + "/"
+		return svc, nil
 	})
 	ctx = authclient.WithAccessToken(ctx, "test-token")
 	if execErr := runKong(t, &GmailWatchServeCmd{}, []string{"--port", "9999", "--path", "/hook"}, ctx, flags); execErr != nil {
@@ -497,8 +514,29 @@ func TestGmailWatchServeCmd_PreservesDirectAccessTokenForRequestContexts(t *test
 	if got == nil {
 		t.Fatalf("expected server")
 	}
-	if _, callErr := got.newService(context.Background(), "a@b.com"); callErr != nil {
+	requestCtx, cancelRequest := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancelRequest()
+	svc, callErr := got.newService(requestCtx, "a@b.com")
+	if callErr != nil {
 		t.Fatalf("newService: %v", callErr)
+	}
+	wantDeadline, _ := requestCtx.Deadline()
+	if deadline, ok := serviceCtx.Deadline(); !ok || !deadline.Equal(wantDeadline) {
+		t.Fatalf("service deadline = %v, %t; want %v", deadline, ok, wantDeadline)
+	}
+	if serviceCtx.Done() != requestCtx.Done() {
+		t.Fatal("service context does not preserve request cancellation")
+	}
+	response, err := svc.Users.History.List("me").StartHistoryId(100).Context(requestCtx).Do()
+	if err != nil {
+		t.Fatalf("history: %v", err)
+	}
+	if response.HistoryId != 101 {
+		t.Fatalf("history ID = %d, want 101", response.HistoryId)
+	}
+	cancelRequest()
+	if err := serviceCtx.Err(); !errors.Is(err, context.Canceled) {
+		t.Fatalf("service context error = %v, want context.Canceled", err)
 	}
 }
 

--- a/internal/cmd/gmail_watch_serve_test.go
+++ b/internal/cmd/gmail_watch_serve_test.go
@@ -460,6 +460,48 @@ func TestGmailWatchServeCmd_PreservesClientOverrideForRequestContexts(t *testing
 	}
 }
 
+func TestGmailWatchServeCmd_PreservesDirectAccessTokenForRequestContexts(t *testing.T) {
+	origListen := listenAndServe
+	t.Cleanup(func() { listenAndServe = origListen })
+
+	setWatchTestConfigHome(t)
+
+	store := newGmailWatchTestStore(t, "a@b.com")
+	updateErr := store.Update(func(s *gmailWatchState) error {
+		s.Account = "a@b.com"
+		return nil
+	})
+	if updateErr != nil {
+		t.Fatalf("seed: %v", updateErr)
+	}
+
+	flags := &RootFlags{Account: "a@b.com"}
+	var got *gmailWatchServer
+	listenAndServe = func(srv *http.Server) error {
+		if gs, ok := srv.Handler.(*gmailWatchServer); ok {
+			got = gs
+		}
+		return nil
+	}
+
+	ctx := withGmailTestServiceFactory(newCmdRuntimeOutputContext(t, io.Discard, io.Discard), func(ctx context.Context, _ string) (*gmail.Service, error) {
+		if token := authclient.AccessTokenFromContext(ctx); token != "test-token" {
+			t.Fatalf("expected direct access token, got %q", token)
+		}
+		return &gmail.Service{}, nil
+	})
+	ctx = authclient.WithAccessToken(ctx, "test-token")
+	if execErr := runKong(t, &GmailWatchServeCmd{}, []string{"--port", "9999", "--path", "/hook"}, ctx, flags); execErr != nil {
+		t.Fatalf("execute: %v", execErr)
+	}
+	if got == nil {
+		t.Fatalf("expected server")
+	}
+	if _, callErr := got.newService(context.Background(), "a@b.com"); callErr != nil {
+		t.Fatalf("newService: %v", callErr)
+	}
+}
+
 func TestGmailWatchServeCmd_HTTPServerTimeouts(t *testing.T) {
 	origListen := listenAndServe
 	t.Cleanup(func() { listenAndServe = origListen })


### PR DESCRIPTION
## What Problem This Solves

`gog gmail watch serve` recognizes `--access-token` and
`GOG_ACCESS_TOKEN` when it starts, but loses that token while processing
Pub/Sub notifications.

When no stored OAuth credential metadata exists, each notification fails with:

```text
watch: handle push failed: gmail options: read credentials:
read credentials metadata: oauth credentials missing
```

The push endpoint consequently returns HTTP 500 even though the command was
started with a valid direct access token.

## Root Cause

The direct access token is stored in the command context. Each HTTP request
arrives with its own request context, which does not contain that value.

The watch server already captures and restores the selected OAuth client before
constructing a Gmail service for a request, but it does not do the same for the
direct access token. Gmail client construction therefore falls back to the
stored-credential path.

## Change

Capture the direct access token when `watch serve` starts and reattach it to
each request context before constructing the Gmail service.

Only the token value is copied. The HTTP request context remains the parent, so
request cancellation and deadlines are preserved.

This does not change:

- Stored OAuth credential behavior.
- Gmail watch authorization or filtering.
- Direct-token expiration or refresh behavior.
- CLI flags, output formats, or persisted state.

## User Impact

`gog gmail watch serve` can process notifications using its documented direct
access-token authentication mode without requiring stored OAuth client
credentials or refresh tokens.

The token remains static and expires normally; this change does not add
automatic refresh.

## Regression Coverage

Added
`TestGmailWatchServeCmd_PreservesDirectAccessTokenForRequestContexts`
beside the existing client-override request-context regression.

The test starts the command with a direct token in its command context, invokes
the constructed Gmail factory with a fresh request context, and verifies the
factory receives the original token. It fails on unmodified `main` with
`expected direct access token, got ""`.

## Real Behavior Proof

Tested on Linux amd64 with a real Gmail account, a broker-issued direct access
token, and a Gmail Pub/Sub notification. Identifiers and credentials are
redacted.

Before the change:

```text
Note: Using direct access token (expires in ~1 hour; no auto-refresh)
watch: listening on 127.0.0.1:<port>/
watch: handle push failed: gmail options: read credentials:
read credentials metadata: oauth credentials missing
HTTP/1.1 500 Internal Server Error
```

After the change, using a binary built from this PR:

```text
Note: Using direct access token (expires in ~1 hour; no auto-refresh)
watch: listening on 127.0.0.1:<port>/
DEBUG using direct access token serviceLabel=gmail
HTTP/1.1 200 OK
```

The patched process fetched the pending Gmail history successfully. No OAuth
client metadata or refresh token was available to the process.

## Testing

- `go test ./internal/cmd -run '^TestGmailWatchServeCmd_Preserves(DirectAccessToken|ClientOverride)ForRequestContexts$' -count=1`
- `make ci`
- Live Gmail Pub/Sub push verification described above.

## What Was Not Tested

- Allowing one direct token to expire inside a continuously running server.
  Direct tokens remain static and non-refreshing as documented.
- Stored-refresh-token authentication, which is unchanged.
- Pub/Sub OIDC verification, which is independent of Gmail API authentication.

## Maintainer follow-up

Kept the four-line production repair and strengthened the regression to use the real Gmail client against a local HTTP endpoint. It now verifies the outgoing bearer header as well as the incoming request's deadline and cancellation. Added watch documentation that distinguishes Gmail API authentication from push-sender authentication and makes static-token expiration explicit.

Independent before/after verification used two fresh, isolated gog homes with no stored OAuth client metadata. The only credential supplied to each watcher was a short-lived direct token, which authenticated real Gmail profile/history reads; the incoming push was synthetic and delivered only over loopback. Unchanged main returned HTTP 500 with the missing-credentials error. The repaired binary returned HTTP 202 for empty history and persisted the unique push ID and update timestamp, with the real history cursor unchanged and no auth-recovery state. Those state assertions rule out a stale/duplicate-push acknowledgment being mistaken for a successful authenticated request.

This verification did not send or modify mail, register a Gmail watch, or change Pub/Sub/IAM configuration. It was not an end-to-end Pub/Sub delivery test and did not wait for token expiration. The contributor's separate live Pub/Sub proof above is preserved as contributor evidence.

Verification:

- The direct-token regression fails against the original main service factory and passes with this repair.
- All watch-serve tests pass; the focused direct-token regression also passes with the race detector.
- Full local `make ci` passes on the patch applied to current main.
- Independent Codex autoreview found no findings in its requested P0 scope; the request-context and transport paths were also reviewed directly.

Thanks @bill-starfoundry for the fix and original live reproduction. Contributor credit is retained.

Exact-head GitHub verification also passed: [Linux, macOS, Windows, and worker CI](https://github.com/openclaw/gogcli/actions/runs/33607492291), plus the [Docker build](https://github.com/openclaw/gogcli/actions/runs/33607492284). Both fork workflows initially required maintainer approval; after approval, their first executed attempts passed. No CI repair or test rerun was needed.
