### PR TITLE
fix(drive): reject repeated page tokens in sync push listing

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -78,6 +78,8 @@ gog drive labels file list <fileId> --json
 gog drive labels file apply <fileId> <labelId> --text fieldId=value
 
 # Recursively push local contents without deleting remote-only files.
+# Listing errors, repeated page tokens, and page-limit failures stop preflight.
+# Remote writes begin only after the complete recursive plan succeeds.
 gog drive sync push ./backup --parent <folderId> --dry-run --json
 gog drive sync push ./backup --parent <folderId>
 

--- a/internal/cmd/drive_sync_push.go
+++ b/internal/cmd/drive_sync_push.go
@@ -793,9 +793,7 @@ func (c *googleDriveSyncClient) Children(ctx context.Context, parentID string) (
 
 func listDriveSyncChildren(ctx context.Context, svc *drive.Service, parentID, driveID string) ([]*drive.File, error) {
 	query := buildDriveListQuery(parentID, "")
-	files := make([]*drive.File, 0, 64)
-	var pageToken string
-	for {
+	fetch := func(pageToken string) ([]*drive.File, string, error) {
 		call := svc.Files.List().
 			Q(query).
 			PageSize(driveDefaultPageSize).
@@ -814,17 +812,14 @@ func listDriveSyncChildren(ctx context.Context, svc *drive.Service, parentID, dr
 			gapi.Field("files("+driveSyncFields+")"),
 		).Context(ctx).Do()
 		if err != nil {
-			return nil, err
+			return nil, "", err
 		}
 		if response.IncompleteSearch {
-			return nil, fmt.Errorf("drive returned an incomplete child listing for parent %q", parentID)
+			return nil, "", fmt.Errorf("drive returned an incomplete child listing for parent %q", parentID)
 		}
-		files = append(files, response.Files...)
-		if response.NextPageToken == "" {
-			return files, nil
-		}
-		pageToken = response.NextPageToken
+		return response.Files, response.NextPageToken, nil
 	}
+	return collectAllPages("", fetch)
 }
 
 func (c *googleDriveSyncClient) CreateFolder(ctx context.Context, name, parentID string) (*drive.File, error) {

--- a/internal/cmd/drive_sync_push_test.go
+++ b/internal/cmd/drive_sync_push_test.go
@@ -14,7 +14,9 @@ import (
 	"runtime"
 	"sort"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"google.golang.org/api/drive/v3"
 
@@ -604,6 +606,41 @@ func TestListDriveSyncChildrenRejectsIncompleteSearch(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "incomplete child listing") {
 		t.Fatalf("error = %v", err)
 	}
+}
+
+func TestListDriveSyncChildrenRejectsRepeatedPageToken(t *testing.T) {
+	t.Parallel()
+
+	var listCalls atomic.Int32
+	svc, closeServer := newDriveTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !strings.HasSuffix(r.URL.Path, "/files") {
+			http.NotFound(w, r)
+			return
+		}
+		if listCalls.Add(1) > 2 {
+			http.Error(w, "unexpected extra page request", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"files": []any{
+				map[string]any{"id": "child-1", "name": "a.txt"},
+			},
+			"nextPageToken": "stuck",
+		})
+	}))
+	defer closeServer()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	_, err := listDriveSyncChildren(ctx, svc, "parent", "")
+	if err == nil || !strings.Contains(err.Error(), "repeated page token") {
+		t.Fatalf("err = %v after %d list calls", err, listCalls.Load())
+	}
+	if got := listCalls.Load(); got != 2 {
+		t.Fatalf("list calls = %d, want 2", got)
+	}
+	t.Logf("err = %v after %d list calls", err, listCalls.Load())
 }
 
 func TestExecuteDriveSyncPushDryRunPlansWithoutWrites(t *testing.T) {

--- a/internal/cmd/drive_sync_push_test.go
+++ b/internal/cmd/drive_sync_push_test.go
@@ -617,10 +617,16 @@ func TestListDriveSyncChildrenRejectsRepeatedPageToken(t *testing.T) {
 			http.NotFound(w, r)
 			return
 		}
-		if listCalls.Add(1) > 2 {
+		n := listCalls.Add(1)
+		if n > 2 {
 			http.Error(w, "unexpected extra page request", http.StatusBadRequest)
 			return
 		}
+		wantToken := ""
+		if n == 2 {
+			wantToken = "stuck"
+		}
+		requireQuery(t, r, "pageToken", wantToken)
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"files": []any{
@@ -633,14 +639,137 @@ func TestListDriveSyncChildrenRejectsRepeatedPageToken(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	_, err := listDriveSyncChildren(ctx, svc, "parent", "")
+	files, err := listDriveSyncChildren(ctx, svc, "parent", "")
 	if err == nil || !strings.Contains(err.Error(), "repeated page token") {
 		t.Fatalf("err = %v after %d list calls", err, listCalls.Load())
 	}
 	if got := listCalls.Load(); got != 2 {
 		t.Fatalf("list calls = %d, want 2", got)
 	}
+	if files != nil {
+		t.Fatalf("unexpected partial children: %#v", files)
+	}
 	t.Logf("err = %v after %d list calls", err, listCalls.Load())
+}
+
+func TestListDriveSyncChildrenLaterPages(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		apiError   bool
+		incomplete bool
+		wantError  string
+	}{
+		{name: "complete"},
+		{name: "API error", apiError: true, wantError: "403"},
+		{name: "incomplete search", incomplete: true, wantError: "incomplete child listing"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var calls atomic.Int32
+			svc, closeServer := newDriveTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodGet || !strings.HasSuffix(r.URL.Path, "/files") {
+					http.NotFound(w, r)
+					return
+				}
+				n := calls.Add(1)
+				if n > 2 {
+					http.Error(w, "unexpected extra page request", http.StatusBadRequest)
+					return
+				}
+				wantToken := ""
+				if n == 2 {
+					wantToken = "page-2"
+				}
+				requireQuery(t, r, "pageToken", wantToken)
+				if n == 2 && tc.apiError {
+					http.Error(w, "permission denied", http.StatusForbidden)
+					return
+				}
+				response := map[string]any{
+					"files": []any{map[string]any{"id": fmt.Sprintf("child-%d", n), "name": fmt.Sprintf("%d.txt", n)}},
+				}
+				if n == 1 {
+					response["nextPageToken"] = "page-2"
+				} else if tc.incomplete {
+					response["incompleteSearch"] = true
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(response)
+			}))
+			defer closeServer()
+
+			ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+			defer cancel()
+			files, err := listDriveSyncChildren(ctx, svc, "parent", "")
+			if calls.Load() != 2 {
+				t.Fatalf("list calls = %d, want 2", calls.Load())
+			}
+			if tc.wantError != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantError) || files != nil {
+					t.Fatalf("files = %#v, error = %v; want no partial children and %q", files, err, tc.wantError)
+				}
+				return
+			}
+			if err != nil || len(files) != 2 || files[0].Id != "child-1" || files[1].Id != "child-2" {
+				t.Fatalf("files = %#v, error = %v; want both pages in order", files, err)
+			}
+		})
+	}
+}
+
+func TestExecuteDriveSyncPushPaginationErrorDoesNotWrite(t *testing.T) {
+	t.Parallel()
+
+	root := writeDriveSyncFixture(t)
+	var listCalls, writes atomic.Int32
+	svc, closeServer := newDriveTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			writes.Add(1)
+			http.Error(w, "unexpected write", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if strings.HasSuffix(r.URL.Path, "/files/parent") {
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": "parent", "name": "parent", "mimeType": driveMimeFolder})
+			return
+		}
+		if strings.HasSuffix(r.URL.Path, "/files") {
+			if strings.Contains(r.URL.Query().Get("q"), "'parent' in parents") {
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"files": []any{map[string]any{"id": "nested", "name": "nested", "mimeType": driveMimeFolder}},
+				})
+				return
+			}
+			if strings.Contains(r.URL.Query().Get("q"), "'nested' in parents") {
+				if listCalls.Add(1) > 2 {
+					http.Error(w, "unexpected extra nested page", http.StatusBadRequest)
+					return
+				}
+				_ = json.NewEncoder(w).Encode(map[string]any{"files": []any{}, "nextPageToken": "stuck"})
+				return
+			}
+		}
+		http.NotFound(w, r)
+	}))
+	defer closeServer()
+
+	result := executeWithDriveTestService(t, []string{
+		"--account", "test@example.com", "--json",
+		"drive", "sync", "push", root, "--parent", "parent",
+	}, svc)
+	if result.err == nil || !strings.Contains(result.err.Error(), "repeated page token") {
+		t.Fatalf("execute: %v; stderr: %s", result.err, result.stderr)
+	}
+	if listCalls.Load() != 2 || writes.Load() != 0 {
+		t.Fatalf("nested list calls = %d, writes = %d; want two reads and no writes", listCalls.Load(), writes.Load())
+	}
+	if strings.TrimSpace(result.stdout) != "" {
+		t.Fatalf("unexpected success output: %s", result.stdout)
+	}
 }
 
 func TestExecuteDriveSyncPushDryRunPlansWithoutWrites(t *testing.T) {


### PR DESCRIPTION
## Summary

`gog drive sync push` previously copied each `nextPageToken` into the next folder-list request without detecting repeated tokens. A faulty continuation could keep the recursive preflight running indefinitely and repeatedly accumulate the same children.

Keep @SebTardif's narrow fix: route `listDriveSyncChildren` through the existing `collectAllPages` helper, preserving the query, selected fields, shared-drive flags, request context, ordering, and incomplete-search rejection. Repeated tokens and the shared page limit now fail preflight. Ordinary provider failures still discard partial children; remote writes begin only after the entire recursive plan succeeds.

The maintainer follow-up strengthens the existing regression test, adds populated multi-page success and later-page failure cases, and exercises the real command path with a nested pagination failure after an earlier upload could already have been planned. The command must make zero writes and emit no success output. `docs/examples.md` documents that boundary.

## Validation

Tested the complete candidate integrated on main at `eaea84227d4f0d8b7ebb5beccaca80ede0876677`.

- The maintained repeated-token test fails against the old production adapter after a bounded third request; the corrected adapter rejects the repeated token after two requests and returns no partial children.
- Populated two-page results preserve order. A second-page API error or incomplete-search response returns no partial listing.
- The full `drive sync push` regression, without `--dry-run`, verifies no HTTP writes and no success output on a nested pagination error.
- Focused tests and the full `make ci` gate passed. One initial test-lint finding was corrected by marking the independent table subtests parallel; no lint rule was disabled.
- Independent Codex review of the complete integrated candidate was scoped-clean at P0/P1.

```sh
go test ./internal/cmd -run '^(TestDriveSyncPush|TestGoogleDriveSyncClientUsesSharedDriveFlags|TestListDriveSyncChildren|TestExecuteDriveSyncPush)' -count=1 -timeout=90s
go test -race ./internal/cmd -run '^(TestDriveSyncPush|TestGoogleDriveSyncClientUsesSharedDriveFlags|TestListDriveSyncChildren|TestExecuteDriveSyncPush)' -parallel=1 -count=1 -timeout=120s
make ci
```

The serialized race run passed. The default-parallel run exposed a separate preexisting global locked-flag-state race; the same failure was reproduced on unchanged main using only the existing dry-run/help tests. That ownership defect is being handled separately, not hidden by deleting concurrent tests or attributed to this pagination change.

This is deterministic fault injection through the production adapter, Google's generated Drive HTTP client, and a synthetic server. No live Google response was forced to repeat a token, and a CLI help check is not presented as provider proof.

Exact head `e6a159d718c6c6a16f489953b16219adfd357295` passed [CI](https://github.com/openclaw/gogcli/actions/runs/33652515443) (Linux tests, Windows, Darwin/cgo, and worker) and [Docker](https://github.com/openclaw/gogcli/actions/runs/33652515595).

## Provenance and related work

The unguarded child-list loop was added by [`fa832b3e`](https://github.com/openclaw/gogcli/commit/fa832b3e212c14ab4d1de58b09c2f6321ee1bbf9), [#927](https://github.com/openclaw/gogcli/pull/927), on 2026-07-16; the raw recorded parent and introducing patch were checked. The shared guard is also used by calendar listing in [#1004](https://github.com/openclaw/gogcli/pull/1004) and Chat/Classroom backup in [#1063](https://github.com/openclaw/gogcli/pull/1063).

Thanks @SebTardif for the implementation and original bounded regression fixture.
