### PR TITLE
fix(backup): reject repeated Chat and Classroom page tokens

### DIFF
--- a/docs/backup.md
+++ b/docs/backup.md
@@ -357,6 +357,12 @@ stores project metadata plus source content. Chat and Classroom adapters
 enumerate data visible to the authenticated account; personal/permission-limited
 accounts may produce encrypted error shards under `--best-effort`.
 
+Chat and Classroom stop a listing if a continuation token repeats or more than
+10,000 pages would be needed. Under the default `--best-effort`, these collection
+errors become encrypted error shards and other services can continue;
+`--no-best-effort` returns the error. Classroom child lists still retain pages
+already fetched when a later ordinary API request fails.
+
 ## Adding Services
 
 Keep one backup engine and add service adapters. A service adapter should:

--- a/internal/cmd/backup_chat_classroom.go
+++ b/internal/cmd/backup_chat_classroom.go
@@ -258,79 +258,51 @@ func fetchBackupClassroomChildren(ctx context.Context, svc *classroom.Service, c
 }
 
 func fetchClassroomTopicsBestEffort(ctx context.Context, svc *classroom.Service, courseID string) ([]*classroom.Topic, error) {
-	out, err := collectAllPages("", func(pageToken string) ([]*classroom.Topic, string, error) {
-		resp, listErr := svc.Courses.Topics.List(courseID).PageSize(100).PageToken(pageToken).Context(ctx).Do()
-		if listErr != nil {
-			return nil, "", listErr
+	return collectAllPages("", func(pageToken string) ([]*classroom.Topic, string, error) {
+		resp, err := svc.Courses.Topics.List(courseID).PageSize(100).PageToken(pageToken).Context(ctx).Do()
+		if err != nil {
+			return nil, "", nil //nolint:nilerr // End best-effort listing without losing earlier pages.
 		}
 		return resp.Topic, resp.NextPageToken, nil
 	})
-	if isBackupPaginationGuardError(err) {
-		return nil, err
-	}
-	return out, nil
 }
 
 func fetchClassroomAnnouncementsBestEffort(ctx context.Context, svc *classroom.Service, courseID string) ([]*classroom.Announcement, error) {
-	out, err := collectAllPages("", func(pageToken string) ([]*classroom.Announcement, string, error) {
-		resp, listErr := svc.Courses.Announcements.List(courseID).PageSize(100).PageToken(pageToken).Context(ctx).Do()
-		if listErr != nil {
-			return nil, "", listErr
+	return collectAllPages("", func(pageToken string) ([]*classroom.Announcement, string, error) {
+		resp, err := svc.Courses.Announcements.List(courseID).PageSize(100).PageToken(pageToken).Context(ctx).Do()
+		if err != nil {
+			return nil, "", nil //nolint:nilerr // End best-effort listing without losing earlier pages.
 		}
 		return resp.Announcements, resp.NextPageToken, nil
 	})
-	if isBackupPaginationGuardError(err) {
-		return nil, err
-	}
-	return out, nil
 }
 
 func fetchClassroomCourseWorkBestEffort(ctx context.Context, svc *classroom.Service, courseID string) ([]*classroom.CourseWork, error) {
-	out, err := collectAllPages("", func(pageToken string) ([]*classroom.CourseWork, string, error) {
-		resp, listErr := svc.Courses.CourseWork.List(courseID).PageSize(100).PageToken(pageToken).Context(ctx).Do()
-		if listErr != nil {
-			return nil, "", listErr
+	return collectAllPages("", func(pageToken string) ([]*classroom.CourseWork, string, error) {
+		resp, err := svc.Courses.CourseWork.List(courseID).PageSize(100).PageToken(pageToken).Context(ctx).Do()
+		if err != nil {
+			return nil, "", nil //nolint:nilerr // End best-effort listing without losing earlier pages.
 		}
 		return resp.CourseWork, resp.NextPageToken, nil
 	})
-	if isBackupPaginationGuardError(err) {
-		return nil, err
-	}
-	return out, nil
 }
 
 func fetchClassroomMaterialsBestEffort(ctx context.Context, svc *classroom.Service, courseID string) ([]*classroom.CourseWorkMaterial, error) {
-	out, err := collectAllPages("", func(pageToken string) ([]*classroom.CourseWorkMaterial, string, error) {
-		resp, listErr := svc.Courses.CourseWorkMaterials.List(courseID).PageSize(100).PageToken(pageToken).Context(ctx).Do()
-		if listErr != nil {
-			return nil, "", listErr
+	return collectAllPages("", func(pageToken string) ([]*classroom.CourseWorkMaterial, string, error) {
+		resp, err := svc.Courses.CourseWorkMaterials.List(courseID).PageSize(100).PageToken(pageToken).Context(ctx).Do()
+		if err != nil {
+			return nil, "", nil //nolint:nilerr // End best-effort listing without losing earlier pages.
 		}
 		return resp.CourseWorkMaterial, resp.NextPageToken, nil
 	})
-	if isBackupPaginationGuardError(err) {
-		return nil, err
-	}
-	return out, nil
 }
 
 func fetchClassroomSubmissionsBestEffort(ctx context.Context, svc *classroom.Service, courseID string) ([]*classroom.StudentSubmission, error) {
-	out, err := collectAllPages("", func(pageToken string) ([]*classroom.StudentSubmission, string, error) {
-		resp, listErr := svc.Courses.CourseWork.StudentSubmissions.List(courseID, "-").PageSize(100).PageToken(pageToken).Context(ctx).Do()
-		if listErr != nil {
-			return nil, "", listErr
+	return collectAllPages("", func(pageToken string) ([]*classroom.StudentSubmission, string, error) {
+		resp, err := svc.Courses.CourseWork.StudentSubmissions.List(courseID, "-").PageSize(100).PageToken(pageToken).Context(ctx).Do()
+		if err != nil {
+			return nil, "", nil //nolint:nilerr // End best-effort listing without losing earlier pages.
 		}
 		return resp.StudentSubmissions, resp.NextPageToken, nil
 	})
-	if isBackupPaginationGuardError(err) {
-		return nil, err
-	}
-	return out, nil
-}
-
-func isBackupPaginationGuardError(err error) bool {
-	if err == nil {
-		return false
-	}
-	msg := err.Error()
-	return strings.Contains(msg, "pagination loop") || strings.Contains(msg, "pagination exceeded")
 }

--- a/internal/cmd/backup_chat_classroom.go
+++ b/internal/cmd/backup_chat_classroom.go
@@ -94,7 +94,10 @@ func buildClassroomBackupSnapshot(ctx context.Context, flags *RootFlags, shardMa
 	if err != nil {
 		return backup.Snapshot{}, err
 	}
-	topics, announcements, coursework, materials, submissions := fetchBackupClassroomChildren(ctx, svc, courses)
+	topics, announcements, coursework, materials, submissions, err := fetchBackupClassroomChildren(ctx, svc, courses)
+	if err != nil {
+		return backup.Snapshot{}, err
+	}
 	shards := make([]backup.PlainShard, 0, 6)
 	courseShard, err := backup.NewJSONLShard(backupServiceClassroom, "courses", accountHash, fmt.Sprintf("data/classroom/%s/courses.jsonl.gz.age", accountHash), courses)
 	if err != nil {
@@ -133,22 +136,20 @@ func buildClassroomBackupSnapshot(ctx context.Context, flags *RootFlags, shardMa
 }
 
 func fetchBackupChatSpaces(ctx context.Context, svc *chat.Service) ([]*chat.Space, error) {
-	var out []*chat.Space
-	pageToken := ""
-	for {
+	fetch := func(pageToken string) ([]*chat.Space, string, error) {
 		call := svc.Spaces.List().PageSize(1000).Context(ctx)
 		if pageToken != "" {
 			call = call.PageToken(pageToken)
 		}
 		resp, err := call.Do()
 		if err != nil {
-			return nil, err
+			return nil, "", err
 		}
-		out = append(out, resp.Spaces...)
-		if resp.NextPageToken == "" {
-			break
-		}
-		pageToken = resp.NextPageToken
+		return resp.Spaces, resp.NextPageToken, nil
+	}
+	out, err := collectAllPages("", fetch)
+	if err != nil {
+		return nil, err
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
 	return out, nil
@@ -160,51 +161,49 @@ func fetchBackupChatMessages(ctx context.Context, svc *chat.Service, spaces []*c
 		if space == nil || strings.TrimSpace(space.Name) == "" {
 			continue
 		}
-		pageToken := ""
-		for {
+		fetch := func(pageToken string) ([]*chat.Message, string, error) {
 			call := svc.Spaces.Messages.List(space.Name).PageSize(1000).Context(ctx)
 			if pageToken != "" {
 				call = call.PageToken(pageToken)
 			}
 			resp, err := call.Do()
 			if err != nil {
-				return nil, fmt.Errorf("chat messages %s: %w", space.Name, err)
+				return nil, "", fmt.Errorf("chat messages %s: %w", space.Name, err)
 			}
-			for _, message := range resp.Messages {
-				out = append(out, chatBackupMessage{SpaceName: space.Name, Message: message})
-			}
-			if resp.NextPageToken == "" {
-				break
-			}
-			pageToken = resp.NextPageToken
+			return resp.Messages, resp.NextPageToken, nil
+		}
+		messages, err := collectAllPages("", fetch)
+		if err != nil {
+			return nil, err
+		}
+		for _, message := range messages {
+			out = append(out, chatBackupMessage{SpaceName: space.Name, Message: message})
 		}
 	}
 	return out, nil
 }
 
 func fetchBackupClassroomCourses(ctx context.Context, svc *classroom.Service) ([]*classroom.Course, error) {
-	var out []*classroom.Course
-	pageToken := ""
-	for {
+	fetch := func(pageToken string) ([]*classroom.Course, string, error) {
 		call := svc.Courses.List().PageSize(100).Context(ctx)
 		if pageToken != "" {
 			call = call.PageToken(pageToken)
 		}
 		resp, err := call.Do()
 		if err != nil {
-			return nil, err
+			return nil, "", err
 		}
-		out = append(out, resp.Courses...)
-		if resp.NextPageToken == "" {
-			break
-		}
-		pageToken = resp.NextPageToken
+		return resp.Courses, resp.NextPageToken, nil
+	}
+	out, err := collectAllPages("", fetch)
+	if err != nil {
+		return nil, err
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Id < out[j].Id })
 	return out, nil
 }
 
-func fetchBackupClassroomChildren(ctx context.Context, svc *classroom.Service, courses []*classroom.Course) ([]classroomBackupTopic, []classroomBackupAnnouncement, []classroomBackupCourseWork, []classroomBackupMaterial, []classroomBackupSubmission) {
+func fetchBackupClassroomChildren(ctx context.Context, svc *classroom.Service, courses []*classroom.Course) ([]classroomBackupTopic, []classroomBackupAnnouncement, []classroomBackupCourseWork, []classroomBackupMaterial, []classroomBackupSubmission, error) {
 	var topics []classroomBackupTopic
 	var announcements []classroomBackupAnnouncement
 	var coursework []classroomBackupCourseWork
@@ -215,19 +214,39 @@ func fetchBackupClassroomChildren(ctx context.Context, svc *classroom.Service, c
 			continue
 		}
 		courseID := course.Id
-		for _, topic := range fetchClassroomTopicsBestEffort(ctx, svc, courseID) {
+		courseTopics, err := fetchClassroomTopicsBestEffort(ctx, svc, courseID)
+		if err != nil {
+			return nil, nil, nil, nil, nil, err
+		}
+		for _, topic := range courseTopics {
 			topics = append(topics, classroomBackupTopic{CourseID: courseID, Topic: topic})
 		}
-		for _, announcement := range fetchClassroomAnnouncementsBestEffort(ctx, svc, courseID) {
+		courseAnnouncements, err := fetchClassroomAnnouncementsBestEffort(ctx, svc, courseID)
+		if err != nil {
+			return nil, nil, nil, nil, nil, err
+		}
+		for _, announcement := range courseAnnouncements {
 			announcements = append(announcements, classroomBackupAnnouncement{CourseID: courseID, Announcement: announcement})
 		}
-		for _, work := range fetchClassroomCourseWorkBestEffort(ctx, svc, courseID) {
+		courseWork, err := fetchClassroomCourseWorkBestEffort(ctx, svc, courseID)
+		if err != nil {
+			return nil, nil, nil, nil, nil, err
+		}
+		for _, work := range courseWork {
 			coursework = append(coursework, classroomBackupCourseWork{CourseID: courseID, CourseWork: work})
 		}
-		for _, material := range fetchClassroomMaterialsBestEffort(ctx, svc, courseID) {
+		courseMaterials, err := fetchClassroomMaterialsBestEffort(ctx, svc, courseID)
+		if err != nil {
+			return nil, nil, nil, nil, nil, err
+		}
+		for _, material := range courseMaterials {
 			materials = append(materials, classroomBackupMaterial{CourseID: courseID, Material: material})
 		}
-		for _, submission := range fetchClassroomSubmissionsBestEffort(ctx, svc, courseID) {
+		courseSubmissions, err := fetchClassroomSubmissionsBestEffort(ctx, svc, courseID)
+		if err != nil {
+			return nil, nil, nil, nil, nil, err
+		}
+		for _, submission := range courseSubmissions {
 			courseWorkID := ""
 			if submission != nil {
 				courseWorkID = submission.CourseWorkId
@@ -235,85 +254,83 @@ func fetchBackupClassroomChildren(ctx context.Context, svc *classroom.Service, c
 			submissions = append(submissions, classroomBackupSubmission{CourseID: courseID, CourseWorkID: courseWorkID, Submission: submission})
 		}
 	}
-	return topics, announcements, coursework, materials, submissions
+	return topics, announcements, coursework, materials, submissions, nil
 }
 
-func fetchClassroomTopicsBestEffort(ctx context.Context, svc *classroom.Service, courseID string) []*classroom.Topic {
-	var out []*classroom.Topic
-	pageToken := ""
-	for {
-		resp, err := svc.Courses.Topics.List(courseID).PageSize(100).PageToken(pageToken).Context(ctx).Do()
-		if err != nil {
-			return out
+func fetchClassroomTopicsBestEffort(ctx context.Context, svc *classroom.Service, courseID string) ([]*classroom.Topic, error) {
+	out, err := collectAllPages("", func(pageToken string) ([]*classroom.Topic, string, error) {
+		resp, listErr := svc.Courses.Topics.List(courseID).PageSize(100).PageToken(pageToken).Context(ctx).Do()
+		if listErr != nil {
+			return nil, "", listErr
 		}
-		out = append(out, resp.Topic...)
-		if resp.NextPageToken == "" {
-			return out
-		}
-		pageToken = resp.NextPageToken
+		return resp.Topic, resp.NextPageToken, nil
+	})
+	if isBackupPaginationGuardError(err) {
+		return nil, err
 	}
+	return out, nil
 }
 
-func fetchClassroomAnnouncementsBestEffort(ctx context.Context, svc *classroom.Service, courseID string) []*classroom.Announcement {
-	var out []*classroom.Announcement
-	pageToken := ""
-	for {
-		resp, err := svc.Courses.Announcements.List(courseID).PageSize(100).PageToken(pageToken).Context(ctx).Do()
-		if err != nil {
-			return out
+func fetchClassroomAnnouncementsBestEffort(ctx context.Context, svc *classroom.Service, courseID string) ([]*classroom.Announcement, error) {
+	out, err := collectAllPages("", func(pageToken string) ([]*classroom.Announcement, string, error) {
+		resp, listErr := svc.Courses.Announcements.List(courseID).PageSize(100).PageToken(pageToken).Context(ctx).Do()
+		if listErr != nil {
+			return nil, "", listErr
 		}
-		out = append(out, resp.Announcements...)
-		if resp.NextPageToken == "" {
-			return out
-		}
-		pageToken = resp.NextPageToken
+		return resp.Announcements, resp.NextPageToken, nil
+	})
+	if isBackupPaginationGuardError(err) {
+		return nil, err
 	}
+	return out, nil
 }
 
-func fetchClassroomCourseWorkBestEffort(ctx context.Context, svc *classroom.Service, courseID string) []*classroom.CourseWork {
-	var out []*classroom.CourseWork
-	pageToken := ""
-	for {
-		resp, err := svc.Courses.CourseWork.List(courseID).PageSize(100).PageToken(pageToken).Context(ctx).Do()
-		if err != nil {
-			return out
+func fetchClassroomCourseWorkBestEffort(ctx context.Context, svc *classroom.Service, courseID string) ([]*classroom.CourseWork, error) {
+	out, err := collectAllPages("", func(pageToken string) ([]*classroom.CourseWork, string, error) {
+		resp, listErr := svc.Courses.CourseWork.List(courseID).PageSize(100).PageToken(pageToken).Context(ctx).Do()
+		if listErr != nil {
+			return nil, "", listErr
 		}
-		out = append(out, resp.CourseWork...)
-		if resp.NextPageToken == "" {
-			return out
-		}
-		pageToken = resp.NextPageToken
+		return resp.CourseWork, resp.NextPageToken, nil
+	})
+	if isBackupPaginationGuardError(err) {
+		return nil, err
 	}
+	return out, nil
 }
 
-func fetchClassroomMaterialsBestEffort(ctx context.Context, svc *classroom.Service, courseID string) []*classroom.CourseWorkMaterial {
-	var out []*classroom.CourseWorkMaterial
-	pageToken := ""
-	for {
-		resp, err := svc.Courses.CourseWorkMaterials.List(courseID).PageSize(100).PageToken(pageToken).Context(ctx).Do()
-		if err != nil {
-			return out
+func fetchClassroomMaterialsBestEffort(ctx context.Context, svc *classroom.Service, courseID string) ([]*classroom.CourseWorkMaterial, error) {
+	out, err := collectAllPages("", func(pageToken string) ([]*classroom.CourseWorkMaterial, string, error) {
+		resp, listErr := svc.Courses.CourseWorkMaterials.List(courseID).PageSize(100).PageToken(pageToken).Context(ctx).Do()
+		if listErr != nil {
+			return nil, "", listErr
 		}
-		out = append(out, resp.CourseWorkMaterial...)
-		if resp.NextPageToken == "" {
-			return out
-		}
-		pageToken = resp.NextPageToken
+		return resp.CourseWorkMaterial, resp.NextPageToken, nil
+	})
+	if isBackupPaginationGuardError(err) {
+		return nil, err
 	}
+	return out, nil
 }
 
-func fetchClassroomSubmissionsBestEffort(ctx context.Context, svc *classroom.Service, courseID string) []*classroom.StudentSubmission {
-	var out []*classroom.StudentSubmission
-	pageToken := ""
-	for {
-		resp, err := svc.Courses.CourseWork.StudentSubmissions.List(courseID, "-").PageSize(100).PageToken(pageToken).Context(ctx).Do()
-		if err != nil {
-			return out
+func fetchClassroomSubmissionsBestEffort(ctx context.Context, svc *classroom.Service, courseID string) ([]*classroom.StudentSubmission, error) {
+	out, err := collectAllPages("", func(pageToken string) ([]*classroom.StudentSubmission, string, error) {
+		resp, listErr := svc.Courses.CourseWork.StudentSubmissions.List(courseID, "-").PageSize(100).PageToken(pageToken).Context(ctx).Do()
+		if listErr != nil {
+			return nil, "", listErr
 		}
-		out = append(out, resp.StudentSubmissions...)
-		if resp.NextPageToken == "" {
-			return out
-		}
-		pageToken = resp.NextPageToken
+		return resp.StudentSubmissions, resp.NextPageToken, nil
+	})
+	if isBackupPaginationGuardError(err) {
+		return nil, err
 	}
+	return out, nil
+}
+
+func isBackupPaginationGuardError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "pagination loop") || strings.Contains(msg, "pagination exceeded")
 }

--- a/internal/cmd/backup_chat_classroom_test.go
+++ b/internal/cmd/backup_chat_classroom_test.go
@@ -8,6 +8,9 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"google.golang.org/api/chat/v1"
+	"google.golang.org/api/classroom/v1"
 )
 
 func TestFetchBackupChatSpacesRejectsRepeatedPageToken(t *testing.T) {
@@ -66,6 +69,153 @@ func TestFetchBackupClassroomCoursesRejectsRepeatedPageToken(t *testing.T) {
 	}
 	if got := calls.Load(); got != 2 {
 		t.Fatalf("list calls = %d, want 2", got)
+	}
+}
+
+func TestFetchBackupChatMessagesRejectsRepeatedPageToken(t *testing.T) {
+	var calls atomic.Int32
+	svc := newChatTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !strings.HasSuffix(r.URL.Path, "/messages") {
+			http.NotFound(w, r)
+			return
+		}
+		if calls.Add(1) > 2 {
+			http.Error(w, "unexpected extra message page request", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"messages":      []map[string]any{{"name": "spaces/aaa/messages/m1"}},
+			"nextPageToken": "stuck",
+		})
+	}))
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+	got, err := fetchBackupChatMessages(ctx, svc, []*chat.Space{{Name: "spaces/aaa"}})
+	if err == nil || !strings.Contains(err.Error(), "repeated page token") {
+		t.Fatalf("err = %v after %d list calls", err, calls.Load())
+	}
+	if got != nil || calls.Load() != 2 {
+		t.Fatalf("messages = %#v, calls = %d; want no partial result and two calls", got, calls.Load())
+	}
+}
+
+func TestFetchBackupClassroomChildrenRejectRepeatedPageTokens(t *testing.T) {
+	tests := []struct {
+		path        string
+		responseKey string
+	}{
+		{path: "/topics", responseKey: "topic"},
+		{path: "/announcements", responseKey: "announcements"},
+		{path: "/courseWork", responseKey: "courseWork"},
+		{path: "/courseWorkMaterials", responseKey: "courseWorkMaterial"},
+		{path: "/studentSubmissions", responseKey: "studentSubmissions"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.responseKey, func(t *testing.T) {
+			var calls atomic.Int32
+			svc, closeService := newClassroomTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if !strings.HasSuffix(r.URL.Path, tc.path) {
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = w.Write([]byte("{}"))
+					return
+				}
+				if calls.Add(1) > 2 {
+					http.Error(w, "unexpected extra child page request", http.StatusBadRequest)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					tc.responseKey:  []map[string]any{{"id": "item-1"}},
+					"nextPageToken": "stuck",
+				})
+			}))
+			defer closeService()
+
+			ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+			defer cancel()
+			_, _, _, _, _, err := fetchBackupClassroomChildren(ctx, svc, []*classroom.Course{{Id: "course-1"}})
+			if err == nil || !strings.Contains(err.Error(), "repeated page token") {
+				t.Fatalf("err = %v after %d child list calls", err, calls.Load())
+			}
+			if got := calls.Load(); got != 2 {
+				t.Fatalf("child list calls = %d, want 2", got)
+			}
+		})
+	}
+}
+
+func TestFetchBackupClassroomChildrenPreservesPartialPagesOnAPIError(t *testing.T) {
+	for _, message := range []string{"permission denied", "upstream pagination loop"} {
+		t.Run(message, func(t *testing.T) {
+			responses := map[string]struct {
+				key  string
+				item map[string]any
+			}{
+				"topics":              {key: "topic", item: map[string]any{"topicId": "topic-1"}},
+				"announcements":       {key: "announcements", item: map[string]any{"id": "announcement-1"}},
+				"courseWork":          {key: "courseWork", item: map[string]any{"id": "work-1"}},
+				"courseWorkMaterials": {key: "courseWorkMaterial", item: map[string]any{"id": "material-1"}},
+				"studentSubmissions":  {key: "studentSubmissions", item: map[string]any{"id": "submission-1", "courseWorkId": "work-1"}},
+			}
+			calls := make(map[string]*atomic.Int32, len(responses))
+			for resource := range responses {
+				calls[resource] = &atomic.Int32{}
+			}
+			svc, closeService := newClassroomTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				resource := r.URL.Path[strings.LastIndex(r.URL.Path, "/")+1:]
+				response, ok := responses[resource]
+				if !ok || r.Method != http.MethodGet {
+					http.NotFound(w, r)
+					return
+				}
+				n := calls[resource].Add(1)
+				if n == 1 {
+					if token := r.URL.Query().Get("pageToken"); token != "" {
+						t.Errorf("%s initial page token = %q", resource, token)
+					}
+					w.Header().Set("Content-Type", "application/json")
+					_ = json.NewEncoder(w).Encode(map[string]any{
+						response.key:    []map[string]any{response.item},
+						"nextPageToken": "page-2",
+					})
+					return
+				}
+				if n != 2 || r.URL.Query().Get("pageToken") != "page-2" {
+					t.Errorf("%s page request %d has token %q", resource, n, r.URL.Query().Get("pageToken"))
+				}
+				http.Error(w, message, http.StatusForbidden)
+			}))
+			defer closeService()
+
+			ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+			defer cancel()
+			topics, announcements, work, materials, submissions, err := fetchBackupClassroomChildren(ctx, svc, []*classroom.Course{{Id: "course-1"}})
+			if err != nil {
+				t.Fatalf("ordinary API error must remain best-effort: %v", err)
+			}
+			if len(topics) != 1 || topics[0].Topic.TopicId != "topic-1" || topics[0].CourseID != "course-1" {
+				t.Errorf("topics = %#v, want the first page", topics)
+			}
+			if len(announcements) != 1 || announcements[0].Announcement.Id != "announcement-1" {
+				t.Errorf("announcements = %#v, want the first page", announcements)
+			}
+			if len(work) != 1 || work[0].CourseWork.Id != "work-1" {
+				t.Errorf("coursework = %#v, want the first page", work)
+			}
+			if len(materials) != 1 || materials[0].Material.Id != "material-1" {
+				t.Errorf("materials = %#v, want the first page", materials)
+			}
+			if len(submissions) != 1 || submissions[0].Submission.Id != "submission-1" || submissions[0].CourseWorkID != "work-1" {
+				t.Errorf("submissions = %#v, want the first page", submissions)
+			}
+			for resource, count := range calls {
+				if got := count.Load(); got != 2 {
+					t.Errorf("%s list calls = %d, want 2", resource, got)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/cmd/backup_chat_classroom_test.go
+++ b/internal/cmd/backup_chat_classroom_test.go
@@ -1,0 +1,268 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"google.golang.org/api/chat/v1"
+)
+
+func TestFetchBackupChatSpacesRejectsRepeatedPageToken(t *testing.T) {
+	var calls atomic.Int32
+	svc := newChatTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !(r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/spaces")) {
+			http.NotFound(w, r)
+			return
+		}
+		if calls.Add(1) > 2 {
+			http.Error(w, "unexpected extra space page request", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"spaces":        []map[string]any{{"name": "spaces/aaa"}},
+			"nextPageToken": "stuck",
+		})
+	}))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	_, err := fetchBackupChatSpaces(ctx, svc)
+	if err == nil || !strings.Contains(err.Error(), "repeated page token") {
+		t.Fatalf("err = %v after %d list calls", err, calls.Load())
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("list calls = %d, want 2", got)
+	}
+}
+
+func TestFetchBackupChatSpacesEmptyNextTokenEnds(t *testing.T) {
+	var calls atomic.Int32
+	svc := newChatTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !(r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/spaces")) {
+			http.NotFound(w, r)
+			return
+		}
+		calls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"spaces": []map[string]any{{"name": "spaces/aaa"}},
+		})
+	}))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	got, err := fetchBackupChatSpaces(ctx, svc)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("list calls = %d, want 1", calls.Load())
+	}
+	if len(got) != 1 || got[0].Name != "spaces/aaa" {
+		t.Fatalf("spaces = %#v", got)
+	}
+}
+
+func TestFetchBackupChatSpacesTwoDistinctPagesSucceed(t *testing.T) {
+	var calls atomic.Int32
+	svc := newChatTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !(r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/spaces")) {
+			http.NotFound(w, r)
+			return
+		}
+		n := calls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		if n == 1 {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"spaces":        []map[string]any{{"name": "spaces/aaa"}},
+				"nextPageToken": "page-2",
+			})
+			return
+		}
+		if n == 2 {
+			if r.URL.Query().Get("pageToken") != "page-2" {
+				t.Errorf("pageToken = %q, want page-2", r.URL.Query().Get("pageToken"))
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"spaces": []map[string]any{{"name": "spaces/bbb"}},
+			})
+			return
+		}
+		http.Error(w, "unexpected extra space page request", http.StatusBadRequest)
+	}))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	got, err := fetchBackupChatSpaces(ctx, svc)
+	if err != nil {
+		t.Fatalf("err = %v after %d list calls", err, calls.Load())
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("list calls = %d, want 2", calls.Load())
+	}
+	if len(got) != 2 || got[0].Name != "spaces/aaa" || got[1].Name != "spaces/bbb" {
+		t.Fatalf("spaces = %#v", got)
+	}
+}
+
+func TestFetchBackupChatMessagesRejectsRepeatedPageToken(t *testing.T) {
+	var calls atomic.Int32
+	svc := newChatTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !(r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/messages")) {
+			http.NotFound(w, r)
+			return
+		}
+		if calls.Add(1) > 2 {
+			http.Error(w, "unexpected extra message page request", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"messages":      []map[string]any{{"name": "spaces/aaa/messages/m1"}},
+			"nextPageToken": "stuck",
+		})
+	}))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	_, err := fetchBackupChatMessages(ctx, svc, []*chat.Space{{Name: "spaces/aaa"}})
+	if err == nil || !strings.Contains(err.Error(), "repeated page token") {
+		t.Fatalf("err = %v after %d list calls", err, calls.Load())
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("list calls = %d, want 2", got)
+	}
+}
+
+func TestFetchBackupClassroomCoursesRejectsRepeatedPageToken(t *testing.T) {
+	var calls atomic.Int32
+	svc, closeService := newClassroomTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !(r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/courses")) {
+			http.NotFound(w, r)
+			return
+		}
+		if calls.Add(1) > 2 {
+			http.Error(w, "unexpected extra course page request", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"courses":       []map[string]any{{"id": "c1", "name": "Biology"}},
+			"nextPageToken": "stuck",
+		})
+	}))
+	defer closeService()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	_, err := fetchBackupClassroomCourses(ctx, svc)
+	if err == nil || !strings.Contains(err.Error(), "repeated page token") {
+		t.Fatalf("err = %v after %d list calls", err, calls.Load())
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("list calls = %d, want 2", got)
+	}
+}
+
+func TestFetchBackupClassroomChildrenRejectRepeatedPageTokens(t *testing.T) {
+	tests := []struct {
+		name        string
+		path        string
+		responseKey string
+	}{
+		{name: "topics", path: "/topics", responseKey: "topic"},
+		{name: "announcements", path: "/announcements", responseKey: "announcements"},
+		{name: "coursework", path: "/courseWork", responseKey: "courseWork"},
+		{name: "materials", path: "/courseWorkMaterials", responseKey: "courseWorkMaterial"},
+		{name: "submissions", path: "/studentSubmissions", responseKey: "studentSubmissions"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var calls atomic.Int32
+			svc, closeService := newClassroomTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if !(r.Method == http.MethodGet && strings.Contains(r.URL.Path, tc.path)) {
+					http.NotFound(w, r)
+					return
+				}
+				if calls.Add(1) > 2 {
+					http.Error(w, "unexpected extra page request", http.StatusBadRequest)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					tc.responseKey:  []map[string]any{{"id": "item-1"}},
+					"nextPageToken": "stuck",
+				})
+			}))
+			defer closeService()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			var err error
+			switch tc.name {
+			case "topics":
+				_, err = fetchClassroomTopicsBestEffort(ctx, svc, "c1")
+			case "announcements":
+				_, err = fetchClassroomAnnouncementsBestEffort(ctx, svc, "c1")
+			case "coursework":
+				_, err = fetchClassroomCourseWorkBestEffort(ctx, svc, "c1")
+			case "materials":
+				_, err = fetchClassroomMaterialsBestEffort(ctx, svc, "c1")
+			case "submissions":
+				_, err = fetchClassroomSubmissionsBestEffort(ctx, svc, "c1")
+			}
+			if err == nil || !strings.Contains(err.Error(), "repeated page token") {
+				t.Fatalf("err = %v after %d list calls", err, calls.Load())
+			}
+			if got := calls.Load(); got != 2 {
+				t.Fatalf("list calls = %d, want 2", got)
+			}
+		})
+	}
+}
+
+func TestFetchBackupClassroomCoursesTwoDistinctPagesSucceed(t *testing.T) {
+	var calls atomic.Int32
+	svc, closeService := newClassroomTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !(r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/courses")) {
+			http.NotFound(w, r)
+			return
+		}
+		n := calls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		if n == 1 {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"courses":       []map[string]any{{"id": "c1", "name": "Biology"}},
+				"nextPageToken": "page-2",
+			})
+			return
+		}
+		if n == 2 {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"courses": []map[string]any{{"id": "c2", "name": "Chemistry"}},
+			})
+			return
+		}
+		http.Error(w, "unexpected extra course page request", http.StatusBadRequest)
+	}))
+	defer closeService()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	got, err := fetchBackupClassroomCourses(ctx, svc)
+	if err != nil {
+		t.Fatalf("err = %v after %d list calls", err, calls.Load())
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("list calls = %d, want 2", calls.Load())
+	}
+	if len(got) != 2 || got[0].Id != "c1" || got[1].Id != "c2" {
+		t.Fatalf("courses = %#v", got)
+	}
+}

--- a/internal/cmd/backup_chat_classroom_test.go
+++ b/internal/cmd/backup_chat_classroom_test.go
@@ -8,8 +8,6 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
-
-	"google.golang.org/api/chat/v1"
 )
 
 func TestFetchBackupChatSpacesRejectsRepeatedPageToken(t *testing.T) {
@@ -33,105 +31,6 @@ func TestFetchBackupChatSpacesRejectsRepeatedPageToken(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	_, err := fetchBackupChatSpaces(ctx, svc)
-	if err == nil || !strings.Contains(err.Error(), "repeated page token") {
-		t.Fatalf("err = %v after %d list calls", err, calls.Load())
-	}
-	if got := calls.Load(); got != 2 {
-		t.Fatalf("list calls = %d, want 2", got)
-	}
-}
-
-func TestFetchBackupChatSpacesEmptyNextTokenEnds(t *testing.T) {
-	var calls atomic.Int32
-	svc := newChatTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if !(r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/spaces")) {
-			http.NotFound(w, r)
-			return
-		}
-		calls.Add(1)
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"spaces": []map[string]any{{"name": "spaces/aaa"}},
-		})
-	}))
-
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-	got, err := fetchBackupChatSpaces(ctx, svc)
-	if err != nil {
-		t.Fatalf("err = %v", err)
-	}
-	if calls.Load() != 1 {
-		t.Fatalf("list calls = %d, want 1", calls.Load())
-	}
-	if len(got) != 1 || got[0].Name != "spaces/aaa" {
-		t.Fatalf("spaces = %#v", got)
-	}
-}
-
-func TestFetchBackupChatSpacesTwoDistinctPagesSucceed(t *testing.T) {
-	var calls atomic.Int32
-	svc := newChatTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if !(r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/spaces")) {
-			http.NotFound(w, r)
-			return
-		}
-		n := calls.Add(1)
-		w.Header().Set("Content-Type", "application/json")
-		if n == 1 {
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"spaces":        []map[string]any{{"name": "spaces/aaa"}},
-				"nextPageToken": "page-2",
-			})
-			return
-		}
-		if n == 2 {
-			if r.URL.Query().Get("pageToken") != "page-2" {
-				t.Errorf("pageToken = %q, want page-2", r.URL.Query().Get("pageToken"))
-			}
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"spaces": []map[string]any{{"name": "spaces/bbb"}},
-			})
-			return
-		}
-		http.Error(w, "unexpected extra space page request", http.StatusBadRequest)
-	}))
-
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-	got, err := fetchBackupChatSpaces(ctx, svc)
-	if err != nil {
-		t.Fatalf("err = %v after %d list calls", err, calls.Load())
-	}
-	if calls.Load() != 2 {
-		t.Fatalf("list calls = %d, want 2", calls.Load())
-	}
-	if len(got) != 2 || got[0].Name != "spaces/aaa" || got[1].Name != "spaces/bbb" {
-		t.Fatalf("spaces = %#v", got)
-	}
-}
-
-func TestFetchBackupChatMessagesRejectsRepeatedPageToken(t *testing.T) {
-	var calls atomic.Int32
-	svc := newChatTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if !(r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/messages")) {
-			http.NotFound(w, r)
-			return
-		}
-		if calls.Add(1) > 2 {
-			http.Error(w, "unexpected extra message page request", http.StatusBadRequest)
-			return
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"messages":      []map[string]any{{"name": "spaces/aaa/messages/m1"}},
-			"nextPageToken": "stuck",
-		})
-	}))
-
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-	_, err := fetchBackupChatMessages(ctx, svc, []*chat.Space{{Name: "spaces/aaa"}})
 	if err == nil || !strings.Contains(err.Error(), "repeated page token") {
 		t.Fatalf("err = %v after %d list calls", err, calls.Load())
 	}
