### PR TITLE
docs(gmail): explain Gmail web draft wrapping workaround

### DIFF
--- a/docs/gmail-workflows.md
+++ b/docs/gmail-workflows.md
@@ -59,6 +59,26 @@ Command pages:
 - [`gog gmail settings filters create`](commands/gog-gmail-settings-filters-create.md)
 - [`gog gmail settings filters delete`](commands/gog-gmail-settings-filters-delete.md)
 
+## Drafts Sent from Gmail Web
+
+gog preserves long logical lines when building a plain-text draft from `--body`
+or `--body-file`. Gmail web has been reported to insert hard line breaks when
+it opens and sends such a draft without edits; see the
+[before/after MIME comparison in #1058](https://github.com/openclaw/gogcli/issues/1058#issuecomment-5501187051).
+
+For drafts you intend to review and send in Gmail web, the reported workaround
+is to supply HTML paragraphs through `--body-html` or `--body-html-file`:
+
+```bash
+gog --account you@example.com gmail drafts create \
+  --to recipient@example.com --subject "Draft for review" \
+  --body-html '<p>One continuous paragraph that can reflow.</p><p>Another paragraph.</p>'
+```
+
+This creates an HTML draft; it does not change plain-text MIME behavior. Check
+the draft and recipient-client rendering before relying on the workaround for
+a particular workflow.
+
 ## Send Guardrails
 
 Block send operations globally for one run:


### PR DESCRIPTION
## Summary

Document the Gmail-web draft-wrapping limitation reported in #1058. The existing MIME writer preserves long logical lines, but the reporter's sanitized before/after control shows Gmail web inserting hard breaks when it sends the draft without edits.

Show the existing `--body-html` / `--body-html-file` workaround and distinguish HTML drafts from unchanged plain-text MIME behavior. This is documentation, not a runtime fix; #1058 stays open for a separately validated compatibility repair. Thanks @daveotero for the controlled reproduction.

## Verification

- `make ci` passed, including MIME/draft tests, lint, dead-code checks, generated command documentation, and agent-skill checks.
- `git diff --check` passed.
- Codex autoreview was scoped-clean with no accepted/actionable findings in its blocking-priority pass.

The Gmail-web send step and HTML workaround are attributed to reporter evidence, not claimed as independently repeated live tests. No messages were sent and no OAuth grants, runtime behavior, version, or changelog were changed.
