### PR TITLE
test(live): cover Chat message search

### DIFF
--- a/docs/live-testing.md
+++ b/docs/live-testing.md
@@ -34,7 +34,7 @@ available services. Recent-feature coverage includes:
 - Drive shortcuts, revisions, and persisted changes polling.
 - Gmail thread-aware drafts, attachment metadata preservation/clearing, and
   explicit thread archive semantics.
-- Chat cross-space message search with basic/full output, formatted text,
+- Chat cross-space message search with basic/full result envelopes,
   explicit cursor continuation, and empty-result exit behavior when configured.
 - Contacts duplicate merge dry-run, apply, merged-field readback, and cleanup.
 - CLI schema exit codes, Git-style help, output-mode precedence, and early
@@ -69,9 +69,15 @@ requires a configured Pub/Sub subscription. The suite reports these as skipped
 instead of treating unavailable infrastructure as a product failure.
 
 `GOG_LIVE_CHAT_SEARCH_QUERY` must match at least one message available to the
-test account. The Chat search smoke path is read-only and checks basic/full JSON,
-Markdown-formatted output, one explicit page token when available, and the
-stable `--fail-empty` exit contract. It uses Google's documented
+test account. The read-only smoke path checks basic/full result envelopes,
+cursor advancement, and the stable `--fail-empty` exit contract. It requests
+Markdown and untrusted-wrapping options to check that the API accepts them;
+it does not compare rendered text or validate the wrapping transformation.
+Cursor continuation must return a different message resource, so silently
+repeating the first page fails the check.
+Full-view read state may be unavailable; when present it must be a boolean.
+The smoke test does not require full and basic results to differ in that case.
+It uses Google's documented
 [`POST spaces.messages.search`](https://developers.google.com/workspace/chat/api/reference/rest/v1/spaces.messages/search)
 method; Developer Preview relevance ordering is intentionally excluded.
 

--- a/docs/live-testing.md
+++ b/docs/live-testing.md
@@ -34,6 +34,8 @@ available services. Recent-feature coverage includes:
 - Drive shortcuts, revisions, and persisted changes polling.
 - Gmail thread-aware drafts, attachment metadata preservation/clearing, and
   explicit thread archive semantics.
+- Chat cross-space message search with basic/full output, formatted text,
+  explicit cursor continuation, and empty-result exit behavior when configured.
 - Contacts duplicate merge dry-run, apply, merged-field readback, and cleanup.
 - CLI schema exit codes, Git-style help, output-mode precedence, and early
   validation errors.
@@ -50,6 +52,7 @@ Some APIs need account- or project-specific setup:
 
 ```bash
 GOG_LIVE_CHAT_SPACE=spaces/... scripts/live-test.sh --account workspace@example.com
+GOG_LIVE_CHAT_SEARCH_QUERY='known matching text' scripts/live-test.sh --account workspace@example.com
 GOG_LIVE_GMAIL_WATCH_TOPIC=projects/.../topics/... scripts/live-test.sh --account bot@example.com
 GOG_LIVE_CLASSROOM_COURSE=<courseId> scripts/live-test.sh --account bot@example.com
 ```
@@ -64,6 +67,13 @@ gog auth add you@gmail.com --services photospicker
 Google Chat attachments and Keep require Workspace accounts. Gmail watch pull
 requires a configured Pub/Sub subscription. The suite reports these as skipped
 instead of treating unavailable infrastructure as a product failure.
+
+`GOG_LIVE_CHAT_SEARCH_QUERY` must match at least one message available to the
+test account. The Chat search smoke path is read-only and checks basic/full JSON,
+Markdown-formatted output, one explicit page token when available, and the
+stable `--fail-empty` exit contract. It uses Google's documented
+[`POST spaces.messages.search`](https://developers.google.com/workspace/chat/api/reference/rest/v1/spaces.messages/search)
+method; Developer Preview relevance ordering is intentionally excluded.
 
 Use `--fast` to skip Docs, Sheets, and Slides, `--skip` for selected modules,
 and `--strict` when optional service failures should fail the run.

--- a/scripts/live-chat-test.sh
+++ b/scripts/live-chat-test.sh
@@ -17,6 +17,7 @@ Options:
 
 Env:
   GOG_LIVE_CHAT_SPACE=spaces/<id>        Existing space to use for list/send
+  GOG_LIVE_CHAT_SEARCH_QUERY='text'      Query known to match at least one message
   GOG_LIVE_CHAT_THREAD=<id|resource>    Thread id or resource for sends
   GOG_LIVE_CHAT_DM=user@domain          DM target (workspace user)
   GOG_LIVE_CHAT_DM_THREAD=<id|resource> Thread id for DM send
@@ -116,10 +117,12 @@ gog() {
 }
 
 TS=$(date +%Y%m%d%H%M%S)
+source "$ROOT_DIR/scripts/live-tests/chat-search.sh"
 
 echo "Using account: $ACCOUNT"
 echo "==> chat spaces list"
 gog chat spaces list --json --max 1 >/dev/null
+run_chat_search_tests
 
 if [ -n "${GOG_LIVE_CHAT_SPACE:-}" ]; then
   echo "==> chat messages list"

--- a/scripts/live-test.sh
+++ b/scripts/live-test.sh
@@ -37,6 +37,7 @@ Skip keys (base):
 Env:
   GOG_LIVE_EMAIL_TEST=steipete+gogtest@gmail.com
   GOG_LIVE_CHAT_SPACE=spaces/...
+  GOG_LIVE_CHAT_SEARCH_QUERY='known matching text'
   GOG_LIVE_GROUP_EMAIL=<group@domain>
   GOG_LIVE_CLASSROOM_COURSE=<courseId>
   GOG_LIVE_CLASSROOM_CREATE=1
@@ -161,6 +162,7 @@ source "$ROOT_DIR/scripts/live-tests/calendar.sh"
 source "$ROOT_DIR/scripts/live-tests/tasks.sh"
 source "$ROOT_DIR/scripts/live-tests/contacts.sh"
 source "$ROOT_DIR/scripts/live-tests/people.sh"
+source "$ROOT_DIR/scripts/live-tests/chat-search.sh"
 source "$ROOT_DIR/scripts/live-tests/workspace.sh"
 source "$ROOT_DIR/scripts/live-tests/classroom.sh"
 source "$ROOT_DIR/scripts/live-tests/meet.sh"

--- a/scripts/live-tests/chat-search.sh
+++ b/scripts/live-tests/chat-search.sh
@@ -17,7 +17,8 @@ run_chat_search_tests() {
     --order "create_time desc" --view basic)
   assert_chat_search_json "$basic_json" basic
 
-  echo "==> chat messages search (full Markdown)"
+  # Smoke-check option acceptance and result shape, not Markdown rendering.
+  echo "==> chat messages search (full Markdown options)"
   full_json=$(gog chat messages search "$query" --readonly --json --max 1 \
     --order "create_time desc" --view full --markup markdown --wrap-untrusted)
   assert_chat_search_json "$full_json" full
@@ -29,6 +30,7 @@ run_chat_search_tests() {
       --page "$page_token" --order "create_time desc" --view full \
       --markup markdown --wrap-untrusted)
     assert_chat_search_json "$page_json" full
+    assert_chat_search_advanced "$full_json" "$page_json"
   else
     echo "==> chat messages search explicit page (skipped; query has one result page)"
   fi
@@ -46,6 +48,16 @@ run_chat_search_tests() {
     echo "chat search --fail-empty returned $empty_rc, want 3" >&2
     return 1
   fi
+}
+
+assert_chat_search_advanced() {
+  $PY -c 'import json,sys
+first=json.loads(sys.argv[1])
+page=json.load(sys.stdin)
+previous={item["resource"] for item in first["results"]}
+if any(item["resource"] in previous for item in page["results"]):
+    raise SystemExit("chat search explicit page repeated a previous result")
+' "$1" <<<"$2"
 }
 
 chat_search_next_page_token() {
@@ -71,6 +83,9 @@ if not isinstance(obj.get("nextPageToken", ""), str):
     raise SystemExit("chat search nextPageToken must be a string")
 if view == "basic" and any("read" in item for item in results):
     raise SystemExit("basic chat search result unexpectedly includes read")
+# Full-view read state is optional: unavailable metadata stays unknown.
+if view == "full" and any("read" in item and not isinstance(item["read"], bool) for item in results):
+    raise SystemExit("full chat search read metadata must be boolean when present")
 if any(not isinstance(item.get("resource"), str) or not item["resource"] for item in results):
     raise SystemExit("chat search result is missing resource")
 ' "$view" <<<"$value"

--- a/scripts/live-tests/chat-search.sh
+++ b/scripts/live-tests/chat-search.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# SearchMessages uses POST with a JSON request body.
+# https://developers.google.com/workspace/chat/api/reference/rest/v1/spaces.messages/search
+run_chat_search_tests() {
+  local query basic_json full_json page_json page_token empty_query empty_rc
+  query="${GOG_LIVE_CHAT_SEARCH_QUERY:-}"
+  if [ -z "$query" ]; then
+    echo "==> chat messages search (skipped; set GOG_LIVE_CHAT_SEARCH_QUERY)"
+    return 0
+  fi
+
+  echo "==> chat messages search (basic)"
+  basic_json=$(gog chat messages search "$query" --readonly --json --max 1 \
+    --order "create_time desc" --view basic)
+  assert_chat_search_json "$basic_json" basic
+
+  echo "==> chat messages search (full Markdown)"
+  full_json=$(gog chat messages search "$query" --readonly --json --max 1 \
+    --order "create_time desc" --view full --markup markdown --wrap-untrusted)
+  assert_chat_search_json "$full_json" full
+
+  page_token=$(chat_search_next_page_token "$full_json")
+  if [ -n "$page_token" ]; then
+    echo "==> chat messages search (explicit page)"
+    page_json=$(gog chat messages search "$query" --readonly --json --max 1 \
+      --page "$page_token" --order "create_time desc" --view full \
+      --markup markdown --wrap-untrusted)
+    assert_chat_search_json "$page_json" full
+  else
+    echo "==> chat messages search explicit page (skipped; query has one result page)"
+  fi
+
+  echo "==> chat messages search (fail-empty)"
+  empty_query="gogcli-live-no-match-$TS"
+  if gog chat messages search "$empty_query" --readonly --json --max 1 \
+    --fail-empty >/dev/null; then
+    echo "chat search --fail-empty unexpectedly succeeded" >&2
+    return 1
+  else
+    empty_rc=$?
+  fi
+  if [ "$empty_rc" -ne 3 ]; then
+    echo "chat search --fail-empty returned $empty_rc, want 3" >&2
+    return 1
+  fi
+}
+
+chat_search_next_page_token() {
+  $PY -c 'import json,sys
+obj=json.load(sys.stdin)
+value=obj.get("nextPageToken", "")
+if not isinstance(value, str):
+    raise SystemExit("chat search nextPageToken must be a string")
+print(value)
+' <<<"$1"
+}
+
+assert_chat_search_json() {
+  local value="$1"
+  local view="$2"
+  $PY -c 'import json,sys
+obj=json.load(sys.stdin)
+view=sys.argv[1]
+results=obj.get("results")
+if not isinstance(results, list) or not results:
+    raise SystemExit("chat search query must return at least one result")
+if not isinstance(obj.get("nextPageToken", ""), str):
+    raise SystemExit("chat search nextPageToken must be a string")
+if view == "basic" and any("read" in item for item in results):
+    raise SystemExit("basic chat search result unexpectedly includes read")
+if any(not isinstance(item.get("resource"), str) or not item["resource"] for item in results):
+    raise SystemExit("chat search result is missing resource")
+' "$view" <<<"$value"
+}

--- a/scripts/live-tests/workspace.sh
+++ b/scripts/live-tests/workspace.sh
@@ -4,6 +4,14 @@ set -euo pipefail
 
 run_workspace_tests() {
   if is_consumer_account "$ACCOUNT"; then
+    echo "==> chat messages search (skipped; Workspace only)"
+  elif skip "chat"; then
+    echo "==> chat messages search (skipped)"
+  else
+    run_chat_search_tests
+  fi
+
+  if is_consumer_account "$ACCOUNT"; then
     echo "==> chat attachment (skipped; Workspace only)"
   elif [ -n "${GOG_LIVE_CHAT_SPACE:-}" ]; then
     local chat_attachment

--- a/scripts/live_chat_search_test.go
+++ b/scripts/live_chat_search_test.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestChatSearchLiveHarnessExercisesViewsPagingAndEmptyExit(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("bash live-test harness is not supported on Windows")
+	}
+
+	root, err := filepath.Abs("..")
+	if err != nil {
+		t.Fatalf("resolve repository root: %v", err)
+	}
+
+	script := `
+set -euo pipefail
+ROOT_DIR="$1"
+PY=python3
+TS=20260903000000
+GOG_LIVE_CHAT_SEARCH_QUERY="project one"
+LIVE_TMP=$(mktemp -d)
+TRACE_FILE="$LIVE_TMP/trace"
+trap 'rm -rf "$LIVE_TMP"' EXIT
+source "$ROOT_DIR/scripts/live-tests/chat-search.sh"
+gog() {
+  printf '%s\n' "$*" >>"$TRACE_FILE"
+  case "$*" in
+    "chat messages search project one --readonly --json --max 1 --order create_time desc --view basic")
+      printf '{"results":[{"resource":"spaces/a/messages/one"}],"nextPageToken":"next"}\n'
+      ;;
+    "chat messages search project one --readonly --json --max 1 --order create_time desc --view full --markup markdown --wrap-untrusted")
+      printf '{"results":[{"resource":"spaces/a/messages/one","read":false}],"nextPageToken":"next"}\n'
+      ;;
+    "chat messages search project one --readonly --json --max 1 --page next --order create_time desc --view full --markup markdown --wrap-untrusted")
+      printf '{"results":[{"resource":"spaces/b/messages/two","read":true}],"nextPageToken":""}\n'
+      ;;
+    "chat messages search gogcli-live-no-match-20260903000000 --readonly --json --max 1 --fail-empty")
+      printf '{"results":[],"nextPageToken":""}\n'
+      return 3
+      ;;
+    *)
+      echo "unexpected gog call: $*" >&2
+      return 1
+      ;;
+  esac
+}
+run_chat_search_tests
+cat "$TRACE_FILE"
+`
+
+	output, err := exec.CommandContext(t.Context(), "bash", "-c", script, "bash", root).CombinedOutput()
+	if err != nil {
+		t.Fatalf("run Chat search live-test path: %v\n%s", err, output)
+	}
+
+	text := string(output)
+	for _, want := range []string{
+		"chat messages search (basic)",
+		"--view basic",
+		"chat messages search (full Markdown)",
+		"--view full --markup markdown --wrap-untrusted",
+		"chat messages search (explicit page)",
+		"--page next",
+		"chat messages search (fail-empty)",
+		"--fail-empty",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("output missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestChatSearchLiveHarnessSkipsWithoutQuery(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("bash live-test harness is not supported on Windows")
+	}
+
+	root, err := filepath.Abs("..")
+	if err != nil {
+		t.Fatalf("resolve repository root: %v", err)
+	}
+
+	script := `
+set -euo pipefail
+ROOT_DIR="$1"
+PY=python3
+TS=20260903000000
+source "$ROOT_DIR/scripts/live-tests/chat-search.sh"
+gog() {
+  echo "unexpected API call" >&2
+  return 1
+}
+run_chat_search_tests
+`
+
+	output, err := exec.CommandContext(t.Context(), "bash", "-c", script, "bash", root).CombinedOutput()
+	if err != nil {
+		t.Fatalf("run Chat search live-test skip path: %v\n%s", err, output)
+	}
+
+	text := string(output)
+	if !strings.Contains(text, "chat messages search (skipped; set GOG_LIVE_CHAT_SEARCH_QUERY)") {
+		t.Fatalf("output missing Chat search skip:\n%s", text)
+	}
+
+	if strings.Contains(text, "unexpected API call") {
+		t.Fatalf("skip path invoked the API:\n%s", text)
+	}
+}
+
+func TestChatSearchLiveHarnessRejectsBasicReadMetadata(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("bash live-test harness is not supported on Windows")
+	}
+
+	root, err := filepath.Abs("..")
+	if err != nil {
+		t.Fatalf("resolve repository root: %v", err)
+	}
+
+	script := `
+set -euo pipefail
+ROOT_DIR="$1"
+PY=python3
+TS=20260903000000
+GOG_LIVE_CHAT_SEARCH_QUERY=project
+source "$ROOT_DIR/scripts/live-tests/chat-search.sh"
+gog() {
+  printf '{"results":[{"resource":"spaces/a/messages/one","read":false}],"nextPageToken":""}\n'
+}
+run_chat_search_tests
+`
+
+	output, err := exec.CommandContext(t.Context(), "bash", "-c", script, "bash", root).CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected invalid basic read metadata to fail:\n%s", output)
+	}
+
+	if !strings.Contains(string(output), "basic chat search result unexpectedly includes read") {
+		t.Fatalf("output missing validation failure:\n%s", output)
+	}
+}

--- a/scripts/live_chat_search_test.go
+++ b/scripts/live_chat_search_test.go
@@ -63,7 +63,7 @@ cat "$TRACE_FILE"
 	for _, want := range []string{
 		"chat messages search (basic)",
 		"--view basic",
-		"chat messages search (full Markdown)",
+		"chat messages search (full Markdown options)",
 		"--view full --markup markdown --wrap-untrusted",
 		"chat messages search (explicit page)",
 		"--page next",
@@ -134,6 +134,7 @@ source "$ROOT_DIR/scripts/live-tests/chat-search.sh"
 gog() {
   printf '{"results":[{"resource":"spaces/a/messages/one","read":false}],"nextPageToken":""}\n'
 }
+
 run_chat_search_tests
 `
 
@@ -144,5 +145,51 @@ run_chat_search_tests
 
 	if !strings.Contains(string(output), "basic chat search result unexpectedly includes read") {
 		t.Fatalf("output missing validation failure:\n%s", output)
+	}
+}
+
+func TestChatSearchLiveHarnessRejectsNonAdvancingPage(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("bash live-test harness is not supported on Windows")
+	}
+	root, err := filepath.Abs("..")
+	if err != nil {
+		t.Fatal(err)
+	}
+	script := `
+set -euo pipefail
+ROOT_DIR="$1"
+PY=python3
+TS=20260903000000
+GOG_LIVE_CHAT_SEARCH_QUERY=project
+source "$ROOT_DIR/scripts/live-tests/chat-search.sh"
+gog() {
+  printf '{"results":[{"resource":"spaces/a/messages/one"}],"nextPageToken":"next"}\n'
+}
+run_chat_search_tests
+`
+	output, err := exec.CommandContext(t.Context(), "bash", "-c", script, "bash", root).CombinedOutput()
+	if err == nil || !strings.Contains(string(output), "explicit page repeated a previous result") {
+		t.Fatalf("expected unchanged-page rejection, got %v:\n%s", err, output)
+	}
+}
+
+func TestChatSearchLiveHarnessRejectsInvalidFullReadMetadata(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("bash live-test harness is not supported on Windows")
+	}
+	root, err := filepath.Abs("..")
+	if err != nil {
+		t.Fatal(err)
+	}
+	script := `set -euo pipefail
+PY=python3
+source "$1/scripts/live-tests/chat-search.sh"
+assert_chat_search_json "$2" full
+`
+	payload := `{"results":[{"resource":"spaces/a/messages/one","read":"yes"}]}`
+	output, err := exec.CommandContext(t.Context(), "bash", "-c", script, "bash", root, payload).CombinedOutput()
+	if err == nil || !strings.Contains(string(output), "read metadata must be boolean when present") {
+		t.Fatalf("expected invalid read metadata rejection, got %v:\n%s", err, output)
 	}
 }

--- a/scripts/live_chat_search_test.go
+++ b/scripts/live_chat_search_test.go
@@ -152,6 +152,7 @@ func TestChatSearchLiveHarnessRejectsNonAdvancingPage(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("bash live-test harness is not supported on Windows")
 	}
+
 	root, err := filepath.Abs("..")
 	if err != nil {
 		t.Fatal(err)
@@ -168,6 +169,7 @@ gog() {
 }
 run_chat_search_tests
 `
+
 	output, err := exec.CommandContext(t.Context(), "bash", "-c", script, "bash", root).CombinedOutput()
 	if err == nil || !strings.Contains(string(output), "explicit page repeated a previous result") {
 		t.Fatalf("expected unchanged-page rejection, got %v:\n%s", err, output)
@@ -178,6 +180,7 @@ func TestChatSearchLiveHarnessRejectsInvalidFullReadMetadata(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("bash live-test harness is not supported on Windows")
 	}
+
 	root, err := filepath.Abs("..")
 	if err != nil {
 		t.Fatal(err)
@@ -188,6 +191,7 @@ source "$1/scripts/live-tests/chat-search.sh"
 assert_chat_search_json "$2" full
 `
 	payload := `{"results":[{"resource":"spaces/a/messages/one","read":"yes"}]}`
+
 	output, err := exec.CommandContext(t.Context(), "bash", "-c", script, "bash", root, payload).CombinedOutput()
 	if err == nil || !strings.Contains(string(output), "read metadata must be boolean when present") {
 		t.Fatalf("expected invalid read metadata rejection, got %v:\n%s", err, output)

--- a/scripts/live_chat_search_test.go
+++ b/scripts/live_chat_search_test.go
@@ -81,6 +81,8 @@ func TestChatSearchLiveHarnessSkipsWithoutQuery(t *testing.T) {
 		t.Skip("bash live-test harness is not supported on Windows")
 	}
 
+	t.Setenv("GOG_LIVE_CHAT_SEARCH_QUERY", "")
+
 	root, err := filepath.Abs("..")
 	if err != nil {
 		t.Fatalf("resolve repository root: %v", err)


### PR DESCRIPTION
Add opt-in, read-only live coverage for Chat message search to the dedicated Chat runner and broader Workspace suite. The harness checks basic/full result envelopes, explicit cursor continuation, and the empty-result exit code. It requests Markdown and untrusted-wrapping options to exercise acceptance; it does not assert rendered-text transformations. Cursor continuation must return a different resource, so a CLI that ignores the page token fails the test.

The harness reuses existing Chat grants and follows the current client/account conventions. It leaves send, DM, and space-creation coverage opt-in. No production commands, OAuth scopes, or MIME behavior change.

Validation: the scripts test suite and shell syntax checks pass. The strengthened harness passed against Google with an existing Workspace grant: basic JSON, a full-view request with Markdown options, explicit cursor advancement, and `--fail-empty` all succeeded; message sends, DMs, and space creation were disabled. A sanitized exact-head proof comment records the run and CI result.

Google API reference: https://developers.google.com/workspace/chat/api/reference/rest/v1/spaces.messages/search

The no-query regression explicitly clears the inherited search query and passes with `GOG_LIVE_CHAT_SEARCH_QUERY=project` exported. [Sanitized live trace](https://github.com/openclaw/gogcli/pull/1077#issuecomment-5554883783).
