### PR TITLE
fix(backup): reject repeated Drive backup page tokens

### DIFF
--- a/internal/cmd/backup_drive.go
+++ b/internal/cmd/backup_drive.go
@@ -99,9 +99,7 @@ func buildDriveBackupSnapshot(ctx context.Context, flags *RootFlags, opts driveB
 }
 
 func fetchBackupSharedDrives(ctx context.Context, svc *drive.Service) ([]*drive.Drive, error) {
-	var out []*drive.Drive
-	pageToken := ""
-	for {
+	out, err := collectAllPages("", func(pageToken string) ([]*drive.Drive, string, error) {
 		call := svc.Drives.List().
 			PageSize(100).
 			Fields("nextPageToken, drives(id, name, createdTime, hidden, restrictions)").
@@ -111,22 +109,19 @@ func fetchBackupSharedDrives(ctx context.Context, svc *drive.Service) ([]*drive.
 		}
 		resp, err := call.Do()
 		if err != nil {
-			return nil, err
+			return nil, "", err
 		}
-		out = append(out, resp.Drives...)
-		if resp.NextPageToken == "" {
-			break
-		}
-		pageToken = resp.NextPageToken
+		return resp.Drives, resp.NextPageToken, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Id < out[j].Id })
 	return out, nil
 }
 
 func fetchBackupDriveFiles(ctx context.Context, svc *drive.Service) ([]driveBackupFile, error) {
-	var out []driveBackupFile
-	pageToken := ""
-	for {
+	files, err := collectAllPages("", func(pageToken string) ([]*drive.File, string, error) {
 		call := svc.Files.List().
 			Q("trashed = false").
 			PageSize(1000).
@@ -139,15 +134,16 @@ func fetchBackupDriveFiles(ctx context.Context, svc *drive.Service) ([]driveBack
 		}
 		resp, err := call.Do()
 		if err != nil {
-			return nil, err
+			return nil, "", err
 		}
-		for _, file := range resp.Files {
-			out = append(out, driveBackupFile{File: file})
-		}
-		if resp.NextPageToken == "" {
-			break
-		}
-		pageToken = resp.NextPageToken
+		return resp.Files, resp.NextPageToken, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	var out []driveBackupFile
+	for _, file := range files {
+		out = append(out, driveBackupFile{File: file})
 	}
 	return out, nil
 }

--- a/internal/cmd/backup_drive_test.go
+++ b/internal/cmd/backup_drive_test.go
@@ -1,0 +1,192 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestFetchBackupSharedDrivesRejectsRepeatedPageToken(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	svc, closeSvc := newDriveTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !strings.HasSuffix(r.URL.Path, "/drives") {
+			http.NotFound(w, r)
+			return
+		}
+		n := calls.Add(1)
+		if n > 2 {
+			http.Error(w, "unexpected extra shared drive page request", http.StatusBadRequest)
+			return
+		}
+		wantToken := ""
+		if n == 2 {
+			wantToken = "stuck"
+		}
+		requireQuery(t, r, "pageToken", wantToken)
+		requireQuery(t, r, "pageSize", "100")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"drives":        []map[string]any{{"id": "drive-1", "name": "Team"}},
+			"nextPageToken": "stuck",
+		})
+	}))
+	defer closeSvc()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	got, err := fetchBackupSharedDrives(ctx, svc)
+	if err == nil || !strings.Contains(err.Error(), "repeated page token") {
+		t.Fatalf("err = %v after %d list calls", err, calls.Load())
+	}
+	if got != nil {
+		t.Fatalf("drives = %#v, want no partial result", got)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("list calls = %d, want 2", got)
+	}
+	t.Logf("err = %v after %d list calls", err, calls.Load())
+}
+
+func TestFetchBackupDriveFilesRejectsRepeatedPageToken(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	svc, closeSvc := newDriveTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !strings.HasSuffix(r.URL.Path, "/files") {
+			http.NotFound(w, r)
+			return
+		}
+		n := calls.Add(1)
+		if n > 2 {
+			http.Error(w, "unexpected extra drive file page request", http.StatusBadRequest)
+			return
+		}
+		wantToken := ""
+		if n == 2 {
+			wantToken = "stuck"
+		}
+		requireQuery(t, r, "pageToken", wantToken)
+		requireQuery(t, r, "pageSize", "1000")
+		requireQuery(t, r, "q", "trashed = false")
+		requireQuery(t, r, "orderBy", "modifiedTime desc")
+		requireSupportsAllDrives(t, r)
+		requireQuery(t, r, "includeItemsFromAllDrives", "true")
+		requireQuery(t, r, "corpora", "allDrives")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"files":         []map[string]any{{"id": "file-1", "name": "notes.txt"}},
+			"nextPageToken": "stuck",
+		})
+	}))
+	defer closeSvc()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	got, err := fetchBackupDriveFiles(ctx, svc)
+	if err == nil || !strings.Contains(err.Error(), "repeated page token") {
+		t.Fatalf("err = %v after %d list calls", err, calls.Load())
+	}
+	if got != nil {
+		t.Fatalf("files = %#v, want no partial result", got)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("list calls = %d, want 2", got)
+	}
+	t.Logf("err = %v after %d list calls", err, calls.Load())
+}
+
+func TestFetchBackupSharedDrivesTwoDistinctPagesSucceed(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	svc, closeSvc := newDriveTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !strings.HasSuffix(r.URL.Path, "/drives") {
+			http.NotFound(w, r)
+			return
+		}
+		n := calls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		if n == 1 {
+			requireQuery(t, r, "pageToken", "")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"drives":        []map[string]any{{"id": "zzz", "name": "Late"}},
+				"nextPageToken": "page-2",
+			})
+			return
+		}
+		if n == 2 {
+			requireQuery(t, r, "pageToken", "page-2")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"drives": []map[string]any{{"id": "aaa", "name": "Early"}},
+			})
+			return
+		}
+		http.Error(w, "unexpected extra shared drive page request", http.StatusBadRequest)
+	}))
+	defer closeSvc()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	got, err := fetchBackupSharedDrives(ctx, svc)
+	if err != nil {
+		t.Fatalf("err = %v after %d list calls", err, calls.Load())
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("list calls = %d, want 2", calls.Load())
+	}
+	if len(got) != 2 || got[0].Id != "aaa" || got[1].Id != "zzz" {
+		t.Fatalf("drives = %#v, want sorted ids aaa then zzz", got)
+	}
+}
+
+func TestFetchBackupDriveFilesTwoDistinctPagesSucceed(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	svc, closeSvc := newDriveTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !strings.HasSuffix(r.URL.Path, "/files") {
+			http.NotFound(w, r)
+			return
+		}
+		n := calls.Add(1)
+		requireSupportsAllDrives(t, r)
+		requireQuery(t, r, "corpora", "allDrives")
+		w.Header().Set("Content-Type", "application/json")
+		if n == 1 {
+			requireQuery(t, r, "pageToken", "")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"files":         []map[string]any{{"id": "file-1", "name": "a.txt"}},
+				"nextPageToken": "page-2",
+			})
+			return
+		}
+		if n == 2 {
+			requireQuery(t, r, "pageToken", "page-2")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"files": []map[string]any{{"id": "file-2", "name": "b.txt"}},
+			})
+			return
+		}
+		http.Error(w, "unexpected extra drive file page request", http.StatusBadRequest)
+	}))
+	defer closeSvc()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	got, err := fetchBackupDriveFiles(ctx, svc)
+	if err != nil {
+		t.Fatalf("err = %v after %d list calls", err, calls.Load())
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("list calls = %d, want 2", calls.Load())
+	}
+	if len(got) != 2 || got[0].File.Id != "file-1" || got[1].File.Id != "file-2" {
+		t.Fatalf("files = %#v, want both pages concatenated", got)
+	}
+}


