### PR TITLE
fix(cli): isolate locked flag state per parse

### DIFF
--- a/docs/safety-profiles.md
+++ b/docs/safety-profiles.md
@@ -195,6 +195,9 @@ A locked flag behaves as follows:
 A lock the binary cannot enforce is refused at build time rather than silently
 ignored.
 
+Lock presence, output-mode precedence, and diagnostic notes belong to each parsed
+invocation; they are not shared between command executions.
+
 Because a locked value reaches the command without appearing on the command line, a
 usage error that names a locked flag carries a note saying where the value came from:
 

--- a/internal/cmd/kong_helpers.go
+++ b/internal/cmd/kong_helpers.go
@@ -7,7 +7,7 @@ import "github.com/alecthomas/kong"
 // flags were given would otherwise drop a locked value on the floor, leaving the
 // lock set on the struct but absent from the request.
 func flagProvided(kctx *kong.Context, name string) bool {
-	return flagOnCommandLine(kctx, name) || lockedFlagNames[name]
+	return flagOnCommandLine(kctx, name) || lockedFlagStateFor(kctx).has(name)
 }
 
 // flagOnCommandLine reports only what the caller typed. Lock enforcement and

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -119,7 +119,7 @@ func Execute(args []string) (err error) {
 }
 
 func executeWithRuntime(args []string, runtime *app.Runtime) (err error) {
-	resetLockedFlagState()
+	var kctx *kong.Context
 	runtime = normalizedRuntime(runtime)
 	runtimeIO := runtime.IO
 
@@ -130,20 +130,20 @@ func executeWithRuntime(args []string, runtime *app.Runtime) (err error) {
 
 	home, homeProvided := preScanHomeArg(args)
 	if bindErr := bindRuntimeLayoutResolver(runtime, home); bindErr != nil {
-		return reportEarlyError(runtimeIO.Err, newUsageError(bindErr))
+		return reportEarlyError(kctx, runtimeIO.Err, newUsageError(bindErr))
 	}
 	if homeProvided {
 		if validateErr := runtime.LayoutResolver.ValidateHomeOverride(); validateErr != nil {
-			return reportEarlyError(runtimeIO.Err, newUsageError(validateErr))
+			return reportEarlyError(kctx, runtimeIO.Err, newUsageError(validateErr))
 		}
 	}
 
 	parser, cli, err := newParserWithWriters(helpDescription(runtime), runtimeIO.Out, runtimeIO.Err)
 	if err != nil {
-		return reportEarlyError(runtimeIO.Err, err)
+		return reportEarlyError(kctx, runtimeIO.Err, err)
 	}
 	if err = verifyLockedFlagsExist(parser.Model.Node); err != nil {
-		return reportEarlyError(runtimeIO.Err, err)
+		return reportEarlyError(kctx, runtimeIO.Err, err)
 	}
 	args = rewriteDocsCellUpdateContentArgs(parser.Model, args)
 	args = rewriteDesirePathArgs(parser.Model, args)
@@ -162,9 +162,9 @@ func executeWithRuntime(args []string, runtime *app.Runtime) (err error) {
 		}
 	}()
 
-	kctx, err := parser.Parse(args)
+	kctx, err = parser.Parse(args)
 	if err != nil {
-		return reportEarlyError(runtimeIO.Err, wrapParseError(err))
+		return reportEarlyError(kctx, runtimeIO.Err, wrapParseError(err))
 	}
 	cli.diagnostics = runtimeIO.Err
 	cli.authOperations = runtime.Auth
@@ -190,24 +190,24 @@ func executeWithRuntime(args []string, runtime *app.Runtime) (err error) {
 	}
 
 	if err = enforceBakedSafetyProfile(kctx); err != nil {
-		return reportEarlyError(runtimeIO.Err, err)
+		return reportEarlyError(kctx, runtimeIO.Err, err)
 	}
 	if err = enforceLockedFlags(kctx); err != nil {
-		return reportEarlyError(runtimeIO.Err, err)
+		return reportEarlyError(kctx, runtimeIO.Err, err)
 	}
 	// After the locks, so a locked output mode is what precedence resolves around
 	// rather than something a competing mode can leave in conflict.
 	if err = applyExplicitOutputModePrecedence(kctx, &cli.RootFlags); err != nil {
-		return reportEarlyError(runtimeIO.Err, err)
+		return reportEarlyError(kctx, runtimeIO.Err, err)
 	}
 	if err = enforceEnabledCommands(kctx, cli.EnableCommands, cli.EnableCommandsExact); err != nil {
-		return reportEarlyError(runtimeIO.Err, err)
+		return reportEarlyError(kctx, runtimeIO.Err, err)
 	}
 	if err = enforceDisabledCommands(kctx, cli.DisableCommands); err != nil {
-		return reportEarlyError(runtimeIO.Err, err)
+		return reportEarlyError(kctx, runtimeIO.Err, err)
 	}
 	if err = enforceGmailNoSend(kctx, &cli.RootFlags, runtime); err != nil {
-		return reportEarlyError(runtimeIO.Err, err)
+		return reportEarlyError(kctx, runtimeIO.Err, err)
 	}
 
 	logLevel := slog.LevelWarn
@@ -222,11 +222,11 @@ func executeWithRuntime(args []string, runtime *app.Runtime) (err error) {
 
 	mode, err := outfmt.FromFlags(cli.JSON, cli.Plain)
 	if err != nil {
-		return reportEarlyError(runtimeIO.Err, newUsageError(err))
+		return reportEarlyError(kctx, runtimeIO.Err, newUsageError(err))
 	}
 	err = validateJSONTransformFlags(mode, &cli.RootFlags)
 	if err != nil {
-		return reportEarlyError(runtimeIO.Err, err)
+		return reportEarlyError(kctx, runtimeIO.Err, err)
 	}
 
 	ctx := context.Background()
@@ -328,7 +328,7 @@ func executeWithRuntime(args []string, runtime *app.Runtime) (err error) {
 		Color:  uiColor,
 	})
 	if err != nil {
-		return reportEarlyError(runtimeIO.Err, newUsageError(err))
+		return reportEarlyError(kctx, runtimeIO.Err, newUsageError(err))
 	}
 	ctx = ui.WithUI(ctx, u)
 
@@ -346,13 +346,13 @@ func executeWithRuntime(args []string, runtime *app.Runtime) (err error) {
 	err = stableExitCode(err)
 
 	if u := ui.FromContext(ctx); u != nil {
-		msg := errorMessage(err)
+		msg := errorMessage(kctx, err)
 		if msg != "" {
 			u.Err().Error(msg)
 		}
 		return err
 	}
-	msg := errorMessage(err)
+	msg := errorMessage(kctx, err)
 	if msg != "" {
 		_, _ = fmt.Fprintln(runtimeIO.Err, msg)
 	}
@@ -422,19 +422,20 @@ func applyExplicitOutputModePrecedence(kctx *kong.Context, flags *RootFlags) err
 		return nil
 	}
 
-	jsonLocked := lockedFlagNames["json"] && flags.JSON
-	plainLocked := lockedFlagNames["plain"] && flags.Plain
+	locked := lockedFlagStateFor(kctx)
+	jsonLocked := locked.has("json") && flags.JSON
+	plainLocked := locked.has("plain") && flags.Plain
 	jsonSet := flagOnCommandLine(kctx, "json")
 	plainSet := flagOnCommandLine(kctx, "plain")
 	switch {
 	case jsonLocked && !plainLocked:
 		if plainSet {
-			return usagef("flag --plain conflicts with --json, locked by baked safety profile %q", bakedSafetyProfileName())
+			return usagef("flag --plain conflicts with --json, locked by baked safety profile %q", locked.profileName)
 		}
 		flags.Plain = false
 	case plainLocked && !jsonLocked:
 		if jsonSet {
-			return usagef("flag --json conflicts with --plain, locked by baked safety profile %q", bakedSafetyProfileName())
+			return usagef("flag --json conflicts with --plain, locked by baked safety profile %q", locked.profileName)
 		}
 		flags.JSON = false
 	case jsonSet && !plainSet:
@@ -445,11 +446,11 @@ func applyExplicitOutputModePrecedence(kctx *kong.Context, flags *RootFlags) err
 	return nil
 }
 
-func reportEarlyError(w io.Writer, err error) error {
+func reportEarlyError(kctx *kong.Context, w io.Writer, err error) error {
 	if err == nil {
 		return nil
 	}
-	msg := errorMessage(err)
+	msg := errorMessage(kctx, err)
 	if msg != "" {
 		_, _ = fmt.Fprintln(w, msg)
 	}
@@ -458,7 +459,7 @@ func reportEarlyError(w io.Writer, err error) error {
 
 // errorMessage formats err for display and appends a special locked-flag note to
 // errors that mention another locked flag, as when those flags are mutually exclusive.
-func errorMessage(err error) string {
+func errorMessage(kctx *kong.Context, err error) string {
 	msg := strings.TrimSpace(errfmt.Format(err))
 	if msg == "" {
 		return msg
@@ -470,7 +471,7 @@ func errorMessage(err error) string {
 	if errors.As(err, &refusal) {
 		return msg
 	}
-	note := lockedFlagsNote(msg)
+	note := lockedFlagsNote(kctx, msg)
 	if note == "" {
 		return msg
 	}

--- a/internal/cmd/safety_profile.go
+++ b/internal/cmd/safety_profile.go
@@ -46,21 +46,39 @@ func enforceBakedSafetyProfile(kctx *kong.Context) error {
 	return nil
 }
 
-// lockedFlagNames records the locked flags in force for this parse, so a command
-// rejecting a value it never received on the command line can say where it came from.
-var lockedFlagNames = map[string]bool{}
+type lockedFlagState struct {
+	names       map[string]bool
+	profileName string
+}
 
-func resetLockedFlagState() {
-	lockedFlagNames = map[string]bool{}
+func (s *lockedFlagState) has(name string) bool {
+	return s != nil && s.names[name]
+}
+
+func lockedFlagStateFor(kctx *kong.Context) *lockedFlagState {
+	if kctx == nil || kctx.Kong == nil {
+		return nil
+	}
+	var state *lockedFlagState
+	// Context bindings override the typed nil default. Keeping this on the parse,
+	// not the parser or package, prevents another invocation from clearing its locks.
+	if _, err := kctx.Call(func(bound *lockedFlagState) { state = bound }, (*lockedFlagState)(nil)); err != nil {
+		panic(err)
+	}
+	return state
 }
 
 // lockedFlagsNote names the locked flags for display beneath a usage error that
 // mentions one of them: a command can reject a combination involving a value that
 // never appeared on the command line, and the note is what explains where it came from.
-func lockedFlagsNote(msg string) string {
-	names := make([]string, 0, len(lockedFlagNames))
+func lockedFlagsNote(kctx *kong.Context, msg string) string {
+	state := lockedFlagStateFor(kctx)
+	if state == nil {
+		return ""
+	}
+	names := make([]string, 0, len(state.names))
 	mentioned := false
-	for name := range lockedFlagNames {
+	for name := range state.names {
 		names = append(names, "--"+name)
 		mentioned = mentioned || strings.Contains(msg, "--"+name)
 	}
@@ -68,7 +86,7 @@ func lockedFlagsNote(msg string) string {
 		return ""
 	}
 	sort.Strings(names)
-	return fmt.Sprintf("note: %s locked by baked safety profile %q", strings.Join(names, ", "), bakedSafetyProfileName())
+	return fmt.Sprintf("note: %s locked by baked safety profile %q", strings.Join(names, ", "), state.profileName)
 }
 
 // verifyLockedFlagsExist refuses to run when a locked name matches no flag in the
@@ -137,9 +155,11 @@ func (e lockedFlagRefusal) Unwrap() error { return e.error }
 // merely defaulted so it holds without help from the environment, which the caller
 // may not control.
 func enforceLockedFlags(kctx *kong.Context) error {
-	// Rebuilt per parse: carrying names over would let one run's note describe a
-	// profile that is not in force.
-	resetLockedFlagState()
+	state := &lockedFlagState{
+		names:       make(map[string]bool),
+		profileName: bakedSafetyProfileName(),
+	}
+	kctx.Bind(state)
 	if !bakedSafetyEnabled() {
 		return nil
 	}
@@ -151,7 +171,7 @@ func enforceLockedFlags(kctx *kong.Context) error {
 		}
 		// Recorded before anything here can fail, so the note names the profile's locks
 		// instead of however many the loop applied before it stopped.
-		lockedFlagNames[flag.Name] = true
+		state.names[flag.Name] = true
 		// Decode into a zero target so the locked boolean replaces any environment or
 		// default value already resolved by Kong.
 		lockedTarget := reflect.New(flag.Target.Type()).Elem()
@@ -161,7 +181,7 @@ func enforceLockedFlags(kctx *kong.Context) error {
 		// Requesting the value the profile already locks is not an override: refusing it
 		// would break every caller that asks for the safe setting while protecting nothing.
 		if flagOnCommandLine(kctx, flag.Name) && !reflect.DeepEqual(flag.Target.Interface(), lockedTarget.Interface()) {
-			return lockedFlagRefusal{usagef("flag --%s is locked to %s by baked safety profile %q", flag.Name, value, bakedSafetyProfileName())}
+			return lockedFlagRefusal{usagef("flag --%s is locked to %s by baked safety profile %q", flag.Name, value, state.profileName)}
 		}
 		flag.Apply(lockedTarget)
 		lockedPaths = append(lockedPaths, &kong.Path{Flag: flag})
@@ -179,7 +199,7 @@ func enforceLockedFlags(kctx *kong.Context) error {
 	validationErr := kctx.Validate()
 	kctx.Path = kctx.Path[:pathLen]
 	if validationErr != nil {
-		return usagef("baked safety profile %q has locked flags that are invalid for the selected command", bakedSafetyProfileName())
+		return usagef("baked safety profile %q has locked flags that are invalid for the selected command", state.profileName)
 	}
 	return nil
 }

--- a/internal/cmd/safety_profile_locked_flags_test.go
+++ b/internal/cmd/safety_profile_locked_flags_test.go
@@ -1,8 +1,11 @@
 package cmd
 
 import (
+	"io"
 	"strings"
 	"testing"
+
+	"github.com/alecthomas/kong"
 )
 
 const lockedFlagsProfile = `
@@ -321,15 +324,44 @@ gmail:
 // has to count as given or it never reaches the request. Lock enforcement asks the
 // narrower question and must not see itself as an override.
 func TestLockedFlag_CountsAsProvidedButNotAsTyped(t *testing.T) {
-	previous := lockedFlagNames
-	lockedFlagNames = map[string]bool{"summary": true}
-	t.Cleanup(func() { lockedFlagNames = previous })
+	withBakedSafetyProfile(t, lockedFlagsProfile)
+	parse := func(args ...string) *kong.Context {
+		t.Helper()
+		parser, _, err := newParserWithWriters("test", io.Discard, io.Discard)
+		if err != nil {
+			t.Fatal(err)
+		}
+		kctx, err := parser.Parse(args)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := enforceLockedFlags(kctx); err != nil {
+			t.Fatal(err)
+		}
+		return kctx
+	}
 
-	if !flagProvided(nil, "summary") {
+	first := parse("gmail", "get", "m1")
+	if !flagProvided(first, "sanitize-content") {
 		t.Fatal("a locked flag must count as provided")
 	}
-	if flagOnCommandLine(nil, "summary") {
+	if flagOnCommandLine(first, "sanitize-content") {
 		t.Fatal("a locked flag must not count as typed on the command line")
+	}
+
+	second := parse("version")
+	if !flagProvided(first, "sanitize-content") {
+		t.Fatal("a second parse cleared the first parse's locked flags")
+	}
+	if flagProvided(second, "sanitize-content") || flagProvided(nil, "sanitize-content") || flagProvided(&kong.Context{}, "sanitize-content") {
+		t.Fatal("a locked flag leaked to an unrelated parse")
+	}
+	message := usage("--sanitize-content is incompatible with this request")
+	if !strings.Contains(errorMessage(first, message), `locked by baked safety profile "locked"`) {
+		t.Fatal("a second parse cleared the first parse's locked-flag note")
+	}
+	if strings.Contains(errorMessage(second, message), "note:") || strings.Contains(errorMessage(nil, message), "note:") {
+		t.Fatal("a locked-flag note leaked to an unrelated parse")
 	}
 }
 

--- a/scripts/eval-gws.test.mjs
+++ b/scripts/eval-gws.test.mjs
@@ -9,13 +9,14 @@ test("parseArgs validates timeout", () => {
 });
 
 test("runCase records assertions and metrics", () => {
+  // Use the evaluator's normal budget for this functional smoke.
   const result = runCase(process.execPath, {
     args: ["-e", "process.stdout.write(JSON.stringify({ok:true}))"],
     exit: [0],
     contains: ["ok"],
     json: true,
-  }, 5_000, process.env);
-  assert.equal(result.pass, true);
+  }, parseArgs([]).timeoutMs, process.env);
+  assert.equal(result.pass, true, JSON.stringify(result));
   assert.equal(result.exit_code, 0);
   assert.ok(result.stdout_bytes > 0);
   assert.ok(result.elapsed_ms >= 0);


### PR DESCRIPTION
## Problem

Locked-flag bookkeeping was a package-global map even though it described one command parse. Every `executeWithRuntime` and `enforceLockedFlags` reset it. The normal-parallel Drive sync race check exposed concurrent writes on unchanged main, and a deterministic regression confirmed the semantic problem: enforcing a second command without `sanitize-content` clears the first command's record that the flag was locked.

That record is used by partial-request builders (`flagProvided`), locked JSON/plain precedence, and usage-error notes. A map mutex would remove the data race without preventing one invocation from replacing another's state.

## Change

Delete the global map/reset path. Bind a fresh private state object to each Kong parse context, containing the locked names and profile name. Flag-presence checks, output precedence, and both early/command error formatting use that same context. Before enforcement, nil or unbound contexts have no locks and cannot inherit another command's note.

Keep existing flag values, allowed commands, override refusals, validation, exit codes, and OAuth policy unchanged. The existing locked-flag test now exercises two real parser contexts instead of manually replacing a global map, including presence-versus-typed semantics and diagnostic isolation. The safety-profile docs explain invocation ownership.

This is a focused locked-state repair, not a claim of complete concurrent-runtime isolation; the separate process-global `slog` default is unchanged. No command tests were serialized or removed.

## Proof

- Before the production change, the two-parse regression failed with `a second parse cleared the first parse's locked flags`.
- On unchanged main, the existing Drive dry-run/help pair failed under `-race -count=3` in `resetLockedFlagState`.
- After the change, the focused safety/Drive/runtime tests and three normal-parallel race runs passed.
- All 319 entry-point/Gmail tests selected by `^(TestExecute|TestGmailGetCmd_|TestGmailThreadGet_)` passed under the race detector, split into four exhaustive exact-name shards with a 600-second per-shard budget. The original single-process attempt timed out during ordinary parser construction at its 180-second limit without a race warning; no selected test was dropped.
- Full `make ci` passed, including formatting, lint, dead-code checks, tests, generated docs, and skill checks. Independent Codex review of the complete candidate was scoped-clean at P0/P1.
- A binary built through `build-safe.sh` with a synthetic locked profile passed five offline checks: JSON output, rejection of a competing output mode, the locked Gmail-format diagnostic, explicit override refusal without an extra note, and a pre-parse error without a stale note. The smoke used an empty isolated home, no real token or Google request, and left no config/credential JSON or generated source behind.

```sh
go test ./internal/cmd -run '^(TestLockedFlag_|Test.*SafetyProfile|TestExecuteHomeResolversAreIndependent|TestDriveSyncPush|TestGoogleDriveSyncClientUsesSharedDriveFlags|TestListDriveSyncChildren|TestExecuteDriveSyncPush)' -count=1 -timeout=180s
go test -race ./internal/cmd -run '^(TestLockedFlag_|TestExecuteHomeResolversAreIndependent|TestDriveSyncPush|TestGoogleDriveSyncClientUsesSharedDriveFlags|TestListDriveSyncChildren|TestExecuteDriveSyncPush)' -count=3 -timeout=180s
make ci
```

The compiled smoke profile allowed only `gmail get` and `version` and locked `json`, `sanitize-content`, `no-input`, and `readonly` to true. No new account, OAuth grant, IAM setting, or billing configuration was created.

## Windows CI follow-up

The original [PR Windows run](https://github.com/openclaw/gogcli/actions/runs/33655152378) failed in the unchanged Node subprocess metrics smoke after its Go tests passed. The [same-head push run](https://github.com/openclaw/gogcli/actions/runs/33655110993) passed Windows. The failing assertion hid the child result, so the precise original cause is not established.

The functional smoke now uses the evaluator's existing finite 30-second subprocess budget instead of a separate 5-second budget and includes the synthetic result in assertion failures. All assertions and production evaluator behavior are unchanged. A controlled six-second child confirms that the old budget fails while the normal budget passes; that demonstrates timeout behavior, not a reproduction of the historical Windows event. All 19 Node tests and the full local gate pass after this bounded test-only hardening.

Final candidate `75dcdff0a6a48190e772872cac67dcff8ca992f8` passed [PR CI](https://github.com/openclaw/gogcli/actions/runs/33657325112), [push CI](https://github.com/openclaw/gogcli/actions/runs/33657319343), [Docker](https://github.com/openclaw/gogcli/actions/runs/33657325263), and [CodeQL](https://github.com/openclaw/gogcli/actions/runs/33657319352), including both Windows runs.

## Context

Discovered while validating [#1065](https://github.com/openclaw/gogcli/pull/1065), which remains a separate pagination fix. The global map and `flagProvided` dependency were introduced in [`6af89c8d`](https://github.com/openclaw/gogcli/commit/6af89c8dd7cb3749375d88d85c1572c098f16d1f), [#979](https://github.com/openclaw/gogcli/pull/979); the raw recorded parent and introducing patch were verified.
