### PR TITLE
fix(people): reject repeated page tokens in raw email resolve

### DIFF
--- a/docs/raw-api.md
+++ b/docs/raw-api.md
@@ -40,6 +40,12 @@ legacy top-level `Document` fields such as `body`, `lists`, and
 populates its recursive `tabs` tree. Without either flag, the command keeps the
 existing first-tab response.
 
+`gog people raw` and `gog contacts raw` also accept email identifiers. They
+scan contact pages before selecting a unique resource: repeated records for
+the same resource count once, while distinct contacts sharing an email are
+ambiguous. If Google repeats a page token, lookup stops with a pagination
+error instead of paging indefinitely.
+
 Use service-native field masks when available:
 
 ```bash

--- a/internal/cmd/people_raw.go
+++ b/internal/cmd/people_raw.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-
-	"google.golang.org/api/people/v1"
 )
 
 // defaultPeopleRawMask is the field mask used when the user does not
@@ -65,7 +63,8 @@ func runPeopleRaw(ctx context.Context, flags *RootFlags, id, fields string, pret
 
 	resource := normalizePeopleResource(identifier)
 	if strings.Contains(identifier, "@") && !strings.HasPrefix(identifier, "people/") {
-		fetch := func(pageToken string) ([]*people.Person, string, error) {
+		seen := make(map[string]bool)
+		fetch := func(pageToken string) ([]string, string, error) {
 			call := svc.People.Connections.List(peopleMeResource).
 				PersonFields("names,emailAddresses,metadata").
 				PageSize(1000).
@@ -77,20 +76,19 @@ func runPeopleRaw(ctx context.Context, flags *RootFlags, id, fields string, pret
 			if listErr != nil {
 				return nil, "", wrapPeopleAPIError(listErr)
 			}
-			return connections.Connections, connections.NextPageToken, nil
+			var matches []string
+			for _, person := range connections.Connections {
+				if person == nil || !personHasEmail(person, identifier) || person.ResourceName == "" || seen[person.ResourceName] {
+					continue
+				}
+				seen[person.ResourceName] = true
+				matches = append(matches, person.ResourceName)
+			}
+			return matches, connections.NextPageToken, nil
 		}
-		connections, listErr := collectAllPages("", fetch)
+		matches, listErr := collectAllPages("", fetch)
 		if listErr != nil {
 			return listErr
-		}
-		matches := make([]string, 0, 1)
-		seen := make(map[string]bool)
-		for _, person := range connections {
-			if person == nil || !personHasEmail(person, identifier) || person.ResourceName == "" || seen[person.ResourceName] {
-				continue
-			}
-			seen[person.ResourceName] = true
-			matches = append(matches, person.ResourceName)
 		}
 		switch len(matches) {
 		case 0:

--- a/internal/cmd/people_raw.go
+++ b/internal/cmd/people_raw.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"strings"
+
+	"google.golang.org/api/people/v1"
 )
 
 // defaultPeopleRawMask is the field mask used when the user does not
@@ -63,11 +65,7 @@ func runPeopleRaw(ctx context.Context, flags *RootFlags, id, fields string, pret
 
 	resource := normalizePeopleResource(identifier)
 	if strings.Contains(identifier, "@") && !strings.HasPrefix(identifier, "people/") {
-		matches := make([]string, 0, 1)
-		seen := make(map[string]bool)
-
-		pageToken := ""
-		for {
+		fetch := func(pageToken string) ([]*people.Person, string, error) {
 			call := svc.People.Connections.List(peopleMeResource).
 				PersonFields("names,emailAddresses,metadata").
 				PageSize(1000).
@@ -77,19 +75,22 @@ func runPeopleRaw(ctx context.Context, flags *RootFlags, id, fields string, pret
 			}
 			connections, listErr := call.Do()
 			if listErr != nil {
-				return wrapPeopleAPIError(listErr)
+				return nil, "", wrapPeopleAPIError(listErr)
 			}
-			for _, person := range connections.Connections {
-				if person == nil || !personHasEmail(person, identifier) || person.ResourceName == "" || seen[person.ResourceName] {
-					continue
-				}
-				seen[person.ResourceName] = true
-				matches = append(matches, person.ResourceName)
+			return connections.Connections, connections.NextPageToken, nil
+		}
+		connections, listErr := collectAllPages("", fetch)
+		if listErr != nil {
+			return listErr
+		}
+		matches := make([]string, 0, 1)
+		seen := make(map[string]bool)
+		for _, person := range connections {
+			if person == nil || !personHasEmail(person, identifier) || person.ResourceName == "" || seen[person.ResourceName] {
+				continue
 			}
-			if connections.NextPageToken == "" {
-				break
-			}
-			pageToken = connections.NextPageToken
+			seen[person.ResourceName] = true
+			matches = append(matches, person.ResourceName)
 		}
 		switch len(matches) {
 		case 0:

--- a/internal/cmd/people_raw_test.go
+++ b/internal/cmd/people_raw_test.go
@@ -173,6 +173,39 @@ func TestContactsRaw_EmailAmbiguousContactsFails(t *testing.T) {
 	})
 }
 
+func TestPeopleRaw_EmailResolveRejectsRepeatedPageToken(t *testing.T) {
+	var listCalls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !(strings.Contains(r.URL.Path, "/people/me/connections") && r.Method == http.MethodGet) {
+			http.NotFound(w, r)
+			return
+		}
+		listCalls++
+		if listCalls > 8 {
+			t.Fatalf("repeated page token looped: %d list calls", listCalls)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"connections": []map[string]any{
+				{
+					"resourceName":   "people/c1",
+					"emailAddresses": []map[string]any{{"value": "ada@example.com"}},
+				},
+			},
+			"nextPageToken": "stuck",
+		})
+	}))
+	defer srv.Close()
+
+	ctx := withMockPeopleContactsService(t, rawTestContext(t), srv)
+	flags := &RootFlags{Account: "a@b.com"}
+	err := runKong(t, &PeopleRawCmd{}, []string{"ada@example.com"}, ctx, flags)
+	if err == nil || !strings.Contains(err.Error(), "repeated page token") {
+		t.Fatalf("err = %v after %d list calls", err, listCalls)
+	}
+	t.Logf("err = %v after %d list calls", err, listCalls)
+}
+
 func TestPeopleRaw_APIError(t *testing.T) {
 	srv := newPeopleRawTestServer(t, http.StatusInternalServerError, nil)
 	defer srv.Close()

--- a/internal/cmd/people_raw_test.go
+++ b/internal/cmd/people_raw_test.go
@@ -6,7 +6,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"google.golang.org/api/people/v1"
 )
@@ -174,15 +176,15 @@ func TestContactsRaw_EmailAmbiguousContactsFails(t *testing.T) {
 }
 
 func TestPeopleRaw_EmailResolveRejectsRepeatedPageToken(t *testing.T) {
-	var listCalls int
+	var listCalls atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !(strings.Contains(r.URL.Path, "/people/me/connections") && r.Method == http.MethodGet) {
 			http.NotFound(w, r)
 			return
 		}
-		listCalls++
-		if listCalls > 8 {
-			t.Fatalf("repeated page token looped: %d list calls", listCalls)
+		if listCalls.Add(1) > 2 {
+			http.Error(w, "unexpected extra page request", http.StatusBadRequest)
+			return
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
@@ -197,13 +199,144 @@ func TestPeopleRaw_EmailResolveRejectsRepeatedPageToken(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	ctx := withMockPeopleContactsService(t, rawTestContext(t), srv)
+	ctx, cancel := context.WithTimeout(rawTestContext(t), 10*time.Second)
+	defer cancel()
+	ctx = withMockPeopleContactsService(t, ctx, srv)
 	flags := &RootFlags{Account: "a@b.com"}
-	err := runKong(t, &PeopleRawCmd{}, []string{"ada@example.com"}, ctx, flags)
+	var err error
+	out := captureStdout(t, func() {
+		err = runKong(t, &PeopleRawCmd{}, []string{"ada@example.com"}, ctx, flags)
+	})
 	if err == nil || !strings.Contains(err.Error(), "repeated page token") {
-		t.Fatalf("err = %v after %d list calls", err, listCalls)
+		t.Fatalf("err = %v after %d list calls", err, listCalls.Load())
 	}
-	t.Logf("err = %v after %d list calls", err, listCalls)
+	if got := listCalls.Load(); got != 2 {
+		t.Fatalf("list calls = %d, want 2", got)
+	}
+	if out != "" {
+		t.Fatalf("unexpected partial output: %q", out)
+	}
+	t.Logf("err = %v after %d list calls", err, listCalls.Load())
+}
+
+func TestPeopleRaw_EmailResolveAcrossPages(t *testing.T) {
+	match := &people.Person{
+		ResourceName:   "people/c1",
+		EmailAddresses: []*people.EmailAddress{{Value: " ada@EXAMPLE.com "}},
+	}
+	otherMatch := &people.Person{
+		ResourceName:   "people/c2",
+		EmailAddresses: match.EmailAddresses,
+	}
+	tests := []struct {
+		name         string
+		pages        []people.ListConnectionsResponse
+		errorOnPage  int
+		wantErr      string
+		wantGetCalls int32
+	}{
+		{
+			name: "nonmatching page then duplicate matching resource",
+			pages: []people.ListConnectionsResponse{
+				{
+					Connections: []*people.Person{
+						nil,
+						{EmailAddresses: match.EmailAddresses},
+						{ResourceName: "people/c1", EmailAddresses: []*people.EmailAddress{{Value: "other@example.com"}}},
+					},
+					NextPageToken: "page-2",
+				},
+				{Connections: []*people.Person{match}, NextPageToken: "page-3"},
+				{Connections: []*people.Person{match}},
+			},
+			wantGetCalls: 1,
+		},
+		{
+			name: "distinct matching resources are ambiguous",
+			pages: []people.ListConnectionsResponse{
+				{Connections: []*people.Person{match}, NextPageToken: "page-2"},
+				{Connections: []*people.Person{otherMatch}},
+			},
+			wantErr: "matched multiple contacts",
+		},
+		{
+			name: "later page error after a match",
+			pages: []people.ListConnectionsResponse{
+				{Connections: []*people.Person{match}, NextPageToken: "page-2"},
+				{},
+			},
+			errorOnPage: 2,
+			wantErr:     "later page failed",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var listCalls, getCalls atomic.Int32
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch {
+				case strings.Contains(r.URL.Path, "/people/me/connections") && r.Method == http.MethodGet:
+					pageIndex := int(listCalls.Add(1)) - 1
+					if pageIndex >= len(tc.pages) {
+						http.Error(w, "unexpected extra page request", http.StatusBadRequest)
+						return
+					}
+					wantToken := ""
+					if pageIndex > 0 {
+						wantToken = tc.pages[pageIndex-1].NextPageToken
+					}
+					if r.URL.Query().Get("pageToken") != wantToken {
+						http.Error(w, "unexpected page token", http.StatusBadRequest)
+						return
+					}
+					if tc.errorOnPage == pageIndex+1 {
+						http.Error(w, "later page failed", http.StatusBadRequest)
+						return
+					}
+					_ = json.NewEncoder(w).Encode(tc.pages[pageIndex])
+				case strings.Contains(r.URL.Path, "/people/c1") && r.Method == http.MethodGet:
+					getCalls.Add(1)
+					_ = json.NewEncoder(w).Encode(fullPersonResponse())
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			defer srv.Close()
+
+			ctx, cancel := context.WithTimeout(rawTestContext(t), 10*time.Second)
+			defer cancel()
+			ctx = withMockPeopleContactsService(t, ctx, srv)
+			var runErr error
+			out := captureStdout(t, func() {
+				runErr = runKong(t, &PeopleRawCmd{}, []string{"ada@example.com"}, ctx, &RootFlags{Account: "a@b.com"})
+			})
+			if got := listCalls.Load(); got != int32(len(tc.pages)) {
+				t.Errorf("list calls = %d, want %d", got, len(tc.pages))
+			}
+			if got := getCalls.Load(); got != tc.wantGetCalls {
+				t.Errorf("People.Get calls = %d, want %d", got, tc.wantGetCalls)
+			}
+			if tc.wantErr != "" {
+				if runErr == nil || !strings.Contains(runErr.Error(), tc.wantErr) {
+					t.Fatalf("err = %v, want %q", runErr, tc.wantErr)
+				}
+				if out != "" {
+					t.Fatalf("unexpected partial output: %q", out)
+				}
+				return
+			}
+			if runErr != nil {
+				t.Fatalf("run: %v", runErr)
+			}
+			var person people.Person
+			if err := json.Unmarshal([]byte(out), &person); err != nil {
+				t.Fatalf("invalid JSON: %v\nraw: %s", err, out)
+			}
+			if person.ResourceName != "people/c1" {
+				t.Fatalf("resource = %q, want people/c1", person.ResourceName)
+			}
+		})
+	}
 }
 
 func TestPeopleRaw_APIError(t *testing.T) {


### PR DESCRIPTION
## What Problem This Solves

`gog people raw user@host` and `gog contacts raw user@host` resolve an email by paging `People.Connections.List` with `pageToken = connections.NextPageToken` and no seen-set. If Google repeats `nextPageToken`, that loop never finishes and the CLI hangs until the process is killed.

## Why

The repo already has this guard. `collectAllPages` errors with `pagination loop: repeated page token`. Calendar listing uses it after [#1004](https://github.com/openclaw/gogcli/pull/1004). Email resolve lives in the same `cmd` package, so it now calls that helper instead of growing a second loop.

## User Impact

A stuck People connections page token now fails with `repeated page token` instead of hanging `gog people raw` / `gog contacts raw` on an email identifier.

## Evidence

terminal output from the unpatched email-resolve loop versus this patch. A People connections `httptest` server always returns `nextPageToken=stuck`. `gog people raw ada@example.com` (via `PeopleRawCmd`) pages that list, then would call `People.Get`.

Unpatched (the HTTP peer answers immediately; the hang guard stops the loop after 8 list calls):

```console
$ go test ./internal/cmd -run TestPeopleRaw_EmailResolveRejectsRepeatedPageToken -count=1 -timeout 30s -v
=== RUN   TestPeopleRaw_EmailResolveRejectsRepeatedPageToken
    people_raw_test.go:185: repeated page token looped: 9 list calls
    people_raw_test.go:185: repeated page token looped: 10 list calls
    people_raw_test.go:204: err = Get "http://127.0.0.1:62467/v1/people/me/connections?alt=json&pageSize=1000&pageToken=stuck&personFields=names%2CemailAddresses%2Cmetadata&prettyPrint=false": EOF after 10 list calls