@@ -170,67 +69,10 @@ func TestFetchBackupClassroomCoursesRejectsRepeatedPageToken(t *testing.T) {
 	}
 }
 
-func TestFetchBackupClassroomChildrenRejectRepeatedPageTokens(t *testing.T) {
-	tests := []struct {
-		name        string
-		path        string
-		responseKey string
-	}{
-		{name: "topics", path: "/topics", responseKey: "topic"},
-		{name: "announcements", path: "/announcements", responseKey: "announcements"},
-		{name: "coursework", path: "/courseWork", responseKey: "courseWork"},
-		{name: "materials", path: "/courseWorkMaterials", responseKey: "courseWorkMaterial"},
-		{name: "submissions", path: "/studentSubmissions", responseKey: "studentSubmissions"},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			var calls atomic.Int32
-			svc, closeService := newClassroomTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if !(r.Method == http.MethodGet && strings.Contains(r.URL.Path, tc.path)) {
-					http.NotFound(w, r)
-					return
-				}
-				if calls.Add(1) > 2 {
-					http.Error(w, "unexpected extra page request", http.StatusBadRequest)
-					return
-				}
-				w.Header().Set("Content-Type", "application/json")
-				_ = json.NewEncoder(w).Encode(map[string]any{
-					tc.responseKey:  []map[string]any{{"id": "item-1"}},
-					"nextPageToken": "stuck",
-				})
-			}))
-			defer closeService()
-
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-			defer cancel()
-			var err error
-			switch tc.name {
-			case "topics":
-				_, err = fetchClassroomTopicsBestEffort(ctx, svc, "c1")
-			case "announcements":
-				_, err = fetchClassroomAnnouncementsBestEffort(ctx, svc, "c1")
-			case "coursework":
-				_, err = fetchClassroomCourseWorkBestEffort(ctx, svc, "c1")
-			case "materials":
-				_, err = fetchClassroomMaterialsBestEffort(ctx, svc, "c1")
-			case "submissions":
-				_, err = fetchClassroomSubmissionsBestEffort(ctx, svc, "c1")
-			}
-			if err == nil || !strings.Contains(err.Error(), "repeated page token") {
-				t.Fatalf("err = %v after %d list calls", err, calls.Load())
-			}
-			if got := calls.Load(); got != 2 {
-				t.Fatalf("list calls = %d, want 2", got)
-			}
-		})
-	}
-}
-
-func TestFetchBackupClassroomCoursesTwoDistinctPagesSucceed(t *testing.T) {
+func TestFetchBackupChatSpacesTwoDistinctPagesSucceed(t *testing.T) {
 	var calls atomic.Int32
-	svc, closeService := newClassroomTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if !(r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/courses")) {
+	svc := newChatTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !(r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/spaces")) {
 			http.NotFound(w, r)
 			return
 		}
@@ -238,31 +80,30 @@ func TestFetchBackupClassroomCoursesTwoDistinctPagesSucceed(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		if n == 1 {
 			_ = json.NewEncoder(w).Encode(map[string]any{
-				"courses":       []map[string]any{{"id": "c1", "name": "Biology"}},
+				"spaces":        []map[string]any{{"name": "spaces/aaa"}},
 				"nextPageToken": "page-2",
 			})
 			return
 		}
 		if n == 2 {
 			_ = json.NewEncoder(w).Encode(map[string]any{
-				"courses": []map[string]any{{"id": "c2", "name": "Chemistry"}},
+				"spaces": []map[string]any{{"name": "spaces/bbb"}},
 			})
 			return
 		}
-		http.Error(w, "unexpected extra course page request", http.StatusBadRequest)
+		http.Error(w, "unexpected extra space page request", http.StatusBadRequest)
 	}))
-	defer closeService()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	got, err := fetchBackupClassroomCourses(ctx, svc)
+	got, err := fetchBackupChatSpaces(ctx, svc)
 	if err != nil {
 		t.Fatalf("err = %v after %d list calls", err, calls.Load())
 	}
 	if calls.Load() != 2 {
 		t.Fatalf("list calls = %d, want 2", calls.Load())
 	}
-	if len(got) != 2 || got[0].Id != "c1" || got[1].Id != "c2" {
-		t.Fatalf("courses = %#v", got)
+	if len(got) != 2 || got[0].Name != "spaces/aaa" || got[1].Name != "spaces/bbb" {
+		t.Fatalf("spaces = %#v", got)
 	}
 }

--- a/internal/cmd/paging_test.go
+++ b/internal/cmd/paging_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"errors"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -74,6 +75,53 @@ func TestCollectAllPages(t *testing.T) {
 		}
 		if calls != 2 {
 			t.Fatalf("calls = %d, want 2", calls)
+		}
+	})
+
+	t.Run("fetch error discards partial results", func(t *testing.T) {
+		t.Parallel()
+		fetchErr := errors.New("page two failed")
+		var calls int
+		got, err := collectAllPages("", func(pageToken string) ([]string, string, error) {
+			calls++
+			if calls == 1 {
+				return []string{"a"}, "page-2", nil
+			}
+			return nil, "", fetchErr
+		})
+		if !errors.Is(err, fetchErr) || got != nil || calls != 2 {
+			t.Fatalf("got = %#v, err = %v, calls = %d", got, err, calls)
+		}
+	})
+
+	t.Run("multi-token cycle stops before revisiting a page", func(t *testing.T) {
+		t.Parallel()
+		nextTokens := []string{"a", "b", "a"}
+		var calls int
+		got, err := collectAllPages("", func(pageToken string) ([]string, string, error) {
+			calls++
+			if calls > len(nextTokens) {
+				return nil, "", errors.New("fetch called after cycle")
+			}
+			return []string{"item"}, nextTokens[calls-1], nil
+		})
+		if got != nil || err == nil || !strings.Contains(err.Error(), "repeated page token") || calls != 3 {
+			t.Fatalf("got = %#v, err = %v, calls = %d", got, err, calls)
+		}
+	})
+
+	t.Run("unique tokens respect the page limit", func(t *testing.T) {
+		t.Parallel()
+		var calls int
+		got, err := collectAllPages("", func(pageToken string) ([]int, string, error) {
+			calls++
+			if calls > 10_000 {
+				return nil, "", errors.New("fetch called beyond page limit")
+			}
+			return []int{calls}, strconv.Itoa(calls), nil
+		})
+		if got != nil || err == nil || !strings.Contains(err.Error(), "pagination exceeded") || calls != 10_000 {
+			t.Fatalf("rows = %d, err = %v, calls = %d", len(got), err, calls)
 		}
 	})
 }

