### PR TITLE
fix(contacts): reject repeated page tokens in export group listing

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -155,6 +155,11 @@ gog contacts dedupe --resource people/123 --resource people/456 \
   --apply --force --json
 ```
 
+Contact exports include user-defined group names as vCard categories. Group
+names are collected from all pages before output is written. If Google repeats
+a group page token or a group page fails, the command returns an error without
+writing a partial export.
+
 ## Docs
 
 See [Google Docs editing](docs-editing.md), [atomic request batches](docs-batch.md),

--- a/internal/cmd/contacts_export.go
+++ b/internal/cmd/contacts_export.go
@@ -231,9 +231,7 @@ func contactsHaveGroupMemberships(contacts []*people.Person) bool {
 }
 
 func fetchExportContactGroups(ctx context.Context, svc *people.Service) (map[string]string, error) {
-	out := map[string]string{}
-	pageToken := ""
-	for {
+	fetch := func(pageToken string) ([]*people.ContactGroup, string, error) {
 		call := svc.ContactGroups.List().
 			PageSize(1000).
 			GroupFields("groupType,metadata,name").
@@ -243,20 +241,22 @@ func fetchExportContactGroups(ctx context.Context, svc *people.Service) (map[str
 		}
 		resp, err := call.Do()
 		if err != nil {
-			return nil, err
+			return nil, "", err
 		}
-		for _, group := range resp.ContactGroups {
-			if group == nil || group.GroupType != "USER_CONTACT_GROUP" || group.Name == "" {
-				continue
-			}
-			if group.ResourceName != "" {
-				out[group.ResourceName] = group.Name
-			}
+		return resp.ContactGroups, resp.NextPageToken, nil
+	}
+	groups, err := collectAllPages("", fetch)
+	if err != nil {
+		return nil, err
+	}
+	out := map[string]string{}
+	for _, group := range groups {
+		if group == nil || group.GroupType != "USER_CONTACT_GROUP" || group.Name == "" {
+			continue
 		}
-		if resp.NextPageToken == "" {
-			break
+		if group.ResourceName != "" {
+			out[group.ResourceName] = group.Name
 		}
-		pageToken = resp.NextPageToken
 	}
 	return out, nil
 }

--- a/internal/cmd/contacts_export_test.go
+++ b/internal/cmd/contacts_export_test.go
@@ -80,6 +80,48 @@ func TestContactsExport_AllVCF_PaginatesAndIncludesCategories(t *testing.T) {
 	}
 }
 
+func TestContactsExport_GroupListingRejectsRepeatedPageToken(t *testing.T) {
+	var groupListCalls int
+	svc, closeSrv := newPeopleService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.Contains(r.URL.Path, "people/me/connections") && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"connections": []map[string]any{{
+					"resourceName":   "people/c1",
+					"names":          []map[string]any{{"displayName": "Ada Lovelace"}},
+					"emailAddresses": []map[string]any{{"value": "ada@example.com"}},
+					"memberships": []map[string]any{{
+						"contactGroupMembership": map[string]any{"contactGroupResourceName": "contactGroups/friends"},
+					}},
+				}},
+			})
+		case strings.Contains(r.URL.Path, "contactGroups") && r.Method == http.MethodGet:
+			groupListCalls++
+			if groupListCalls > 8 {
+				t.Fatalf("repeated page token looped: %d list calls", groupListCalls)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"contactGroups": []map[string]any{
+					{"resourceName": "contactGroups/friends", "name": "Friends", "groupType": "USER_CONTACT_GROUP"},
+				},
+				"nextPageToken": "stuck",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(closeSrv)
+
+	result := executeWithPeopleTestServices(t, []string{"--account", "a@b.com", "contacts", "export", "--all", "--out", "-"}, peopleTestServices{
+		Contacts: fixedPeopleTestService(svc),
+	})
+	if result.err == nil || !strings.Contains(result.err.Error(), "repeated page token") {
+		t.Fatalf("err = %v after %d list calls", result.err, groupListCalls)
+	}
+	t.Logf("err = %v after %d list calls", result.err, groupListCalls)
+}
+
 func TestContactsExport_SelectorEmailExactMatch(t *testing.T) {
 	svc, closeSrv := newPeopleService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !strings.Contains(r.URL.Path, "people:searchContacts") || r.Method != http.MethodGet {

--- a/internal/cmd/contacts_export_test.go
+++ b/internal/cmd/contacts_export_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"google.golang.org/api/people/v1"
@@ -16,7 +17,8 @@ func TestContactsExport_AllVCF_PaginatesAndIncludesCategories(t *testing.T) {
 		switch {
 		case strings.Contains(r.URL.Path, "people/me/connections") && r.Method == http.MethodGet:
 			if got := r.URL.Query().Get("personFields"); !strings.Contains(got, "memberships") || !strings.Contains(got, "birthdays") {
-				t.Fatalf("missing export fields: %q", got)
+				http.Error(w, "missing export fields: "+got, http.StatusBadRequest)
+				return
 			}
 			if r.URL.Query().Get("pageToken") == "" {
 				_ = json.NewEncoder(w).Encode(map[string]any{
@@ -26,9 +28,10 @@ func TestContactsExport_AllVCF_PaginatesAndIncludesCategories(t *testing.T) {
 						"emailAddresses": []map[string]any{
 							{"value": "ada@example.com", "type": "work"},
 						},
-						"memberships": []map[string]any{{
-							"contactGroupMembership": map[string]any{"contactGroupResourceName": "contactGroups/friends"},
-						}},
+						"memberships": []map[string]any{
+							{"contactGroupMembership": map[string]any{"contactGroupResourceName": "contactGroups/friends"}},
+							{"contactGroupMembership": map[string]any{"contactGroupResourceName": "contactGroups/family"}},
+						},
 					}},
 					"nextPageToken": "next",
 				})
@@ -42,12 +45,25 @@ func TestContactsExport_AllVCF_PaginatesAndIncludesCategories(t *testing.T) {
 				}},
 			})
 		case strings.Contains(r.URL.Path, "contactGroups") && r.Method == http.MethodGet:
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"contactGroups": []map[string]any{
-					{"resourceName": "contactGroups/friends", "name": "Friends, Work", "groupType": "USER_CONTACT_GROUP"},
-					{"resourceName": "contactGroups/myContacts", "name": "Contacts", "groupType": "SYSTEM_CONTACT_GROUP"},
-				},
-			})
+			switch r.URL.Query().Get("pageToken") {
+			case "":
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"contactGroups": []map[string]any{
+						nil,
+						{"resourceName": "contactGroups/friends", "name": "Friends, Work", "groupType": "USER_CONTACT_GROUP"},
+						{"resourceName": "contactGroups/myContacts", "name": "Contacts", "groupType": "SYSTEM_CONTACT_GROUP"},
+					},
+					"nextPageToken": "groups-next",
+				})
+			case "groups-next":
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"contactGroups": []map[string]any{
+						{"resourceName": "contactGroups/family", "name": "Family", "groupType": "USER_CONTACT_GROUP"},
+					},
+				})
+			default:
+				http.Error(w, "unexpected group page token", http.StatusBadRequest)
+			}
 		default:
 			http.NotFound(w, r)
 		}
@@ -67,7 +83,7 @@ func TestContactsExport_AllVCF_PaginatesAndIncludesCategories(t *testing.T) {
 		"FN:Ada Lovelace\r\n",
 		"N:Lovelace;Ada;;;\r\n",
 		"EMAIL;TYPE=work:ada@example.com\r\n",
-		"CATEGORIES:Friends\\, Work\r\n",
+		"CATEGORIES:Family,Friends\\, Work\r\n",
 		"FN:Grace Hopper\r\n",
 		"BDAY:--1209\r\n",
 	} {
@@ -81,7 +97,7 @@ func TestContactsExport_AllVCF_PaginatesAndIncludesCategories(t *testing.T) {
 }
 
 func TestContactsExport_GroupListingRejectsRepeatedPageToken(t *testing.T) {
-	var groupListCalls int
+	var groupListCalls atomic.Int32
 	svc, closeSrv := newPeopleService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
@@ -97,9 +113,9 @@ func TestContactsExport_GroupListingRejectsRepeatedPageToken(t *testing.T) {
 				}},
 			})
 		case strings.Contains(r.URL.Path, "contactGroups") && r.Method == http.MethodGet:
-			groupListCalls++
-			if groupListCalls > 8 {
-				t.Fatalf("repeated page token looped: %d list calls", groupListCalls)
+			if groupListCalls.Add(1) > 2 {
+				http.Error(w, "unexpected extra group page request", http.StatusBadRequest)
+				return
 			}
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"contactGroups": []map[string]any{
@@ -117,9 +133,58 @@ func TestContactsExport_GroupListingRejectsRepeatedPageToken(t *testing.T) {
 		Contacts: fixedPeopleTestService(svc),
 	})
 	if result.err == nil || !strings.Contains(result.err.Error(), "repeated page token") {
-		t.Fatalf("err = %v after %d list calls", result.err, groupListCalls)
+		t.Fatalf("err = %v after %d list calls", result.err, groupListCalls.Load())
 	}
-	t.Logf("err = %v after %d list calls", result.err, groupListCalls)
+	if got := groupListCalls.Load(); got != 2 {
+		t.Fatalf("group list calls = %d, want 2", got)
+	}
+	if result.stdout != "" {
+		t.Fatalf("unexpected partial export: %q", result.stdout)
+	}
+	t.Logf("err = %v after %d list calls", result.err, groupListCalls.Load())
+}
+
+func TestContactsExport_LaterGroupPageErrorDoesNotWritePartialExport(t *testing.T) {
+	person := fullPersonResponse()
+	person["memberships"] = []map[string]any{{
+		"contactGroupMembership": map[string]any{"contactGroupResourceName": "contactGroups/friends"},
+	}}
+	svc, closeSrv := newPeopleService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.Contains(r.URL.Path, "people/me/connections") && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"connections": []map[string]any{person},
+			})
+		case strings.Contains(r.URL.Path, "contactGroups") && r.Method == http.MethodGet:
+			switch r.URL.Query().Get("pageToken") {
+			case "":
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"contactGroups": []map[string]any{
+						{"resourceName": "contactGroups/friends", "name": "Friends", "groupType": "USER_CONTACT_GROUP"},
+					},
+					"nextPageToken": "groups-next",
+				})
+			case "groups-next":
+				http.Error(w, "later group page failed", http.StatusBadRequest)
+			default:
+				http.Error(w, "unexpected group page token", http.StatusBadRequest)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(closeSrv)
+
+	result := executeWithPeopleTestServices(t, []string{"--account", "a@b.com", "contacts", "export", "--all", "--out", "-"}, peopleTestServices{
+		Contacts: fixedPeopleTestService(svc),
+	})
+	if result.err == nil || !strings.HasPrefix(result.err.Error(), "list contact groups:") || !strings.Contains(result.err.Error(), "later group page failed") {
+		t.Fatalf("expected wrapped group page error, got %v", result.err)
+	}
+	if result.stdout != "" {
+		t.Fatalf("unexpected partial export: %q", result.stdout)
+	}
 }
 
 func TestContactsExport_SelectorEmailExactMatch(t *testing.T) {


### PR DESCRIPTION
## What Problem This Solves

`gog contacts export` lists `ContactGroups` with `pageToken = resp.NextPageToken` and no seen-set when memberships need category names. Contact listing already uses `loadPagedItems`. Groups do not. If Google repeats `nextPageToken`, export never finishes and the CLI hangs until the process is killed.

## Why

The repo already has this guard. `collectAllPages` errors with `pagination loop: repeated page token`. Calendar listing uses it after [#1004](https://github.com/openclaw/gogcli/pull/1004). People raw email resolve uses it in [#1044](https://github.com/openclaw/gogcli/pull/1044). The Gmail `--from-contact` fallback uses it in [#1045](https://github.com/openclaw/gogcli/pull/1045). Group listing lives in the same `cmd` package, so it now calls that helper instead of growing a second loop.

## User Impact

A stuck ContactGroups page token now fails with `repeated page token` instead of hanging `gog contacts export` when a contact has group memberships.

## Evidence

terminal output from the unpatched group listing loop versus this patch. A People `httptest` server returns one connection with a group membership (so category names are fetched) and always returns `nextPageToken=stuck` from `ContactGroups.List`.

Unpatched (the HTTP peer answers immediately; the hang guard stops the loop after 8 list calls):

```console
$ go test ./internal/cmd -run TestContactsExport_GroupListingRejectsRepeatedPageToken -count=1 -timeout 30s -v
=== RUN   TestContactsExport_GroupListingRejectsRepeatedPageToken
    contacts_export_test.go:102: repeated page token looped: 9 list calls
    contacts_export_test.go:102: repeated page token looped: 10 list calls
    contacts_export_test.go:120: err = list contact groups: Get "http://127.0.0.1:50484/v1/contactGroups?alt=json&groupFields=groupType%2Cmetadata%2Cname&pageSize=1000&pageToken=stuck&prettyPrint=false": EOF after 10 list calls
