### PR TITLE
docs: correct installation and container release guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,8 @@ go install github.com/openclaw/gogcli/cmd/gog@latest
 gog --version
 ```
 
-The module path moved from `github.com/steipete/gogcli` to
-`github.com/openclaw/gogcli`. Until the first release tagged after that move is
-published, `@latest` still selects an older tag that declares the previous path
-and fails; install a specific version from the old path in the meantime:
-
-```bash
-go install github.com/steipete/gogcli/cmd/gog@v0.34.2
-```
+Install scripts using the former `github.com/steipete/gogcli` module path should
+switch to `github.com/openclaw/gogcli` as shown above.
 
 Docker images, Windows archives, raw macOS/Linux binaries, and source builds
 are covered in the [install guide](docs/install.md).

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -39,6 +39,19 @@ gh workflow run release-unified.yml \
 
 `scripts/release.sh X.Y.Z` is the equivalent convenience wrapper. Watch the exact returned workflow run through completion. Retrying the same version reuses the immutable annotated tag; the workflow never moves it.
 
+## Docker closeout
+
+After the GitHub Release is public and its tag is verified, publish the Docker image separately unless an exact-tag Docker run has already succeeded. The unified workflow creates the tag with `GITHUB_TOKEN`, which does not trigger Docker's tag-push workflow.
+
+```sh
+gh workflow run docker.yml \
+  --repo openclaw/gogcli \
+  --ref vX.Y.Z \
+  -f tag=vX.Y.Z
+```
+
+Use the release tag for both `--ref` and `tag`: checkout follows the input, but build commit metadata comes from the dispatch's `GITHUB_SHA`. Dispatching from `main` can label a tagged build with a newer commit. Verify the resulting run's head SHA matches the frozen release commit and wait for success before treating the GHCR version tag (and `latest` for stable releases) as published.
+
 ## Verify and close out
 
 Before declaring the release complete, verify:

--- a/docs/install.md
+++ b/docs/install.md
@@ -20,11 +20,14 @@ gog --version
 
 ## Docker / GHCR
 
-Release tags publish a non-root GitHub Container Registry image:
+The separate Docker workflow publishes a non-root GitHub Container Registry
+image. Tags created by the unified release workflow do not trigger it
+automatically; maintainers [dispatch Docker after release publication](RELEASING.md#docker-closeout).
+Once the Docker workflow succeeds:
 
 ```bash
 docker run --rm ghcr.io/openclaw/gogcli:latest version
-docker run --rm ghcr.io/openclaw/gogcli:v0.15.0 version
+docker run --rm ghcr.io/openclaw/gogcli:v0.38.2 version
 ```
 
 Authenticated container runs should mount a persistent `GOG_HOME` directory and


### PR DESCRIPTION
## Summary

Remove the obsolete instruction to install GogCLI through its former Go module path. Released versions now declare `github.com/openclaw/gogcli`, so the existing `go install ...@latest` command is the supported path.

Document Docker publication as a separate release closeout step. Tags created by the unified workflow's GitHub token do not trigger the tag-push Docker workflow. The supported manual command binds both the workflow ref and input to the release tag so the image's version, source, and commit metadata agree. Update the installation example to the published `v0.38.2` image.

This is documentation-only and does not change the frozen 0.38.2 release contents, changelog, version metadata, or other release policies.

## Verification

- `make docs-check` passed: site build, four tests, 728 command pages, and 27 feature pages.
- `git diff --check` passed.
- The complete three-file patch passed scoped Codex review at the configured P0 threshold, with no accepted/actionable findings.
- Checked the Docker workflow's tag/ref handling and the shared workflow's tag creation against the documented GitHub token and workflow-dispatch behavior.

[0.38.2 is published](https://github.com/openclaw/gogcli/releases/tag/v0.38.2). The [unified release run](https://github.com/openclaw/gogcli/actions/runs/33622092338) and [exact-tag Docker run](https://github.com/openclaw/gogcli/actions/runs/33623102421) both succeeded at frozen commit `03d192ff9bad1f0540e7b37a527990558ed8a040`. Anonymous GHCR manifest reads confirm that `v0.38.2` and `latest` expose the same image graph, including Linux amd64 image manifest `sha256:4419e87fe094c731108545a2378ffbfc6b81028fa9b863740b6408ad039eafed`. The publication hold is satisfied. This PR does not prefill another release.
