### PR TITLE
fix(docs): validate page layout before dry-run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.38.2 - Unreleased
 
+- Docs: validate page-layout sizes and margins before dry-run, and preview the resolved document-style request used for execution. (#1051) — thanks @ryo-touch.
 - Sheets: preserve zero-valued sheet, row, and column indexes in Connected Sheets refresh status references, keeping A1 anchors identifiable. (#938) — thanks @ryo-touch.
 - Dependencies: prefer Go 1.27 while retaining Go 1.26 compatibility, refresh Google and MCP SDKs, update tracking worker dependencies and Go tooling, and refresh Docker build actions.
 

--- a/docs/docs-editing.md
+++ b/docs/docs-editing.md
@@ -366,6 +366,12 @@ flags are supplied; pass `--layout` when you also want to toggle pageless/pages.
 `--pageless` preserves Google Docs' existing width unless `--page-width` is set
 explicitly.
 
+`docs page-layout --dry-run --json` validates page sizes, dimensions, and
+margins before accessing Google. Its `request.updateDocumentStyle` preview
+includes the resolved point dimensions and field mask used for execution;
+the original flag values remain available alongside it. A requested tab is
+shown by name and resolved only when the command executes.
+
 Command page:
 
 - [`gog docs page-layout`](commands/gog-docs-page-layout.md)

--- a/internal/cmd/docs_set_page_layout.go
+++ b/internal/cmd/docs_set_page_layout.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/alecthomas/kong"
+	"google.golang.org/api/docs/v1"
 
 	"github.com/openclaw/gogcli/internal/outfmt"
 	"github.com/openclaw/gogcli/internal/ui"
@@ -47,8 +48,17 @@ func (c *DocsPageLayoutCmd) Run(ctx context.Context, kctx *kong.Context, flags *
 		return err
 	}
 
+	styleRequest, err := buildUpdateDocumentStyleRequest(docsDocumentStyleOptions{
+		Mode:            mode,
+		DocsLayoutFlags: c.LayoutFlags,
+	})
+	if err != nil {
+		return fmt.Errorf("set page layout: %w", err)
+	}
+
 	dryRunPayload := map[string]any{
-		"documentId": docID,
+		"documentId":          docID,
+		"updateDocumentStyle": styleRequest,
 	}
 	if mode != "" {
 		dryRunPayload["layout"] = c.Layout
@@ -77,11 +87,10 @@ func (c *DocsPageLayoutCmd) Run(ctx context.Context, kctx *kong.Context, flags *
 		}
 	}
 
-	if err := setDocumentStyle(ctx, svc, docID, docsDocumentStyleOptions{
-		Mode:            mode,
-		TabID:           tabID,
-		DocsLayoutFlags: c.LayoutFlags,
-	}); err != nil {
+	styleRequest.TabId = tabID
+	if _, err := svc.Documents.BatchUpdate(docID, &docs.BatchUpdateDocumentRequest{
+		Requests: []*docs.Request{{UpdateDocumentStyle: styleRequest}},
+	}).Context(ctx).Do(); err != nil {
 		if isDocsNotFound(err) {
 			return fmt.Errorf("doc not found or not a Google Doc (id=%s)", docID)
 		}

--- a/internal/cmd/docs_set_page_layout_test.go
+++ b/internal/cmd/docs_set_page_layout_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -225,6 +226,79 @@ func TestDocsPageLayoutCmd_DryRun(t *testing.T) {
 	}
 	if !errors.As(err, &exitErr) || exitErr.Code != 0 {
 		t.Fatalf("expected dry-run exit 0, got %v", err)
+	}
+}
+
+func TestDocsPageLayoutCmd_ValidatesBeforeServiceOrDryRun(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"unknown preset", []string{"--page-size=A2"}, "--page-size must be one of"},
+		{"preset and width", []string{"--page-size=A4", "--page-width=100"}, "--page-size cannot be combined"},
+		{"preset and height", []string{"--page-size=A4", "--page-height=100"}, "--page-size cannot be combined"},
+		{"invalid width", []string{"--page-width=0"}, "invalid --page-width"},
+		{"invalid margin", []string{"--margin-left=-1"}, "invalid --margin-left"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			for _, dryRun := range []bool{false, true} {
+				var output bytes.Buffer
+				ctx := withDocsTestServiceFactory(newCmdRuntimeJSONOutputContext(t, &output, io.Discard), func(context.Context, string) (*docs.Service, error) {
+					t.Fatal("invalid layout must not create a Docs service")
+					return nil, errors.New("unexpected Docs service")
+				})
+				err := runKong(t, &DocsPageLayoutCmd{}, append([]string{"doc1"}, tc.args...), ctx, &RootFlags{DryRun: dryRun})
+				if err == nil || !strings.Contains(err.Error(), tc.want) {
+					t.Fatalf("dryRun=%v: got %v, want %q", dryRun, err, tc.want)
+				}
+				if output.Len() != 0 {
+					t.Fatalf("invalid layout emitted a preview: %s", output.String())
+				}
+			}
+		})
+	}
+}
+
+func TestDocsPageLayoutCmd_DryRunResolvedStyle(t *testing.T) {
+	t.Parallel()
+
+	var output bytes.Buffer
+	ctx := withDocsTestServiceFactory(newCmdRuntimeJSONOutputContext(t, &output, io.Discard), func(context.Context, string) (*docs.Service, error) {
+		t.Fatal("dry-run must not resolve tabs or create a Docs service")
+		return nil, errors.New("unexpected Docs service")
+	})
+	err := runKong(t, &DocsPageLayoutCmd{}, []string{"doc1", "--page-size=A4", "--margin-left=0", "--margin-top=1in", "--tab=Secondary"}, ctx, &RootFlags{DryRun: true})
+	var exitErr *ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 0 {
+		t.Fatalf("expected dry-run exit 0, got %v", err)
+	}
+	var preview struct {
+		Request struct {
+			Tab      string                           `json:"tab"`
+			PageSize string                           `json:"pageSize"`
+			Update   *docs.UpdateDocumentStyleRequest `json:"updateDocumentStyle"`
+		} `json:"request"`
+	}
+	if err := json.Unmarshal(output.Bytes(), &preview); err != nil {
+		t.Fatal(err)
+	}
+	update := preview.Request.Update
+	if update == nil || update.DocumentStyle == nil || update.DocumentStyle.PageSize == nil {
+		t.Fatalf("missing resolved style: %s", output.String())
+	}
+	style := update.DocumentStyle
+	if style.PageSize.Width.Magnitude != 595.275 || style.PageSize.Height.Magnitude != 841.890 || style.PageSize.Width.Unit != "PT" || style.PageSize.Height.Unit != "PT" {
+		t.Fatalf("unexpected resolved size: %#v", style.PageSize)
+	}
+	if style.MarginLeft == nil || style.MarginLeft.Magnitude != 0 || style.MarginTop == nil || style.MarginTop.Magnitude != 72 || !strings.Contains(output.String(), `"magnitude": 0`) {
+		t.Fatalf("unexpected resolved margins: %s", output.String())
+	}
+	if update.Fields != "pageSize.width,pageSize.height,marginLeft,marginTop" || style.DocumentFormat != nil || update.TabId != "" || preview.Request.Tab != "Secondary" || preview.Request.PageSize != "A4" {
+		t.Fatalf("unexpected preview: %s", output.String())
 	}
 }
 


