### PR TITLE
fix(drive): reject repeated page tokens in audit permission listing

### DIFF
--- a/docs/drive-audits.md
+++ b/docs/drive-audits.md
@@ -102,6 +102,11 @@ gog drive bulk remove-public --parent <folderId> --dry-run
 gog drive bulk update-role --parent <folderId> --from writer --to reader --target contractor@example.com --dry-run
 ```
 
+Permission paging must finish for every file included in the scan. API failures,
+repeated page tokens, and page-limit errors fail without partial audit success
+output. Bulk operations complete this permission scan before writing changes, so
+a listing failure prevents writes; this does not roll back later write failures.
+
 ## Shared Drives
 
 The audit commands include shared drives by default where the underlying Drive

--- a/internal/cmd/drive_audit.go
+++ b/internal/cmd/drive_audit.go
@@ -233,9 +233,7 @@ func driveAuditItems(ctx context.Context, svc *drive.Service, fileIDRaw, parentR
 }
 
 func listDrivePermissionsForAudit(ctx context.Context, svc *drive.Service, fileID string) ([]*drive.Permission, error) {
-	out := make([]*drive.Permission, 0, 8)
-	var pageToken string
-	for {
+	fetch := func(pageToken string) ([]*drive.Permission, string, error) {
 		call := svc.Permissions.List(fileID).
 			SupportsAllDrives(true).
 			PageSize(100).
@@ -246,14 +244,11 @@ func listDrivePermissionsForAudit(ctx context.Context, svc *drive.Service, fileI
 		}
 		resp, err := call.Do()
 		if err != nil {
-			return nil, err
+			return nil, "", err
 		}
-		out = append(out, resp.Permissions...)
-		if resp.NextPageToken == "" {
-			return out, nil
-		}
-		pageToken = resp.NextPageToken
+		return resp.Permissions, resp.NextPageToken, nil
 	}
+	return collectAllPages("", fetch)
 }
 
 func driveSharingFinding(item driveTreeItem, perm *drive.Permission, internalDomains map[string]struct{}) (driveSharingAuditFinding, bool) {

--- a/internal/cmd/drive_audit_test.go
+++ b/internal/cmd/drive_audit_test.go
@@ -2,11 +2,14 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func TestDriveAuditSharingFindsPublicAndExternal(t *testing.T) {
@@ -59,4 +62,39 @@ func TestDriveAuditSharingFindsPublicAndExternal(t *testing.T) {
 	if parsed.Findings[0].PermissionID != "anyone" || parsed.Findings[1].PermissionID != "user1" {
 		t.Fatalf("unexpected findings: %#v", parsed.Findings)
 	}
+}
+
+func TestListDrivePermissionsForAuditRejectsRepeatedPageToken(t *testing.T) {
+	t.Parallel()
+
+	var listCalls atomic.Int32
+	svc, closeSvc := newDriveTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !strings.Contains(r.URL.Path, "/files/file1/permissions") {
+			http.NotFound(w, r)
+			return
+		}
+		if listCalls.Add(1) > 2 {
+			http.Error(w, "unexpected extra page request", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"permissions": []map[string]any{
+				{"id": "anyone", "type": "anyone", "role": "reader"},
+			},
+			"nextPageToken": "stuck",
+		})
+	}))
+	defer closeSvc()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	_, err := listDrivePermissionsForAudit(ctx, svc, "file1")
+	if err == nil || !strings.Contains(err.Error(), "repeated page token") {
+		t.Fatalf("err = %v after %d list calls", err, listCalls.Load())
+	}
+	if got := listCalls.Load(); got != 2 {
+		t.Fatalf("list calls = %d, want 2", got)
+	}
+	t.Logf("err = %v after %d list calls", err, listCalls.Load())
 }

--- a/internal/cmd/drive_audit_test.go
+++ b/internal/cmd/drive_audit_test.go
@@ -73,9 +73,16 @@ func TestListDrivePermissionsForAuditRejectsRepeatedPageToken(t *testing.T) {
 			http.NotFound(w, r)
 			return
 		}
-		if listCalls.Add(1) > 2 {
+		call := listCalls.Add(1)
+		if call > 2 {
 			http.Error(w, "unexpected extra page request", http.StatusBadRequest)
 			return
+		}
+		requireSupportsAllDrives(t, r)
+		if call == 1 {
+			requireQuery(t, r, "pageToken", "")
+		} else {
+			requireQuery(t, r, "pageToken", "stuck")
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
@@ -89,12 +96,141 @@ func TestListDrivePermissionsForAuditRejectsRepeatedPageToken(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	_, err := listDrivePermissionsForAudit(ctx, svc, "file1")
+	permissions, err := listDrivePermissionsForAudit(ctx, svc, "file1")
 	if err == nil || !strings.Contains(err.Error(), "repeated page token") {
 		t.Fatalf("err = %v after %d list calls", err, listCalls.Load())
+	}
+	if permissions != nil {
+		t.Fatalf("permissions = %#v, want nil on incomplete listing", permissions)
 	}
 	if got := listCalls.Load(); got != 2 {
 		t.Fatalf("list calls = %d, want 2", got)
 	}
 	t.Logf("err = %v after %d list calls", err, listCalls.Load())
+}
+
+func TestListDrivePermissionsForAuditPagination(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name           string
+		failSecondPage bool
+	}{
+		{name: "success preserves page order"},
+		{name: "later error discards partial permissions", failSecondPage: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var listCalls atomic.Int32
+			svc, closeSvc := newDriveTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodGet || !strings.HasSuffix(r.URL.Path, "/files/file1/permissions") {
+					http.NotFound(w, r)
+					return
+				}
+				requireSupportsAllDrives(t, r)
+				requireQuery(t, r, "pageSize", "100")
+				requireQuery(t, r, "fields", "nextPageToken,permissions(id,type,role,emailAddress,domain,displayName,allowFileDiscovery,deleted,expirationTime,permissionDetails(permissionType,role,inherited,inheritedFrom))")
+				call := listCalls.Add(1)
+				w.Header().Set("Content-Type", "application/json")
+				switch call {
+				case 1:
+					requireQuery(t, r, "pageToken", "")
+					_, _ = io.WriteString(w, `{"permissions":[{"id":"first","type":"anyone","role":"reader"}],"nextPageToken":"page-2"}`)
+				case 2:
+					requireQuery(t, r, "pageToken", "page-2")
+					if tc.failSecondPage {
+						http.Error(w, `{"error":{"code":403,"message":"page two denied"}}`, http.StatusForbidden)
+						return
+					}
+					_, _ = io.WriteString(w, `{"permissions":[{"id":"second","type":"user","role":"writer"}]}`)
+				default:
+					http.Error(w, "unexpected extra page request", http.StatusBadRequest)
+				}
+			}))
+			defer closeSvc()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			permissions, err := listDrivePermissionsForAudit(ctx, svc, "file1")
+			if tc.failSecondPage {
+				if err == nil || !strings.Contains(err.Error(), "page two denied") || permissions != nil {
+					t.Fatalf("permissions = %#v, err = %v; want nil permissions and provider error", permissions, err)
+				}
+			} else if err != nil || len(permissions) != 2 || permissions[0].Id != "first" || permissions[1].Id != "second" {
+				t.Fatalf("permissions = %#v, err = %v; want both pages in order", permissions, err)
+			}
+			if got := listCalls.Load(); got != 2 {
+				t.Fatalf("list calls = %d, want 2", got)
+			}
+		})
+	}
+}
+
+func TestExecuteDrivePermissionScanFailurePreventsOutputAndWrites(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{name: "sharing audit", args: []string{"drive", "audit", "sharing", "--internal-domain", "example.com", "--fail-found"}},
+		{name: "user audit", args: []string{"drive", "audit", "user", "a@external.test", "--fail-found"}},
+		{name: "remove public", args: []string{"drive", "bulk", "remove-public", "--force"}},
+		{name: "update role", args: []string{"drive", "bulk", "update-role", "--force", "--from", "writer", "--to", "reader", "--type", "user", "--target", "a@external.test"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var filesCalls, firstPermissionCalls, secondPermissionCalls, mutations atomic.Int32
+			svc, closeSvc := newDriveTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodGet {
+					mutations.Add(1)
+					http.Error(w, "unexpected permission mutation", http.StatusBadRequest)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				switch {
+				case strings.HasSuffix(r.URL.Path, "/files"):
+					filesCalls.Add(1)
+					if !strings.Contains(r.URL.Query().Get("q"), "'root' in parents") {
+						t.Errorf("unexpected file query: %s", r.URL.RawQuery)
+					}
+					_, _ = io.WriteString(w, `{"files":[{"id":"file1","name":"01-ready","mimeType":"text/plain"},{"id":"file2","name":"02-loop","mimeType":"text/plain"}]}`)
+				case strings.HasSuffix(r.URL.Path, "/files/file1/permissions"):
+					firstPermissionCalls.Add(1)
+					_, _ = io.WriteString(w, `{"permissions":[{"id":"public1","type":"anyone","role":"reader"},{"id":"writer1","type":"user","role":"writer","emailAddress":"a@external.test"}]}`)
+				case strings.HasSuffix(r.URL.Path, "/files/file2/permissions"):
+					if firstPermissionCalls.Load() != 1 {
+						t.Error("later-file failure must follow an earlier actionable permission page")
+					}
+					call := secondPermissionCalls.Add(1)
+					if call > 2 {
+						http.Error(w, "unexpected extra page request", http.StatusBadRequest)
+						return
+					}
+					requireSupportsAllDrives(t, r)
+					if call == 1 {
+						requireQuery(t, r, "pageToken", "")
+					} else {
+						requireQuery(t, r, "pageToken", "stuck")
+					}
+					_, _ = io.WriteString(w, `{"permissions":[{"id":"loop","type":"anyone","role":"reader"}],"nextPageToken":"stuck"}`)
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			defer closeSvc()
+
+			args := append([]string{"--json", "--account", "owner@example.com", "--no-input"}, tc.args...)
+			args = append(args, "--parent", "root", "--depth", "1", "--max", "10")
+			result := executeWithDriveTestService(t, args, svc)
+			wantError := `list permissions for file2: pagination loop: repeated page token "stuck"`
+			if result.err == nil || !strings.Contains(result.err.Error(), wantError) || ExitCode(result.err) != 1 {
+				t.Fatalf("err = %v, exit = %d, stderr = %q; want file-specific scan error", result.err, ExitCode(result.err), result.stderr)
+			}
+			if result.stdout != "" || !strings.Contains(result.stderr, wantError) {
+				t.Fatalf("stdout = %q, stderr = %q; want only the scan error", result.stdout, result.stderr)
+			}
+			if filesCalls.Load() != 1 || firstPermissionCalls.Load() != 1 || secondPermissionCalls.Load() != 2 || mutations.Load() != 0 {
+				t.Fatalf("files = %d, first permissions = %d, second permissions = %d, mutations = %d", filesCalls.Load(), firstPermissionCalls.Load(), secondPermissionCalls.Load(), mutations.Load())
+			}
+			t.Logf("%v; no success output or permission writes", result.err)
+		})
+	}
 }

--- a/internal/cmd/paging_test.go
+++ b/internal/cmd/paging_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"errors"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -9,53 +10,118 @@ import (
 func TestCollectAllPages(t *testing.T) {
 	t.Parallel()
 
-	t.Run("collects successive pages", func(t *testing.T) {
+	t.Run("empty next token ends", func(t *testing.T) {
 		t.Parallel()
-		pages := map[string]struct {
-			items []string
-			next  string
-		}{
-			"":   {items: []string{"a"}, next: "p2"},
-			"p2": {items: []string{"b", "c"}, next: ""},
-		}
+		var calls int
 		got, err := collectAllPages("", func(pageToken string) ([]string, string, error) {
-			page, ok := pages[pageToken]
-			if !ok {
-				t.Fatalf("unexpected page token %q", pageToken)
+			calls++
+			if pageToken != "" {
+				t.Fatalf("pageToken = %q, want empty", pageToken)
 			}
-			return page.items, page.next, nil
+			return []string{"a"}, "", nil
 		})
 		if err != nil {
 			t.Fatalf("err = %v", err)
 		}
-		if strings.Join(got, ",") != "a,b,c" {
-			t.Fatalf("got %v, want [a b c]", got)
+		if calls != 1 {
+			t.Fatalf("calls = %d, want 1", calls)
+		}
+		if len(got) != 1 || got[0] != "a" {
+			t.Fatalf("got = %#v", got)
 		}
 	})
 
-	t.Run("rejects a repeated page token", func(t *testing.T) {
+	t.Run("two distinct pages succeed", func(t *testing.T) {
 		t.Parallel()
 		var calls int
-		_, err := collectAllPages("", func(string) ([]string, string, error) {
+		got, err := collectAllPages("", func(pageToken string) ([]string, string, error) {
 			calls++
-			return []string{"item"}, "stuck", nil
+			switch pageToken {
+			case "":
+				return []string{"a"}, "page-2", nil
+			case "page-2":
+				return []string{"b"}, "", nil
+			default:
+				t.Fatalf("unexpected pageToken %q", pageToken)
+				return nil, "", nil
+			}
 		})
-		if err == nil || !strings.Contains(err.Error(), `repeated page token "stuck"`) {
+		if err != nil {
 			t.Fatalf("err = %v", err)
+		}
+		if calls != 2 {
+			t.Fatalf("calls = %d, want 2", calls)
+		}
+		if len(got) != 2 || got[0] != "a" || got[1] != "b" {
+			t.Fatalf("got = %#v", got)
+		}
+	})
+
+	t.Run("repeated next page token returns an error", func(t *testing.T) {
+		t.Parallel()
+		var calls int
+		got, err := collectAllPages("", func(pageToken string) ([]string, string, error) {
+			calls++
+			if calls > 4 {
+				return nil, "", errors.New("fetch called after repeated token")
+			}
+			return []string{"a"}, "stuck", nil
+		})
+		if err == nil || !strings.Contains(err.Error(), "repeated page token") {
+			t.Fatalf("err = %v", err)
+		}
+		if got != nil {
+			t.Fatalf("got = %#v, want nil", got)
 		}
 		if calls != 2 {
 			t.Fatalf("calls = %d, want 2", calls)
 		}
 	})
 
-	t.Run("returns fetch errors", func(t *testing.T) {
+	t.Run("fetch error discards partial results", func(t *testing.T) {
 		t.Parallel()
-		want := errors.New("boom")
-		_, err := collectAllPages("", func(string) ([]string, string, error) {
-			return nil, "", want
+		fetchErr := errors.New("page two failed")
+		var calls int
+		got, err := collectAllPages("", func(pageToken string) ([]string, string, error) {
+			calls++
+			if calls == 1 {
+				return []string{"a"}, "page-2", nil
+			}
+			return nil, "", fetchErr
 		})
-		if !errors.Is(err, want) {
-			t.Fatalf("err = %v, want %v", err, want)
+		if !errors.Is(err, fetchErr) || got != nil || calls != 2 {
+			t.Fatalf("got = %#v, err = %v, calls = %d", got, err, calls)
+		}
+	})
+
+	t.Run("multi-token cycle stops before revisiting a page", func(t *testing.T) {
+		t.Parallel()
+		nextTokens := []string{"a", "b", "a"}
+		var calls int
+		got, err := collectAllPages("", func(pageToken string) ([]string, string, error) {
+			calls++
+			if calls > len(nextTokens) {
+				return nil, "", errors.New("fetch called after cycle")
+			}
+			return []string{"item"}, nextTokens[calls-1], nil
+		})
+		if got != nil || err == nil || !strings.Contains(err.Error(), "repeated page token") || calls != 3 {
+			t.Fatalf("got = %#v, err = %v, calls = %d", got, err, calls)
+		}
+	})
+
+	t.Run("unique tokens respect the page limit", func(t *testing.T) {
+		t.Parallel()
+		var calls int
+		got, err := collectAllPages("", func(pageToken string) ([]int, string, error) {
+			calls++
+			if calls > 10_000 {
+				return nil, "", errors.New("fetch called beyond page limit")
+			}
+			return []int{calls}, strconv.Itoa(calls), nil
+		})
+		if got != nil || err == nil || !strings.Contains(err.Error(), "pagination exceeded") || calls != 10_000 {
+			t.Fatalf("rows = %d, err = %v, calls = %d", len(got), err, calls)
 		}
 	})
 }

--- a/internal/cmd/paging_test.go
+++ b/internal/cmd/paging_test.go
@@ -1,0 +1,61 @@
+package cmd
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestCollectAllPages(t *testing.T) {
+	t.Parallel()
+
+	t.Run("collects successive pages", func(t *testing.T) {
+		t.Parallel()
+		pages := map[string]struct {
+			items []string
+			next  string
+		}{
+			"":   {items: []string{"a"}, next: "p2"},
+			"p2": {items: []string{"b", "c"}, next: ""},
+		}
+		got, err := collectAllPages("", func(pageToken string) ([]string, string, error) {
+			page, ok := pages[pageToken]
+			if !ok {
+				t.Fatalf("unexpected page token %q", pageToken)
+			}
+			return page.items, page.next, nil
+		})
+		if err != nil {
+			t.Fatalf("err = %v", err)
+		}
+		if strings.Join(got, ",") != "a,b,c" {
+			t.Fatalf("got %v, want [a b c]", got)
+		}
+	})
+
+	t.Run("rejects a repeated page token", func(t *testing.T) {
+		t.Parallel()
+		var calls int
+		_, err := collectAllPages("", func(string) ([]string, string, error) {
+			calls++
+			return []string{"item"}, "stuck", nil
+		})
+		if err == nil || !strings.Contains(err.Error(), `repeated page token "stuck"`) {
+			t.Fatalf("err = %v", err)
+		}
+		if calls != 2 {
+			t.Fatalf("calls = %d, want 2", calls)
+		}
+	})
+
+	t.Run("returns fetch errors", func(t *testing.T) {
+		t.Parallel()
+		want := errors.New("boom")
+		_, err := collectAllPages("", func(string) ([]string, string, error) {
+			return nil, "", want
+		})
+		if !errors.Is(err, want) {
+			t.Fatalf("err = %v, want %v", err, want)
+		}
+	})
+}


### PR DESCRIPTION
## Problem

`listDrivePermissionsForAudit` accepted every returned next-page token without remembering which tokens had already been used. A repeated token could keep both `drive audit` commands waiting indefinitely. The same helper feeds the preflight scan for both bulk permission commands, so those callers must also reject incomplete permission listings before acting on earlier plans.

## Change

Keep @SebTardif's production fix: delegate permission paging to the existing strict `collectAllPages` helper. Preserve request context, field selection, page size, shared-drive support, ordered successful results, and nil-on-error behavior. Repeated tokens and the existing collector page bound now stop the scan with an error.

Retain main's stronger shared-paginator tests to resolve the add/add conflict introduced by the earlier backup fix. Extend the existing Drive audit test file with exact token handoff and nil-on-loop assertions, ordered two-page success, a populated first page followed by a provider error, and four full command-path cases. The documentation states the scan-before-write boundary without claiming rollback after writes begin.

The command-path fixture first returns a complete actionable permission page for one file, then repeats a token while listing a second file. Both audits run with `--fail-found`; both bulk commands run with `--force`, without `--dry-run` or `--readonly`. All four must report the second file's pagination error with exit code 1, emit no success output, and send zero non-GET requests. This checks the actual CLI and generated Drive client rather than an illustrative pagination loop.

## Proof

The maintained regression suite was run against old production source using a Go overlay. The unguarded adapter made a third request, which the synthetic peer deliberately refused to bound the failure; all four CLI cases and the direct adapter regression failed as expected. With the production fix, the selected tests pass: the adapter stops after two calls, successful pages retain order, later provider errors discard partial permissions, and the four command cases return the file-specific error without output or writes.

```sh
go test ./internal/cmd -run '^(TestListDrivePermissionsForAudit|TestExecuteDrivePermissionScanFailurePreventsOutputAndWrites|TestDriveAudit|TestDriveBulk|TestCollectAllPages)' -count=1 -timeout=120s -v
go test -race ./internal/cmd -run '^(TestListDrivePermissionsForAudit|TestExecuteDrivePermissionScanFailurePreventsOutputAndWrites|TestDriveAudit|TestDriveBulk|TestCollectAllPages)' -count=3 -timeout=180s
make ci
```

The focused suite passed both on the contributor branch and on the integrated current-main candidate. Three focused race runs, full `make ci` (including lint, Node tests, generated docs and skill checks), and independent P0/P1 Codex review passed on the integrated candidate.

These are synthetic provider-fault tests through real generated clients and command execution, not a claim that a live Google service returned a faulty page. No Google account request, permission mutation, new grant, IAM setting, or billing change was needed.

Final head `6070f0f9204167858a4d1e6dd383b9e22cdbac34` passed [GitHub CI](https://github.com/openclaw/gogcli/actions/runs/33659723395) (Linux tests, Windows, Darwin/cgo, and worker checks) and [Docker](https://github.com/openclaw/gogcli/actions/runs/33659723301). GitHub confirms the add/add merge conflict is resolved.

## Context and credit

Thanks @SebTardif for the production repair and original adapter regression. The unguarded helper was introduced in [`d949466d`](https://github.com/openclaw/gogcli/commit/d949466d21c49022a5684af19d1a29297fd2d234), relative to raw parent `c84a09192c8092224bbe785184b885de491b99f4`; the introducing patch was inspected directly. The original body's attribution to #914 was incorrect.

Related guard work: [calendar #1004](https://github.com/openclaw/gogcli/pull/1004), [backup #1063](https://github.com/openclaw/gogcli/pull/1063), and [Drive sync #1065](https://github.com/openclaw/gogcli/pull/1065). The integrated candidate is based on main after [#1067](https://github.com/openclaw/gogcli/pull/1067), which separately fixes locked-flag-state ownership.
