### PR TITLE
fix(api): support service-hosted Discovery documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Sheets: preserve zero-valued sheet, row, and column indexes in Connected Sheets refresh status references, keeping A1 anchors identifiable. (#938) — thanks @ryo-touch.
 - Dependencies: prefer Go 1.27 while retaining Go 1.26 compatibility, refresh Google and MCP SDKs, update tracking worker dependencies and Go tooling, and refresh Docker build actions.
+- API: resolve service-hosted Discovery documents such as Meet v2 after a default-directory 404, preserving explicit overrides and Google request-host safeguards. (#1049, #1048) — thanks @goutamadwant.
 
 ## 0.38.1 - 2026-08-25
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ points; the [examples](docs/examples.md) and generated
 | Workspace administration | `gog admin`, `gog groups`, `gog keep` |
 | Discovery API fallback | `gog api describe`, `gog api call` |
 
+Generic API commands support service-hosted Discovery documents such as Meet v2
+when the default central Directory returns 404. Explicit
+`GOG_DISCOVERY_BASE_URL` overrides retain their existing behavior.
+
 Consumer Google accounts work with user-facing APIs. Admin Directory, Cloud
 Identity Groups, Chat, Keep, and domain-wide delegation require a managed
 Google Workspace domain. The [Workspace Admin guide](docs/workspace-admin.md)

--- a/internal/discoveryapi/discovery.go
+++ b/internal/discoveryapi/discovery.go
@@ -32,6 +32,19 @@ type Client struct {
 	HTTP    *http.Client
 }
 
+type responseError struct {
+	statusCode int
+	body       string
+}
+
+func (e *responseError) Error() string {
+	return fmt.Sprintf("%s: HTTP %d: %s", ErrDiscoveryRequest, e.statusCode, e.body)
+}
+
+func (e *responseError) Unwrap() error {
+	return ErrDiscoveryRequest
+}
+
 type Method struct {
 	ID       string               `json:"id"`
 	Resource string               `json:"resource,omitempty"`
@@ -73,6 +86,14 @@ func (c Client) Description(ctx context.Context, api, version string) (*discover
 	u := c.baseURL() + "/apis/" + url.PathEscape(api) + "/" + url.PathEscape(version) + "/rest"
 
 	raw, err := c.get(ctx, u)
+
+	var responseErr *responseError
+	if err != nil && strings.TrimSpace(c.BaseURL) == "" && errors.As(err, &responseErr) && responseErr.statusCode == http.StatusNotFound {
+		if fallbackURL, ok := serviceHostedDescriptionURL(api, version); ok {
+			raw, err = c.get(ctx, fallbackURL)
+		}
+	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -103,10 +124,32 @@ func (c Client) get(ctx context.Context, requestURL string) (json.RawMessage, er
 	}
 
 	if response.StatusCode < 200 || response.StatusCode >= 300 {
-		return nil, fmt.Errorf("%w: HTTP %d: %s", ErrDiscoveryRequest, response.StatusCode, strings.TrimSpace(string(raw)))
+		return nil, &responseError{statusCode: response.StatusCode, body: strings.TrimSpace(string(raw))}
 	}
 
 	return raw, nil
+}
+
+func serviceHostedDescriptionURL(api, version string) (string, bool) {
+	service := strings.ToLower(strings.TrimSpace(api))
+	if service == "" || len(service) > 63 || service[0] == '-' || service[len(service)-1] == '-' {
+		return "", false
+	}
+
+	for _, character := range service {
+		if (character < 'a' || character > 'z') && (character < '0' || character > '9') && character != '-' {
+			return "", false
+		}
+	}
+
+	u := url.URL{
+		Scheme:   "https",
+		Host:     service + ".googleapis.com",
+		Path:     "/$discovery/rest",
+		RawQuery: url.Values{"version": {version}}.Encode(),
+	}
+
+	return u.String(), true
 }
 
 func Methods(description *discovery.RestDescription) []Method {

--- a/internal/discoveryapi/discovery_test.go
+++ b/internal/discoveryapi/discovery_test.go
@@ -1,11 +1,143 @@
 package discoveryapi
 
 import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
 	"strings"
 	"testing"
 
 	discovery "google.golang.org/api/discovery/v1"
 )
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return fn(request)
+}
+
+func TestDescriptionFallsBackToServiceHostedDiscovery(t *testing.T) {
+	var requests []string
+	client := Client{HTTP: &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		requests = append(requests, request.URL.String())
+		status := http.StatusNotFound
+		body := `{"error":"not found"}`
+
+		if request.URL.String() == "https://meet.googleapis.com/$discovery/rest?version=v2" {
+			status = http.StatusOK
+			body = `{
+				"name":"meet",
+				"version":"v2",
+				"rootUrl":"https://meet.googleapis.com/",
+				"servicePath":"v2/",
+				"resources":{"conferenceRecords":{"methods":{"list":{
+					"id":"meet.conferenceRecords.list",
+					"httpMethod":"GET",
+					"path":"conferenceRecords"
+				}}}}
+			}`
+		}
+
+		return &http.Response{
+			StatusCode: status,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     make(http.Header),
+		}, nil
+	})}}
+
+	description, err := client.Description(context.Background(), "meet", "v2")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	method, err := FindMethod(description, "meet.conferenceRecords.list")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	requestURL, err := BuildURL(description, method, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if requestURL != "https://meet.googleapis.com/v2/conferenceRecords" {
+		t.Fatalf("URL = %q", requestURL)
+	}
+
+	wantRequests := []string{
+		"https://www.googleapis.com/discovery/v1/apis/meet/v2/rest",
+		"https://meet.googleapis.com/$discovery/rest?version=v2",
+	}
+	if strings.Join(requests, "\n") != strings.Join(wantRequests, "\n") {
+		t.Fatalf("requests = %q, want %q", requests, wantRequests)
+	}
+}
+
+func TestDescriptionDoesNotFallbackForCustomBaseURL(t *testing.T) {
+	for _, baseURL := range []string{"https://discovery.example.test/root", DefaultBaseURL} {
+		t.Run(baseURL, func(t *testing.T) {
+			requestCount := 0
+			client := Client{
+				BaseURL: baseURL,
+				HTTP: &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+					requestCount++
+
+					return &http.Response{
+						StatusCode: http.StatusNotFound,
+						Body:       io.NopCloser(strings.NewReader(`{"error":"not found"}`)),
+						Header:     make(http.Header),
+					}, nil
+				})},
+			}
+
+			_, err := client.Description(context.Background(), "meet", "v2")
+			if err == nil {
+				t.Fatal("Description unexpectedly succeeded")
+			}
+
+			if !errors.Is(err, ErrDiscoveryRequest) {
+				t.Fatalf("error = %v, want ErrDiscoveryRequest", err)
+			}
+
+			if requestCount != 1 {
+				t.Fatalf("request count = %d, want 1", requestCount)
+			}
+		})
+	}
+}
+
+func TestDescriptionFallbackRequiresDefaultNotFoundAndSafeServiceName(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		api        string
+		statusCode int
+	}{
+		{name: "server error", api: "meet", statusCode: http.StatusInternalServerError},
+		{name: "unsafe service name", api: "meet.example", statusCode: http.StatusNotFound},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			requestCount := 0
+			client := Client{HTTP: &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+				requestCount++
+
+				return &http.Response{
+					StatusCode: test.statusCode,
+					Body:       io.NopCloser(strings.NewReader(`{"error":"request failed"}`)),
+					Header:     make(http.Header),
+				}, nil
+			})}}
+
+			if _, err := client.Description(context.Background(), test.api, "v2"); err == nil {
+				t.Fatal("Description unexpectedly succeeded")
+			}
+
+			if requestCount != 1 {
+				t.Fatalf("request count = %d, want 1", requestCount)
+			}
+		})
+	}
+}
 
 func TestMethodsAndBuildURL(t *testing.T) {
 	description := &discovery.RestDescription{


### PR DESCRIPTION
Closes #1048

## What Problem This Solves

Fixes an issue where `gog api describe` and `gog api call` returned a central Discovery Directory 404 for APIs such as Meet v2 whose Discovery document is published only on the service host.

## Why This Change Was Made

The Discovery client now retries a default-directory 404 against the safely constructed `{api}.googleapis.com/$discovery/rest?version={version}` URL. Explicit `GOG_DISCOVERY_BASE_URL` overrides, non-404 responses, and unsafe service names do not trigger fallback. Existing OAuth request and redirect host validation remains unchanged.

## User Impact

Generic API commands can resolve service-hosted Discovery documents, including Meet v2 resources not exposed by first-class commands, without brittle environment-variable URL fragments.

## Evidence

- `go test ./internal/discoveryapi ./internal/cmd`
- `make ci`
- `go run ./cmd/gog api describe meet v2 meet.conferenceRecords.list`
- `go run ./cmd/gog --dry-run api call meet v2 meet.conferenceRecords.list --params '{"pageSize":1}'`

The regression test fails on current main at the central Directory 404 and passes after the fallback. The credential-free live command resolves the official Meet v2 Discovery document, and the dry run builds `https://meet.googleapis.com/v2/conferenceRecords?pageSize=1`.

Captured after-fix terminal output (no account or credentials used):

```console
$ go run ./cmd/gog api describe meet v2 meet.conferenceRecords.list | jq '{id, resource, name, http_method: .spec.httpMethod, path: .spec.path}'
{
  "id": "meet.conferenceRecords.list",
  "resource": "conferenceRecords",
  "name": "list",
  "http_method": "GET",
  "path": "v2/conferenceRecords"
}

$ go run ./cmd/gog --dry-run api call meet v2 meet.conferenceRecords.list --params '{"pageSize":1}'
Dry run: would api.call
{
  "api": "meet",
  "has_body": false,
  "http_method": "GET",
  "method": "meet.conferenceRecords.list",
  "url": "https://meet.googleapis.com/v2/conferenceRecords?pageSize=1",
  "version": "v2"
}
```

## Limitations

The fallback only runs after a 404 from the implicit default central Directory. It does not apply to explicit Discovery base overrides, non-404 responses, or service names that are not safe DNS labels. No authenticated Meet API request was made.

Disclosure: AI was used to understand the codebase and review the fix.
