### PR TITLE
fix(gmail): reject repeated page tokens in --from-contact fallback

### DIFF
--- a/docs/gmail-workflows.md
+++ b/docs/gmail-workflows.md
@@ -15,6 +15,12 @@ gog gmail get <messageId> --json
 gog gmail thread get <threadId> --json
 ```
 
+Use `--from-contact 'Ada Lovelace'` with `gmail search` to resolve a contact
+into a sender query. If contact search misses, the fallback scans connections
+page by page and retains only exact name or email matches. Multiple matching
+contacts require a more specific selector; a repeated page token stops with a
+pagination error instead of leaving the command stuck.
+
 For agents, logs, or issue reports, prefer sanitized content:
 
 ```bash

--- a/internal/cmd/gmail_from_contact_test.go
+++ b/internal/cmd/gmail_from_contact_test.go
@@ -6,7 +6,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"google.golang.org/api/people/v1"
 )
@@ -59,16 +61,16 @@ func TestGmailFromContactQuery_WarmsContactsSearchCache(t *testing.T) {
 }
 
 func TestGmailFromContactFallbackRejectsRepeatedPageToken(t *testing.T) {
-	var listCalls int
+	var listCalls atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case strings.Contains(r.URL.Path, "people:searchContacts") && r.Method == http.MethodGet:
 			_ = json.NewEncoder(w).Encode(map[string]any{"results": []map[string]any{}})
 		case strings.Contains(r.URL.Path, "/people/me/connections") && r.Method == http.MethodGet:
-			listCalls++
-			if listCalls > 8 {
-				t.Fatalf("repeated page token looped: %d list calls", listCalls)
+			if listCalls.Add(1) > 2 {
+				http.Error(w, "too many fallback list requests", http.StatusBadRequest)
+				return
 			}
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"connections": []map[string]any{
@@ -87,9 +89,115 @@ func TestGmailFromContactFallbackRejectsRepeatedPageToken(t *testing.T) {
 	defer srv.Close()
 
 	svc := newPeopleServiceFromServer(t, srv)
-	_, err := gmailFromContactQuery(withPeopleContactsTestService(context.Background(), svc), "a@b.com", "Ada")
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	_, err := gmailFromContactQuery(withPeopleContactsTestService(ctx, svc), "a@b.com", "Ada")
 	if err == nil || !strings.Contains(err.Error(), "repeated page token") {
-		t.Fatalf("err = %v after %d list calls", err, listCalls)
+		t.Fatalf("err = %v after %d list calls", err, listCalls.Load())
 	}
-	t.Logf("err = %v after %d list calls", err, listCalls)
+	if got := listCalls.Load(); got != 2 {
+		t.Fatalf("list calls = %d, want 2", got)
+	}
+}
+
+func TestGmailFromContactFallbackMatchesAcrossPages(t *testing.T) {
+	pages := map[string]*people.ListConnectionsResponse{
+		"": {
+			Connections: []*people.Person{
+				nil,
+				{
+					Names:          []*people.Name{{DisplayName: "Ada Lovelace"}},
+					EmailAddresses: []*people.EmailAddress{{Value: "ada.lovelace@example.com"}},
+				},
+				{
+					Names:          []*people.Name{{DisplayName: "Grace"}},
+					EmailAddresses: []*people.EmailAddress{{Value: "grace@example.com"}},
+				},
+			},
+			NextPageToken: "next",
+		},
+		"next": {
+			Connections: []*people.Person{
+				{
+					Names: []*people.Name{{DisplayName: "Ada"}},
+					EmailAddresses: []*people.EmailAddress{
+						{Value: "ada@example.com"},
+						{Value: " ada.work@example.com "},
+					},
+				},
+				{
+					Names:          []*people.Name{{DisplayName: "GRACE"}},
+					EmailAddresses: []*people.EmailAddress{{Value: "grace.work@example.com"}},
+				},
+			},
+		},
+	}
+	cases := []struct {
+		name      string
+		selector  string
+		wantQuery string
+		wantErr   string
+	}{
+		{
+			name:      "exact name on later page",
+			selector:  " aDa ",
+			wantQuery: "from:(ada@example.com OR ada.work@example.com)",
+		},
+		{
+			name:      "secondary email on later page",
+			selector:  " ADA.WORK@EXAMPLE.COM ",
+			wantQuery: "from:(ada@example.com OR ada.work@example.com)",
+		},
+		{
+			name:     "ambiguity across pages",
+			selector: "Grace",
+			wantErr:  "matched multiple contacts (Grace, GRACE)",
+		},
+		{
+			name:     "no exact match",
+			selector: "Ad",
+			wantErr:  "no contact found",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var listCalls atomic.Int32
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch {
+				case strings.Contains(r.URL.Path, "people:searchContacts") && r.Method == http.MethodGet:
+					_ = json.NewEncoder(w).Encode(&people.SearchResponse{})
+				case strings.Contains(r.URL.Path, "/people/me/connections") && r.Method == http.MethodGet:
+					if listCalls.Add(1) > 2 {
+						http.Error(w, "too many fallback list requests", http.StatusBadRequest)
+						return
+					}
+					page, ok := pages[r.URL.Query().Get("pageToken")]
+					if !ok {
+						http.Error(w, "unexpected fallback page token", http.StatusBadRequest)
+						return
+					}
+					_ = json.NewEncoder(w).Encode(page)
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			defer srv.Close()
+
+			svc := newPeopleServiceFromServer(t, srv)
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			got, err := gmailFromContactQuery(withPeopleContactsTestService(ctx, svc), "a@b.com", tc.selector)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("err = %v, want %q", err, tc.wantErr)
+				}
+			} else if err != nil || got != tc.wantQuery {
+				t.Fatalf("query = %q, err = %v, want %q", got, err, tc.wantQuery)
+			}
+			if got := listCalls.Load(); got != 2 {
+				t.Fatalf("list calls = %d, want 2", got)
+			}
+		})
+	}
 }

--- a/internal/cmd/gmail_from_contact_test.go
+++ b/internal/cmd/gmail_from_contact_test.go
@@ -2,6 +2,9 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -53,4 +56,40 @@ func TestGmailFromContactQuery_WarmsContactsSearchCache(t *testing.T) {
 	if got, want := strings.Join(queries, ","), ",Alice"; got != want {
 		t.Fatalf("search queries = %q, want %q", got, want)
 	}
+}
+
+func TestGmailFromContactFallbackRejectsRepeatedPageToken(t *testing.T) {
+	var listCalls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.Contains(r.URL.Path, "people:searchContacts") && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode(map[string]any{"results": []map[string]any{}})
+		case strings.Contains(r.URL.Path, "/people/me/connections") && r.Method == http.MethodGet:
+			listCalls++
+			if listCalls > 8 {
+				t.Fatalf("repeated page token looped: %d list calls", listCalls)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"connections": []map[string]any{
+					{
+						"resourceName":   "people/c1",
+						"names":          []map[string]any{{"displayName": "Ada"}},
+						"emailAddresses": []map[string]any{{"value": "ada@example.com"}},
+					},
+				},
+				"nextPageToken": "stuck",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	svc := newPeopleServiceFromServer(t, srv)
+	_, err := gmailFromContactQuery(withPeopleContactsTestService(context.Background(), svc), "a@b.com", "Ada")
+	if err == nil || !strings.Contains(err.Error(), "repeated page token") {
+		t.Fatalf("err = %v after %d list calls", err, listCalls)
+	}
+	t.Logf("err = %v after %d list calls", err, listCalls)
 }

--- a/internal/cmd/gmail_search.go
+++ b/internal/cmd/gmail_search.go
@@ -185,9 +185,7 @@ func gmailFromContactQuery(ctx context.Context, account, selector string) (strin
 
 func listExactGmailFromContactPeople(ctx context.Context, svc *people.Service, selector string) ([]*people.Person, error) {
 	selectorLower := strings.ToLower(strings.TrimSpace(selector))
-	var matches []*people.Person
-	pageToken := ""
-	for {
+	fetch := func(pageToken string) ([]*people.Person, string, error) {
 		call := svc.People.Connections.List(peopleMeResource).
 			PersonFields("names,emailAddresses").
 			PageSize(200).
@@ -197,21 +195,24 @@ func listExactGmailFromContactPeople(ctx context.Context, svc *people.Service, s
 		}
 		resp, err := call.Do()
 		if err != nil {
-			return nil, fmt.Errorf("resolve --from-contact fallback list: %w", err)
+			return nil, "", fmt.Errorf("resolve --from-contact fallback list: %w", err)
 		}
-		for _, p := range resp.Connections {
-			if p == nil {
-				continue
-			}
-			if strings.ToLower(primaryName(p)) == selectorLower || contactHasEmail(p, selectorLower) {
-				matches = append(matches, p)
-			}
-		}
-		if resp.NextPageToken == "" {
-			return matches, nil
-		}
-		pageToken = resp.NextPageToken
+		return resp.Connections, resp.NextPageToken, nil
 	}
+	listed, err := collectAllPages("", fetch)
+	if err != nil {
+		return nil, err
+	}
+	var matches []*people.Person
+	for _, p := range listed {
+		if p == nil {
+			continue
+		}
+		if strings.ToLower(primaryName(p)) == selectorLower || contactHasEmail(p, selectorLower) {
+			matches = append(matches, p)
+		}
+	}
+	return matches, nil
 }
 
 func selectGmailFromContactPeople(selector string, resp *people.SearchResponse) []*people.Person {

--- a/internal/cmd/gmail_search.go
+++ b/internal/cmd/gmail_search.go
@@ -197,22 +197,18 @@ func listExactGmailFromContactPeople(ctx context.Context, svc *people.Service, s
 		if err != nil {
 			return nil, "", fmt.Errorf("resolve --from-contact fallback list: %w", err)
 		}
-		return resp.Connections, resp.NextPageToken, nil
-	}
-	listed, err := collectAllPages("", fetch)
-	if err != nil {
-		return nil, err
-	}
-	var matches []*people.Person
-	for _, p := range listed {
-		if p == nil {
-			continue
+		var matches []*people.Person
+		for _, p := range resp.Connections {
+			if p == nil {
+				continue
+			}
+			if strings.ToLower(primaryName(p)) == selectorLower || contactHasEmail(p, selectorLower) {
+				matches = append(matches, p)
+			}
 		}
-		if strings.ToLower(primaryName(p)) == selectorLower || contactHasEmail(p, selectorLower) {
-			matches = append(matches, p)
-		}
+		return matches, resp.NextPageToken, nil
 	}
-	return matches, nil
+	return collectAllPages("", fetch)
 }
 
 func selectGmailFromContactPeople(selector string, resp *people.SearchResponse) []*people.Person {


### PR DESCRIPTION
## What Problem This Solves

`gog gmail search --from-contact NAME` falls back to paging `People.Connections.List` when `SearchContacts` misses. That fallback assigned `pageToken = resp.NextPageToken` with no seen-set. If Google repeats `nextPageToken`, search never finishes and the CLI hangs until the process is killed.

## Why

The repo already has this guard. `collectAllPages` errors with `pagination loop: repeated page token`. Calendar listing uses it after [#1004](https://github.com/openclaw/gogcli/pull/1004). People raw email resolve uses it in [#1044](https://github.com/openclaw/gogcli/pull/1044). The Gmail `--from-contact` fallback lives in the same `cmd` package, so it now calls that helper instead of growing a second loop.

## User Impact

A stuck People connections page token now fails with `repeated page token` instead of hanging `gog gmail search --from-contact` after a SearchContacts miss.

## Evidence

terminal output from the unpatched `--from-contact` fallback versus this patch. A People `httptest` server returns an empty `SearchContacts` result (so the list fallback runs) and always returns `nextPageToken=stuck` from `People.Connections.List`.

Unpatched (the HTTP peer answers immediately; the hang guard stops the loop after 8 list calls):

```console
$ go test ./internal/cmd -run TestGmailFromContactFallbackRejectsRepeatedPageToken -count=1 -timeout 30s -v
=== RUN   TestGmailFromContactFallbackRejectsRepeatedPageToken
    gmail_from_contact_test.go:71: repeated page token looped: 9 list calls
    gmail_from_contact_test.go:71: repeated page token looped: 10 list calls
    gmail_from_contact_test.go:92: err = resolve --from-contact fallback list: Get "http://127.0.0.1:57606/v1/people/me/connections?alt=json&pageSize=200&pageToken=stuck&personFields=names%2CemailAddresses&prettyPrint=false": EOF after 10 list calls
--- FAIL: TestGmailFromContactFallbackRejectsRepeatedPageToken (0.00s)
FAIL
```

Patched (same command, same stuck token, returns immediately):

```console
$ go test ./internal/cmd -run TestGmailFromContactFallbackRejectsRepeatedPageToken -count=1 -timeout 15s -v
=== RUN   TestGmailFromContactFallbackRejectsRepeatedPageToken
    gmail_from_contact_test.go:94: err = pagination loop: repeated page token "stuck" after 2 list calls
--- PASS: TestGmailFromContactFallbackRejectsRepeatedPageToken (0.00s)
PASS
ok  	github.com/openclaw/gogcli/internal/cmd	0.441s
```

Live CLI still accepts `--from-contact`:

```console
$ /tmp/gog-f009 gmail search --help
Usage: gog gmail (mail,email) search (find,query,ls,list) <query> ... [flags]
      --from-contact=STRING    Resolve a Google Contact and add from:(email OR
                               email) to the Gmail query
```

`go test ./internal/cmd -count=1` also completed on this tree (ok, 55.584s). `gofmt` is clean. `golangci-lint run ./internal/cmd/ --new-from-rev=upstream/main` reported 0 issues.

## Real behavior proof

- **Behavior or issue addressed:** Repeated Google `nextPageToken` values could hang `gog gmail search --from-contact NAME` while falling back through `People.Connections.List` after SearchContacts missed.
- **Real environment tested:** macOS Darwin 25.6.0 arm64, Go go1.27.0, full clone at `/tmp/oc-pr-gogcli-F009` on `fix/f009-gmail-from-contact-page-token` from `upstream/main` at `be4037f7`.
- **Exact steps or command run after this patch:** From `/tmp/oc-pr-gogcli-F009`, ran `go test ./internal/cmd -run TestGmailFromContactFallbackRejectsRepeatedPageToken -count=1 -timeout 15s -v` against a People `httptest` that misses SearchContacts and always returns `nextPageToken=stuck` from Connections.List, then ran `/tmp/gog-f009 gmail search --help` on the binary built from this branch.
- **Evidence after fix:** terminal output above. The fallback now returns `pagination loop: repeated page token "stuck"` after 2 list calls (0.00s). The unpatched loop made 9+ list calls and only stopped when the hang guard closed the server.
- **Observed result after fix:** The stuck token no longer pages forever. `gmailFromContactQuery` returns the repeated-token error on the next page instead of hanging.
- **What was not tested:** A live `people.connections.list` response that actually repeats a token. That requires a faulty Google page, which we cannot force from a healthy account.

## Related

- Same-repo guard already used by `collectAllPages` in `internal/cmd/paging.go`, by calendar listing in [#1004](https://github.com/openclaw/gogcli/pull/1004), and by People raw email resolve in [#1044](https://github.com/openclaw/gogcli/pull/1044).
- Unguarded `--from-contact` fallback paging dates to [`3bed2b06`](https://github.com/openclaw/gogcli/commit/3bed2b06e) (landed in [#668](https://github.com/openclaw/gogcli/pull/668), closes #657, 2026-05-30, 91 days ago).

## Maintainer follow-up

The fallback now filters each page before returning it to the shared paginator. This preserves the previous match-only memory behavior instead of retaining the entire address book. The updated regression uses a bounded HTTP error guard and request deadline; additional two-page coverage checks later-page names and secondary email addresses, nil contacts, nonmatches, and ambiguity across pages. The Gmail workflow guide documents the failure behavior.

The repeated-token regression fails against current main (03900e5a) after a third request reaches the test guard, and passes with this fix after two requests. All focused Gmail contact-resolution tests pass, and Codex Auto Review found no accepted/actionable findings.
