### PR TITLE
fix(docs): preserve underscores in rendered identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Docs: preserve underscores in enum values and environment-variable names in rendered command references instead of treating them as emphasis. (#1047)
 - Auth: explicitly select a Google Cloud quota project with `--quota-project` or `GOG_QUOTA_PROJECT`, preserving default auth behavior and forwarding the setting through Gmail watch and MCP requests. (#1056, #1055) — thanks @prateek.
 - AdSense: add explicitly opted-in read-only account, inventory, and report commands, including saved reports and validated reporting timezones. (#1047) — thanks @ptz0n.
 - Chat: search messages across Workspace spaces with paging, formatted text, optional read-state metadata, and read-only/untrusted-output support; unavailable read state stays unknown. (#1069, #1068) — thanks @wrgrant.

--- a/scripts/build-docs-site.mjs
+++ b/scripts/build-docs-site.mjs
@@ -379,7 +379,7 @@ function inline(text, currentRel) {
   out = escapeHtml(out)
     .replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>")
     .replace(/(^|[^*])\*([^*\s][^*]*?)\*(?!\*)/g, "$1<em>$2</em>")
-    .replace(/(^|[^_])_([^_\s][^_]*?)_(?!_)/g, "$1<em>$2</em>")
+    .replace(/(^|[^\p{L}\p{N}_])_([^_\s][^_]*?)_(?![\p{L}\p{N}_])/gu, "$1<em>$2</em>")
     .replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_, label, href) => `<a href="${escapeAttr(rewriteHref(href, currentRel))}">${label}</a>`)
     .replace(/&lt;(https?:\/\/[^\s<>]+)&gt;/g, '<a href="$1">$1</a>');
   out = out.replace(/\\\|/g, "|");

--- a/scripts/check-docs-coverage.test.mjs
+++ b/scripts/check-docs-coverage.test.mjs
@@ -1,11 +1,34 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 
 import { checkMarkdownLinks, headingAnchors } from "./check-docs-coverage.mjs";
 import { stripHtmlTags } from "./html-text.mjs";
+
+test("docs rendering preserves intraword underscores and ordinary emphasis", (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "gog-doc-emphasis-"));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  fs.mkdirSync(path.join(dir, "docs"));
+  fs.writeFileSync(path.join(dir, "docs", "quickstart.md"), "# Quickstart\n");
+  fs.writeFileSync(path.join(dir, "docs", "install.md"), "# Install\n");
+  fs.writeFileSync(path.join(dir, "docs", "index.md"), `# Reference
+
+ACCOUNT_TIME_ZONE GOOGLE_CLOUD_QUOTA_PROJECT foo_2_bar α_β_γ; _emphasis_ and *asterisk*.
+
+| Flag | Help |
+| --- | --- |
+| --timezone | Reporting timezone: ACCOUNT_TIME_ZONE or GOOGLE_TIME_ZONE |
+`);
+
+  execFileSync(process.execPath, [fileURLToPath(new URL("./build-docs-site.mjs", import.meta.url))], { cwd: dir });
+  const html = fs.readFileSync(path.join(dir, "dist", "docs-site", "index.html"), "utf8");
+  assert.ok(html.includes("<p>ACCOUNT_TIME_ZONE GOOGLE_CLOUD_QUOTA_PROJECT foo_2_bar α_β_γ; <em>emphasis</em> and <em>asterisk</em>.</p>"));
+  assert.ok(html.includes("<td>Reporting timezone: ACCOUNT_TIME_ZONE or GOOGLE_TIME_ZONE</td>"));
+});
 
 test("stripHtmlTags removes nested and unterminated markup in one pass", () => {
   assert.equal(


### PR DESCRIPTION
## Summary

Fix a live documentation rendering bug found while verifying the newly landed AdSense commands: plain enum values such as `ACCOUNT_TIME_ZONE` became `ACCOUNT<em>TIME</em>ZONE`, so readers saw the wrong spelling. Preserve underscores inside alphanumeric identifiers (including Unicode words), while retaining ordinary underscore and asterisk emphasis.

The regression test runs the actual site builder against disposable Markdown pages and covers both prose and the generated-command table shape. Includes a credited-feature reference in Unreleased; no CLI runtime or release version changes.

## Verification

- Confirmed the broken served HTML at https://gogcli.sh/commands/gog-adsense-reports-query.html before the fix.
- New regression failed before the renderer change and passes afterward.
- Full `GOTOOLCHAIN=go1.27.1 make ci` passed, including 766 command pages and 28 feature guides.
- Generated AdSense report HTML now preserves both `ACCOUNT_TIME_ZONE` and `GOOGLE_TIME_ZONE`.
- Independent Codex review found no actionable P0/P1 issues.

Browser screenshots are unavailable because the local Chrome extension relay could not connect. The before/after evidence is served HTML versus generated HTML plus the real-builder regression; this is not claimed as browser UI proof. After deployment, HTTP 200 responses and parsed HTML text were verified on the published AdSense guide, AdSense report command, Chat search command, and quota-auth guide. Both reporting timezone enum names are now intact.

Follow-up to #1047 and the approved feature/docs landing batch.

## Landed

Merged as `1a38d795d8d475d08688441de2642b763cefbc3f`; the merged tree exactly matches the reviewed/tested candidate. [PR CI](https://github.com/openclaw/gogcli/actions/runs/33723496602), [push CI](https://github.com/openclaw/gogcli/actions/runs/33723472598), and [Pages deployment](https://github.com/openclaw/gogcli/actions/runs/33724140462) passed.