--- a/internal/cmd/paging_test.go
+++ b/internal/cmd/paging_test.go
@@ -1,0 +1,79 @@
+package cmd
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestCollectAllPages(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty next token ends", func(t *testing.T) {
+		t.Parallel()
+		var calls int
+		got, err := collectAllPages("", func(pageToken string) ([]string, string, error) {
+			calls++
+			if pageToken != "" {
+				t.Fatalf("pageToken = %q, want empty", pageToken)
+			}
+			return []string{"a"}, "", nil
+		})
+		if err != nil {
+			t.Fatalf("err = %v", err)
+		}
+		if calls != 1 {
+			t.Fatalf("calls = %d, want 1", calls)
+		}
+		if len(got) != 1 || got[0] != "a" {
+			t.Fatalf("got = %#v", got)
+		}
+	})
+
+	t.Run("two distinct pages succeed", func(t *testing.T) {
+		t.Parallel()
+		var calls int
+		got, err := collectAllPages("", func(pageToken string) ([]string, string, error) {
+			calls++
+			switch pageToken {
+			case "":
+				return []string{"a"}, "page-2", nil
+			case "page-2":
+				return []string{"b"}, "", nil
+			default:
+				t.Fatalf("unexpected pageToken %q", pageToken)
+				return nil, "", nil
+			}
+		})
+		if err != nil {
+			t.Fatalf("err = %v", err)
+		}
+		if calls != 2 {
+			t.Fatalf("calls = %d, want 2", calls)
+		}
+		if len(got) != 2 || got[0] != "a" || got[1] != "b" {
+			t.Fatalf("got = %#v", got)
+		}
+	})
+
+	t.Run("repeated next page token returns an error", func(t *testing.T) {
+		t.Parallel()
+		var calls int
+		got, err := collectAllPages("", func(pageToken string) ([]string, string, error) {
+			calls++
+			if calls > 4 {
+				return nil, "", errors.New("fetch called after repeated token")
+			}
+			return []string{"a"}, "stuck", nil
+		})
+		if err == nil || !strings.Contains(err.Error(), "repeated page token") {
+			t.Fatalf("err = %v", err)
+		}
+		if got != nil {
+			t.Fatalf("got = %#v, want nil", got)
+		}
+		if calls != 2 {
+			t.Fatalf("calls = %d, want 2", calls)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Use the existing shared paginator for Chat spaces/messages and Classroom courses, topics, announcements, coursework, materials, and submissions. Repeated or cyclic continuation tokens now stop collection instead of repeatedly fetching the same pages; the shared 10,000-page limit also applies.

Preserve the existing Classroom child-list best-effort contract: an ordinary API failure ends that child listing without discarding earlier pages. The maintainer follow-up handles that policy inside the fetch callback, leaves the shared paginator strict, and removes error-string classification. Chat and top-level course listing errors remain strict.

## User-visible behavior

Pagination guard errors stop the affected service collection. Default `--best-effort` records them in an encrypted service error shard and lets other services continue; `--no-best-effort` returns the error. No flags, scopes, list filters, or provider permissions changed. The handwritten backup guide documents the boundary.

## Verification

- Maintained Chat-spaces and Classroom-courses tests against the old main implementation made an unwanted third request before the synthetic peer's safety cap returned HTTP 400. The guarded implementation stops after two requests with the pagination error.
- Added tests failed on contributor head `c0238cce`: a page-two 403 erased earlier rows from all five Classroom child collections; provider error text containing `pagination loop` was also incorrectly treated as a guard error. Both cases pass after the follow-up.
- Restored generated-client coverage for Chat messages and all five Classroom child types, including propagation through the aggregate child collector.
- Shared helper coverage checks ordinary fetch errors, multi-token cycles, and the page cap without making 10,000 HTTP requests.
- `go test ./internal/cmd -run '^(TestFetchBackup(Chat|Classroom)|TestCollectAllPages)' -count=1 -timeout=90s -v` passed.
- `go test -race ./internal/cmd -run '^(TestFetchBackup(Chat|Classroom)|TestCollectAllPages)' -count=1 -timeout=120s` passed.
- `make ci` and `git diff --check` passed with Go 1.27.0 on macOS arm64.

Codex autoreview of the complete integrated candidate was scoped-clean with no actionable P0/P1 findings. Exact-head [CI](https://github.com/openclaw/gogcli/actions/runs/33648974807) and [Docker](https://github.com/openclaw/gogcli/actions/runs/33648975008) passed with the restored adapter coverage.

These are deterministic generated-client HTTP fault-injection tests, not a live Google backup. No Chat/Classroom account, credentials, or extra grants were used. The earlier Windows run at `ccc52c3e` crashed inside Go's runtime with `found pointer to free object`; that did not identify a failing backup assertion, and removing adapter coverage was not a verified root-cause repair.

## Credits and provenance

Thanks @SebTardif for the original guard refactor and bounded reproduction. The unguarded loops were introduced in [068ff0e5](https://github.com/openclaw/gogcli/commit/068ff0e593cdf5d6fff08eb34fd6b5cc2cab017d), not #914; the recorded-parent diff confirms the original loops.

Related shared-paginator repairs: #1004, #1044, #1045, #1046.