--- FAIL: TestContactsExport_GroupListingRejectsRepeatedPageToken (0.04s)
FAIL
```

Patched (same command, same stuck token, returns immediately):

```console
$ go test ./internal/cmd -run TestContactsExport_GroupListingRejectsRepeatedPageToken -count=1 -timeout 15s -v
=== RUN   TestContactsExport_GroupListingRejectsRepeatedPageToken
    contacts_export_test.go:122: err = list contact groups: pagination loop: repeated page token "stuck" after 2 list calls
--- PASS: TestContactsExport_GroupListingRejectsRepeatedPageToken (0.04s)
PASS
ok  	github.com/openclaw/gogcli/internal/cmd	0.446s
```

Live CLI still accepts `--all` and group-backed export flags:

```console
$ /tmp/gog-f010 contacts export --help
Usage: gog contacts (contact) export [<selector>] [flags]
      --all                    Export all personal contacts
      --page=STRING            Start page token for --all
```

`go test ./internal/cmd -count=1` also completed on this tree (ok, 79.720s). `gofmt` is clean. `golangci-lint run ./internal/cmd/ --new-from-rev=upstream/main` reported 0 issues.

## Real behavior proof

- **Behavior or issue addressed:** Repeated Google `nextPageToken` values could hang `gog contacts export` while listing `ContactGroups` for category names.
- **Real environment tested:** macOS Darwin 25.6.0 arm64, Go go1.27.0, full clone at `/tmp/oc-pr-gogcli-F010` on `fix/f010-contacts-export-page-token` from `upstream/main` at `be4037f7`.
- **Exact steps or command run after this patch:** From `/tmp/oc-pr-gogcli-F010`, ran `go test ./internal/cmd -run TestContactsExport_GroupListingRejectsRepeatedPageToken -count=1 -timeout 15s -v` against a People `httptest` that returns a membership and always returns `nextPageToken=stuck` from `ContactGroups.List`, then ran `/tmp/gog-f010 contacts export --help` on the binary built from this branch.
- **Evidence after fix:** terminal output above. Group listing now returns `pagination loop: repeated page token "stuck"` after 2 list calls (0.04s). The unpatched loop made 9+ list calls and only stopped when the hang guard closed the server.
- **Observed result after fix:** The stuck token no longer pages forever. `fetchExportContactGroups` returns the repeated-token error on the next page instead of hanging.
- **What was not tested:** A live `contactGroups.list` response that actually repeats a token. That requires a faulty Google page, which we cannot force from a healthy account.

## Related

- Same-repo guard already used by `collectAllPages` in `internal/cmd/paging.go`, by calendar listing in [#1004](https://github.com/openclaw/gogcli/pull/1004), by People raw email resolve in [#1044](https://github.com/openclaw/gogcli/pull/1044), and by the Gmail `--from-contact` fallback in [#1045](https://github.com/openclaw/gogcli/pull/1045).
- Unguarded ContactGroups paging dates to [`e30d870b`](https://github.com/openclaw/gogcli/commit/e30d870b3fb26df83d2b29578d91a307c54b7206) (`feat(contacts): export vCards`, 2026-04-28, 123 days ago).

## Maintainer follow-up

The production guard is unchanged. The repeated-token regression now uses an HTTP 400 sentinel on a third group request instead of failing inside the HTTP handler, then asserts exactly two requests and no partial stdout with the fix. The existing vCard pagination test now spans two group pages as well as two contact pages, includes a null group entry, and checks category names from both pages. A later-group-page error test verifies the wrapped error and absence of partial output. The examples document that group lookup finishes before export output is written.

Focused proof: `go test -vet=off ./internal/cmd -run '^Test(ContactsExport_|WriteContactVCard_)' -count=1 -timeout=2m -v` passes all six focused tests. Replacing only the production export file with the unpatched main implementation makes only the repeated-token regression fail, after three requests; the fixed command returns the intended error after two requests. This is injected-fault proof through the command and generated People client, not a claim that a live Google server returned a malformed token.