### PR DESCRIPTION
## What Problem This Solves

`gog backup push` with Drive lists shared drives (`Drives.List`) and files (`Files.List`) by walking Google page tokens. Both helpers in `internal/cmd/backup_drive.go` copied `nextPageToken` into the next request with no seen-set.

When Drive repeats a continuation token, those loops never terminate. Backup collection keeps requesting the same page and never finishes a Drive snapshot.

The same hang class is already closed for Chat and Classroom backup (#1063), Drive sync push listing (#1065), Drive audit permission listing (#1066), calendar and Gmail listing (#1004), and People/Gmail-from-contact/contacts-export listing (#1044, #1045, #1046). Drive backup listing was still on the unguarded loop.

## Evidence

terminal output from the compiled `internal/cmd` listing binary after the patch. A stuck continuation token is rejected after two list calls, with no third request:

```console
$ gogcli-backup-paging.exe -test.run TestFetchBackupSharedDrivesRejectsRepeatedPageToken -test.v
    backup_drive_test.go:53: err = pagination loop: repeated page token "stuck" after 2 list calls

$ gogcli-backup-paging.exe -test.run TestFetchBackupDriveFilesRejectsRepeatedPageToken -test.v
    backup_drive_test.go:101: err = pagination loop: repeated page token "stuck" after 2 list calls
```

Before the patch, the same stuck token made a third list request and returned HTTP 400 from the safety cap (`unexpected extra ... page request after 3 list calls`) instead of stopping on the repeated token.

## Real behavior proof

- **Behavior or issue addressed:** Drive backup shared-drive and file listing hung when Google repeated a page token. `gog backup push` with Drive never finished those listings.
- **Real environment tested:** Windows, Go 1.27.1, branch `fix/backup-paging-seen-token` at current HEAD, compiled `internal/cmd` listing binary.
- **Exact steps or command run after this patch:** Compiled the listing binary with `go`, then ran `gogcli-backup-paging.exe` with `-test.v` on the shared-drive and file hang-guard cases.
- **Evidence after fix:** terminal output from that binary shows `pagination loop: repeated page token "stuck"` after 2 list calls for both `fetchBackupSharedDrives` and `fetchBackupDriveFiles`.
- **Observed result after fix:** A repeated Drive backup page token now fails closed with the shared paginator error after two requests. Distinct pages still concatenate. Shared drives stay sorted by id. File listing still uses `driveFilesListCallWithDriveSupport` (`corpora=allDrives`).
- **What was not tested:** A live Google Drive account with a real repeated token. Snapshot write / `--best-effort` handling after the listing error.

## Summary

Route `fetchBackupSharedDrives` and `fetchBackupDriveFiles` through existing `collectAllPages`. Keep the original field lists, page sizes, query, order, shared-drive flags, and shared-drive sort.

Related: #1063, #1065, #1066, #1004, #1044, #1045, #1046.

Introduced in `068ff0e5` (2026-04-27, `feat(backup): expand workspace backup coverage`).