--- FAIL: TestPeopleRaw_EmailResolveRejectsRepeatedPageToken (0.00s)
FAIL
```

Patched (same command, same stuck token, returns immediately):

```console
$ go test ./internal/cmd -run TestPeopleRaw_EmailResolveRejectsRepeatedPageToken -count=1 -timeout 15s -v
=== RUN   TestPeopleRaw_EmailResolveRejectsRepeatedPageToken
    people_raw_test.go:206: err = pagination loop: repeated page token "stuck" after 2 list calls
--- PASS: TestPeopleRaw_EmailResolveRejectsRepeatedPageToken (0.00s)
PASS
ok  	github.com/openclaw/gogcli/internal/cmd	0.948s
```

Live CLI still accepts an email as the raw identifier:

```console
$ /tmp/gog-f008 people raw --help
Usage: gog people (person) raw <userId> [flags]
Dump raw People API response as JSON (People.Get; lossless; for scripting and
LLM consumption)
Arguments:
  <userId>    Person resource name (people/...) or email
```

`go test ./internal/cmd -count=1` also completed on this tree (ok, 62.568s). `gofmt` is clean. `golangci-lint run ./internal/cmd/ --new-from-rev=upstream/main` reported 0 issues.

## Real behavior proof

- **Behavior or issue addressed:** Repeated Google `nextPageToken` values could hang `gog people raw user@host` / `gog contacts raw user@host` while resolving the email through `People.Connections.List`.
- **Real environment tested:** macOS Darwin 25.6.0 arm64, Go go1.27.0, full clone at `/tmp/oc-pr-gogcli-F008` on `fix/f008-people-raw-page-token` from `upstream/main` at `be4037f7`.
- **Exact steps or command run after this patch:** From `/tmp/oc-pr-gogcli-F008`, ran `go test ./internal/cmd -run TestPeopleRaw_EmailResolveRejectsRepeatedPageToken -count=1 -timeout 15s -v` against a People connections `httptest` that always returns `nextPageToken=stuck`, then ran `/tmp/gog-f008 people raw --help` on the binary built from this branch.
- **Evidence after fix:** terminal output above. Email resolve now returns `pagination loop: repeated page token "stuck"` after 2 list calls (0.00s). The unpatched loop made 9+ list calls and only stopped when the hang guard closed the server.
- **Observed result after fix:** The stuck token no longer pages forever. `PeopleRawCmd` returns the repeated-token error on the next page instead of hanging.
- **What was not tested:** A live `people.connections.list` response that actually repeats a token. That requires a faulty Google page, which we cannot force from a healthy account.

## Related

- Same-repo guard already used by `collectAllPages` in `internal/cmd/paging.go` and by calendar listing in [#1004](https://github.com/openclaw/gogcli/pull/1004).
- Unguarded People raw email paging dates to [`e16241bc`](https://github.com/openclaw/gogcli/commit/e16241bc9a1b6348c7898c63b450c5e321cbf54e) (`fix(contacts): resolve raw email identifiers`, 2026-06-01, 89 days ago).

## Maintainer follow-up

The resolver now filters and deduplicates matching resource names inside each page fetch, then passes only those identifiers to the shared pagination collector. This preserves the original lookup's memory behavior while adding the repeated-token guard.

The command-level regression now uses an HTTP 400 sentinel on a third request instead of failing inside the HTTP handler. With only the production resolver replaced by the unpatched implementation from main, the regression fails after three requests; with this fix it returns the repeated-token error after exactly two requests. Additional cases cover matches on later pages, duplicate records for one resource, distinct-resource ambiguity, and a later-page API failure without partial output. The raw API documentation records these semantics.

Focused proof: `go test ./internal/cmd -run '^(TestPeopleRaw|TestContactsRaw)' -count=1 -timeout=45s -v` passes. This is injected-fault command-path proof using the real generated People client, not a claim that a live Google server returned a malformed page token.