### PR DESCRIPTION
`docs page-layout --dry-run` reported success for unknown page sizes, conflicting size flags, and invalid dimensions because it exited before building the document-style request.

Build and validate that request before dry-run, expose its resolved dimensions and field mask as `request.updateDocumentStyle`, and execute that same request after resolving the optional tab. Existing preview fields remain available. Add command-level regressions and document the preview. Thanks @ryo-touch for the diagnosis.

Closes #1051.

Validation:

- `go test ./internal/cmd -run 'TestDocsPageLayoutCmd|TestDocsPageSize|TestDocsWrite' -count=1` — passed.
- `golangci-lint run ./internal/cmd/ --new-from-rev HEAD` — 0 issues (run before committing).
- Codex autoreview — scoped clean at its default P0 threshold.
- Built CLI, isolated temporary `GOG_HOME`, no credentials or Google requests:

```console
$ gog docs page-layout doc1 --page-size=A2 --dry-run --json
set page layout: --page-size must be one of A4, A5, Letter, Legal, Tabloid
exit 2
$ gog docs page-layout doc1 --page-size=A4 --page-width=100 --dry-run --json
set page layout: --page-size cannot be combined with --page-width or --page-height
exit 2
$ gog docs page-layout doc1 --page-size=A4 --margin-left=0 --dry-run --json
exit 0
```

The valid preview includes width `595.275 PT`, height `841.89 PT`, zero left margin, and field mask `pageSize.width,pageSize.height,marginLeft`. Both invalid page-layout commands exited 0 on main before this fix. `docs write --text=x --page-size=A2 --dry-run --json` still exits 2.

This fix uses the presets currently on main and does not depend on the separate A3 addition in #1050.
