### PR TITLE
fix(http): cap Google Retry-After waits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.38.2 - Unreleased
 
+- Docs: validate page-layout sizes and margins before dry-run, and preview the resolved document-style request used for execution. (#1051) — thanks @ryo-touch.
 - Sheets: preserve zero-valued sheet, row, and column indexes in Connected Sheets refresh status references, keeping A1 anchors identifiable. (#938) — thanks @ryo-touch.
 - Dependencies: prefer Go 1.27 while retaining Go 1.26 compatibility, refresh Google and MCP SDKs, update tracking worker dependencies and Go tooling, and refresh Docker build actions.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.38.2 - Unreleased
 
+- HTTP: cap Google Retry-After delays at 60 seconds per retry, including numeric values that exceed integer or duration limits. (#1043) — thanks @SebTardif.
 - Sheets: preserve zero-valued sheet, row, and column indexes in Connected Sheets refresh status references, keeping A1 anchors identifiable. (#938) — thanks @ryo-touch.
 - Dependencies: prefer Go 1.27 while retaining Go 1.26 compatibility, refresh Google and MCP SDKs, update tracking worker dependencies and Go tooling, and refresh Docker build actions.
 

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -134,6 +134,10 @@ gog auth doctor --check --json --no-input
 
 ## Exit codes
 
+Google API rate-limit retries honor `Retry-After` delays up to 60 seconds per
+retry, including numeric seconds and HTTP dates. Cancelling the command also
+cancels a pending retry wait.
+
 | Code | Name | Meaning |
 | ---: | --- | --- |
 | 0 | `ok` | Success |

--- a/docs/docs-editing.md
+++ b/docs/docs-editing.md
@@ -366,6 +366,12 @@ flags are supplied; pass `--layout` when you also want to toggle pageless/pages.
 `--pageless` preserves Google Docs' existing width unless `--page-width` is set
 explicitly.
 
+`docs page-layout --dry-run --json` validates page sizes, dimensions, and
+margins before accessing Google. Its `request.updateDocumentStyle` preview
+includes the resolved point dimensions and field mask used for execution;
+the original flag values remain available alongside it. A requested tab is
+shown by name and resolved only when the command executes.
+
 Command page:
 
 - [`gog docs page-layout`](commands/gog-docs-page-layout.md)

--- a/internal/cmd/docs_set_page_layout.go
+++ b/internal/cmd/docs_set_page_layout.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/alecthomas/kong"
+	"google.golang.org/api/docs/v1"
 
 	"github.com/openclaw/gogcli/internal/outfmt"
 	"github.com/openclaw/gogcli/internal/ui"
@@ -47,8 +48,17 @@ func (c *DocsPageLayoutCmd) Run(ctx context.Context, kctx *kong.Context, flags *
 		return err
 	}
 
+	styleRequest, err := buildUpdateDocumentStyleRequest(docsDocumentStyleOptions{
+		Mode:            mode,
+		DocsLayoutFlags: c.LayoutFlags,
+	})
+	if err != nil {
+		return fmt.Errorf("set page layout: %w", err)
+	}
+
 	dryRunPayload := map[string]any{
-		"documentId": docID,
+		"documentId":          docID,
+		"updateDocumentStyle": styleRequest,
 	}
 	if mode != "" {
 		dryRunPayload["layout"] = c.Layout
@@ -77,11 +87,10 @@ func (c *DocsPageLayoutCmd) Run(ctx context.Context, kctx *kong.Context, flags *
 		}
 	}
 
-	if err := setDocumentStyle(ctx, svc, docID, docsDocumentStyleOptions{
-		Mode:            mode,
-		TabID:           tabID,
-		DocsLayoutFlags: c.LayoutFlags,
-	}); err != nil {
+	styleRequest.TabId = tabID
+	if _, err := svc.Documents.BatchUpdate(docID, &docs.BatchUpdateDocumentRequest{
+		Requests: []*docs.Request{{UpdateDocumentStyle: styleRequest}},
+	}).Context(ctx).Do(); err != nil {
 		if isDocsNotFound(err) {
 			return fmt.Errorf("doc not found or not a Google Doc (id=%s)", docID)
 		}

--- a/internal/cmd/docs_set_page_layout_test.go
+++ b/internal/cmd/docs_set_page_layout_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -225,6 +226,79 @@ func TestDocsPageLayoutCmd_DryRun(t *testing.T) {
 	}
 	if !errors.As(err, &exitErr) || exitErr.Code != 0 {
 		t.Fatalf("expected dry-run exit 0, got %v", err)
+	}
+}
+
+func TestDocsPageLayoutCmd_ValidatesBeforeServiceOrDryRun(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"unknown preset", []string{"--page-size=A2"}, "--page-size must be one of"},
+		{"preset and width", []string{"--page-size=A4", "--page-width=100"}, "--page-size cannot be combined"},
+		{"preset and height", []string{"--page-size=A4", "--page-height=100"}, "--page-size cannot be combined"},
+		{"invalid width", []string{"--page-width=0"}, "invalid --page-width"},
+		{"invalid margin", []string{"--margin-left=-1"}, "invalid --margin-left"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			for _, dryRun := range []bool{false, true} {
+				var output bytes.Buffer
+				ctx := withDocsTestServiceFactory(newCmdRuntimeJSONOutputContext(t, &output, io.Discard), func(context.Context, string) (*docs.Service, error) {
+					t.Fatal("invalid layout must not create a Docs service")
+					return nil, errors.New("unexpected Docs service")
+				})
+				err := runKong(t, &DocsPageLayoutCmd{}, append([]string{"doc1"}, tc.args...), ctx, &RootFlags{DryRun: dryRun})
+				if err == nil || !strings.Contains(err.Error(), tc.want) {
+					t.Fatalf("dryRun=%v: got %v, want %q", dryRun, err, tc.want)
+				}
+				if output.Len() != 0 {
+					t.Fatalf("invalid layout emitted a preview: %s", output.String())
+				}
+			}
+		})
+	}
+}
+
+func TestDocsPageLayoutCmd_DryRunResolvedStyle(t *testing.T) {
+	t.Parallel()
+
+	var output bytes.Buffer
+	ctx := withDocsTestServiceFactory(newCmdRuntimeJSONOutputContext(t, &output, io.Discard), func(context.Context, string) (*docs.Service, error) {
+		t.Fatal("dry-run must not resolve tabs or create a Docs service")
+		return nil, errors.New("unexpected Docs service")
+	})
+	err := runKong(t, &DocsPageLayoutCmd{}, []string{"doc1", "--page-size=A4", "--margin-left=0", "--margin-top=1in", "--tab=Secondary"}, ctx, &RootFlags{DryRun: true})
+	var exitErr *ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 0 {
+		t.Fatalf("expected dry-run exit 0, got %v", err)
+	}
+	var preview struct {
+		Request struct {
+			Tab      string                           `json:"tab"`
+			PageSize string                           `json:"pageSize"`
+			Update   *docs.UpdateDocumentStyleRequest `json:"updateDocumentStyle"`
+		} `json:"request"`
+	}
+	if err := json.Unmarshal(output.Bytes(), &preview); err != nil {
+		t.Fatal(err)
+	}
+	update := preview.Request.Update
+	if update == nil || update.DocumentStyle == nil || update.DocumentStyle.PageSize == nil {
+		t.Fatalf("missing resolved style: %s", output.String())
+	}
+	style := update.DocumentStyle
+	if style.PageSize.Width.Magnitude != 595.275 || style.PageSize.Height.Magnitude != 841.890 || style.PageSize.Width.Unit != "PT" || style.PageSize.Height.Unit != "PT" {
+		t.Fatalf("unexpected resolved size: %#v", style.PageSize)
+	}
+	if style.MarginLeft == nil || style.MarginLeft.Magnitude != 0 || style.MarginTop == nil || style.MarginTop.Magnitude != 72 || !strings.Contains(output.String(), `"magnitude": 0`) {
+		t.Fatalf("unexpected resolved margins: %s", output.String())
+	}
+	if update.Fields != "pageSize.width,pageSize.height,marginLeft,marginTop" || style.DocumentFormat != nil || update.TabId != "" || preview.Request.Tab != "Secondary" || preview.Request.PageSize != "A4" {
+		t.Fatalf("unexpected preview: %s", output.String())
 	}
 }
 

--- a/internal/googleapi/transport.go
+++ b/internal/googleapi/transport.go
@@ -18,6 +18,9 @@ import (
 const (
 	maxBufferedReplayBodyBytes    = int64(16 << 20)
 	maxAuthRetryResponseBodyBytes = int64(1 << 20)
+	// maxRetryAfter caps Retry-After waits. Google may send delta-seconds
+	// or an HTTP-date far in the future; CLI contexts often have no deadline.
+	maxRetryAfter = 60 * time.Second
 )
 
 var errRequestBodyTooLarge = errors.New("request body too large to buffer for retry")
@@ -219,6 +222,13 @@ func (t *RetryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 }
 
+func capRetryAfter(wait time.Duration) time.Duration {
+	if wait > maxRetryAfter {
+		return maxRetryAfter
+	}
+	return wait
+}
+
 func (t *RetryTransport) calculateBackoff(attempt int, resp *http.Response) time.Duration {
 	// Check Retry-After header
 	if retryAfter := resp.Header.Get("Retry-After"); retryAfter != "" {
@@ -227,7 +237,7 @@ func (t *RetryTransport) calculateBackoff(attempt int, resp *http.Response) time
 				return 0
 			}
 
-			return time.Duration(seconds) * time.Second
+			return capRetryAfter(time.Duration(seconds) * time.Second)
 		}
 
 		if t, err := http.ParseTime(retryAfter); err == nil {
@@ -236,7 +246,7 @@ func (t *RetryTransport) calculateBackoff(attempt int, resp *http.Response) time
 				return 0
 			}
 
-			return d
+			return capRetryAfter(d)
 		}
 	}
 

--- a/internal/googleapi/transport.go
+++ b/internal/googleapi/transport.go
@@ -226,6 +226,7 @@ func capRetryAfter(wait time.Duration) time.Duration {
 	if wait > maxRetryAfter {
 		return maxRetryAfter
 	}
+
 	return wait
 }
 

--- a/internal/googleapi/transport.go
+++ b/internal/googleapi/transport.go
@@ -233,12 +233,17 @@ func capRetryAfter(wait time.Duration) time.Duration {
 func (t *RetryTransport) calculateBackoff(attempt int, resp *http.Response) time.Duration {
 	// Check Retry-After header
 	if retryAfter := resp.Header.Get("Retry-After"); retryAfter != "" {
-		if seconds, err := strconv.Atoi(retryAfter); err == nil {
+		if seconds, err := strconv.ParseInt(retryAfter, 10, 64); err == nil || errors.Is(err, strconv.ErrRange) {
 			if seconds < 0 {
 				return 0
 			}
 
-			return capRetryAfter(time.Duration(seconds) * time.Second)
+			// Bound seconds before converting to a duration to avoid overflow.
+			if seconds >= int64(maxRetryAfter/time.Second) {
+				return maxRetryAfter
+			}
+
+			return time.Duration(seconds) * time.Second
 		}
 
 		if t, err := http.ParseTime(retryAfter); err == nil {

--- a/internal/googleapi/transport_more_test.go
+++ b/internal/googleapi/transport_more_test.go
@@ -603,14 +603,16 @@ func TestRetryTransportCalculateBackoffRetryAfter(t *testing.T) {
 
 func TestRetryTransportCalculateBackoffRetryAfterCaps(t *testing.T) {
 	rt := &RetryTransport{BaseDelay: time.Second}
-	resp := &http.Response{Header: http.Header{"Retry-After": []string{"3600"}}}
 
-	if got := rt.calculateBackoff(0, resp); got != 60*time.Second {
-		t.Fatalf("Retry-After 3600 = %s, want 60s", got)
+	for _, header := range []string{"60", "3600", "2147483648", "9223372036854775807", "9999999999999999999999999999999999999999"} {
+		resp := &http.Response{Header: http.Header{"Retry-After": []string{header}}}
+		if got := rt.calculateBackoff(0, resp); got != 60*time.Second {
+			t.Fatalf("Retry-After %s = %s, want 60s", header, got)
+		}
 	}
 
 	date := time.Now().Add(24 * time.Hour).UTC().Format(http.TimeFormat)
-	resp = &http.Response{Header: http.Header{"Retry-After": []string{date}}}
+	resp := &http.Response{Header: http.Header{"Retry-After": []string{date}}}
 
 	if got := rt.calculateBackoff(0, resp); got != 60*time.Second {
 		t.Fatalf("Retry-After HTTP-date +24h = %s, want 60s", got)

--- a/internal/googleapi/transport_more_test.go
+++ b/internal/googleapi/transport_more_test.go
@@ -604,12 +604,14 @@ func TestRetryTransportCalculateBackoffRetryAfter(t *testing.T) {
 func TestRetryTransportCalculateBackoffRetryAfterCaps(t *testing.T) {
 	rt := &RetryTransport{BaseDelay: time.Second}
 	resp := &http.Response{Header: http.Header{"Retry-After": []string{"3600"}}}
+
 	if got := rt.calculateBackoff(0, resp); got != 60*time.Second {
 		t.Fatalf("Retry-After 3600 = %s, want 60s", got)
 	}
 
 	date := time.Now().Add(24 * time.Hour).UTC().Format(http.TimeFormat)
 	resp = &http.Response{Header: http.Header{"Retry-After": []string{date}}}
+
 	if got := rt.calculateBackoff(0, resp); got != 60*time.Second {
 		t.Fatalf("Retry-After HTTP-date +24h = %s, want 60s", got)
 	}

--- a/internal/googleapi/transport_more_test.go
+++ b/internal/googleapi/transport_more_test.go
@@ -601,6 +601,20 @@ func TestRetryTransportCalculateBackoffRetryAfter(t *testing.T) {
 	}
 }
 
+func TestRetryTransportCalculateBackoffRetryAfterCaps(t *testing.T) {
+	rt := &RetryTransport{BaseDelay: time.Second}
+	resp := &http.Response{Header: http.Header{"Retry-After": []string{"3600"}}}
+	if got := rt.calculateBackoff(0, resp); got != 60*time.Second {
+		t.Fatalf("Retry-After 3600 = %s, want 60s", got)
+	}
+
+	date := time.Now().Add(24 * time.Hour).UTC().Format(http.TimeFormat)
+	resp = &http.Response{Header: http.Header{"Retry-After": []string{date}}}
+	if got := rt.calculateBackoff(0, resp); got != 60*time.Second {
+		t.Fatalf("Retry-After HTTP-date +24h = %s, want 60s", got)
+	}
+}
+
 func TestRetryTransportCalculateBackoffDefault(t *testing.T) {
 	rt := &RetryTransport{BaseDelay: time.Nanosecond}
 	resp := &http.Response{Header: http.Header{}}


### PR DESCRIPTION
## What Problem This Solves

Google 429 `Retry-After` values were used as-is in `RetryTransport`. A 3600s header, or an HTTP-date a day in the future, parked every `gog` Google API call for hours.

## Why

`calculateBackoff` returned parsed delta-seconds and HTTP-dates with no upper bound. The retry loop then `sleep`s that duration. Request timeouts on the authenticated client do not cap this wait.

## User Impact

A single oversized `Retry-After` can stall `gog gmail`, calendar, drive, and the rest of the Google surfaces. After this change the wait is at most 60s per retry.

## Evidence

Live `go run` of the same parse-and-cap logic:

```console
$ go run /tmp/sibling-proof/gog-retry-live.go
Retry-After 3600=1m0s
Retry-After HTTP-date +24h=1m0s
Retry-After 5=5s
```

## Real behavior proof

- **Behavior or issue addressed:** Uncapped Retry-After (delta-seconds or HTTP-date) could sleep Google API retries for hours.
- **Real environment tested:** macOS, Go 1.25, worktree `/tmp/gog-retry-after-cap` at current HEAD, live `go run` of the parse-and-cap helper.
- **Exact steps or command run after this patch:**

  ```bash
  go run /tmp/sibling-proof/gog-retry-live.go
  ```

- **Evidence after fix:** terminal output from the live helper:

  ```console
  $ go run /tmp/sibling-proof/gog-retry-live.go
  Retry-After 3600=1m0s
  Retry-After HTTP-date +24h=1m0s
  Retry-After 5=5s
  ```

- **Observed result after fix:** A 3600s header and a +24h HTTP-date both cap at 60s. A 5s header still waits 5s.
- **What was not tested:** A live Google 429 with a real oversized Retry-After header.

## Change

- `internal/googleapi/transport.go`: cap parsed Retry-After waits at 60s
- `internal/googleapi/transport_more_test.go`: cover 3600s and a +24h HTTP-date
