### PR TITLE
fix(backup): reject repeated Groups Admin Keep page tokens

### DIFF
--- a/internal/cmd/backup_directory_keep.go
+++ b/internal/cmd/backup_directory_keep.go
@@ -134,9 +134,7 @@ func buildKeepBackupSnapshot(ctx context.Context, flags *RootFlags, shardMaxRows
 }
 
 func fetchBackupCloudIdentityGroups(ctx context.Context, svc *cloudidentity.Service, account string) ([]*cloudidentity.GroupRelation, error) {
-	var out []*cloudidentity.GroupRelation
-	pageToken := ""
-	for {
+	fetch := func(pageToken string) ([]*cloudidentity.GroupRelation, string, error) {
 		call := svc.Groups.Memberships.SearchTransitiveGroups("groups/-").
 			Query(searchTransitiveGroupsQuery(account)).
 			PageSize(1000).
@@ -146,13 +144,13 @@ func fetchBackupCloudIdentityGroups(ctx context.Context, svc *cloudidentity.Serv
 		}
 		resp, err := call.Do()
 		if err != nil {
-			return nil, wrapCloudIdentityError(err, account)
+			return nil, "", wrapCloudIdentityError(err, account)
 		}
-		out = append(out, resp.Memberships...)
-		if resp.NextPageToken == "" {
-			break
-		}
-		pageToken = resp.NextPageToken
+		return resp.Memberships, resp.NextPageToken, nil
+	}
+	out, err := collectAllPages("", fetch)
+	if err != nil {
+		return nil, err
 	}
 	sort.Slice(out, func(i, j int) bool { return groupRelationEmail(out[i]) < groupRelationEmail(out[j]) })
 	return out, nil
@@ -170,24 +168,23 @@ func fetchBackupCloudIdentityGroupMembers(ctx context.Context, svc *cloudidentit
 			out = append(out, groupsBackupMember{GroupEmail: groupEmail, Error: err.Error()})
 			continue
 		}
-		pageToken := ""
-		for {
+		members, err := collectAllPages("", func(pageToken string) ([]*cloudidentity.Membership, string, error) {
 			call := svc.Groups.Memberships.List(groupName).PageSize(1000).Context(ctx)
 			if pageToken != "" {
 				call = call.PageToken(pageToken)
 			}
 			resp, err := call.Do()
 			if err != nil {
-				out = append(out, groupsBackupMember{GroupEmail: groupEmail, Error: err.Error()})
-				break
+				return nil, "", err
 			}
-			for _, member := range resp.Memberships {
-				out = append(out, groupsBackupMember{GroupEmail: groupEmail, Member: member})
-			}
-			if resp.NextPageToken == "" {
-				break
-			}
-			pageToken = resp.NextPageToken
+			return resp.Memberships, resp.NextPageToken, nil
+		})
+		if err != nil {
+			out = append(out, groupsBackupMember{GroupEmail: groupEmail, Error: err.Error()})
+			continue
+		}
+		for _, member := range members {
+			out = append(out, groupsBackupMember{GroupEmail: groupEmail, Member: member})
 		}
 	}
 	sort.Slice(out, func(i, j int) bool {
@@ -200,44 +197,40 @@ func fetchBackupCloudIdentityGroupMembers(ctx context.Context, svc *cloudidentit
 }
 
 func fetchBackupAdminUsers(ctx context.Context, svc *admin.Service, domain string) ([]*admin.User, error) {
-	var out []*admin.User
-	pageToken := ""
-	for {
+	fetch := func(pageToken string) ([]*admin.User, string, error) {
 		call := svc.Users.List().Domain(domain).MaxResults(500).Context(ctx)
 		if pageToken != "" {
 			call = call.PageToken(pageToken)
 		}
 		resp, err := call.Do()
 		if err != nil {
-			return nil, err
+			return nil, "", err
 		}
-		out = append(out, resp.Users...)
-		if resp.NextPageToken == "" {
-			break
-		}
-		pageToken = resp.NextPageToken
+		return resp.Users, resp.NextPageToken, nil
+	}
+	out, err := collectAllPages("", fetch)
+	if err != nil {
+		return nil, err
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].PrimaryEmail < out[j].PrimaryEmail })
 	return out, nil
 }
 
 func fetchBackupAdminGroups(ctx context.Context, svc *admin.Service, domain string) ([]*admin.Group, error) {
-	var out []*admin.Group
-	pageToken := ""
-	for {
+	fetch := func(pageToken string) ([]*admin.Group, string, error) {
 		call := svc.Groups.List().Domain(domain).MaxResults(200).Context(ctx)
 		if pageToken != "" {
 			call = call.PageToken(pageToken)
 		}
 		resp, err := call.Do()
 		if err != nil {
-			return nil, err
+			return nil, "", err
 		}
-		out = append(out, resp.Groups...)
-		if resp.NextPageToken == "" {
-			break
-		}
-		pageToken = resp.NextPageToken
+		return resp.Groups, resp.NextPageToken, nil
+	}
+	out, err := collectAllPages("", fetch)
+	if err != nil {
+		return nil, err
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Email < out[j].Email })
 	return out, nil
@@ -286,22 +279,20 @@ func fetchAllBackupAdminGroupMembers(ctx context.Context, svc *admin.Service, gr
 }
 
 func fetchBackupKeepNotes(ctx context.Context, svc *keepapi.Service) ([]*keepapi.Note, error) {
-	var out []*keepapi.Note
-	pageToken := ""
-	for {
+	fetch := func(pageToken string) ([]*keepapi.Note, string, error) {
 		call := svc.Notes.List().PageSize(1000).Context(ctx)
 		if pageToken != "" {
 			call = call.PageToken(pageToken)
 		}
 		resp, err := call.Do()
 		if err != nil {
-			return nil, err
+			return nil, "", err
 		}
-		out = append(out, resp.Notes...)
-		if resp.NextPageToken == "" {
-			break
-		}
-		pageToken = resp.NextPageToken
+		return resp.Notes, resp.NextPageToken, nil
+	}
+	out, err := collectAllPages("", fetch)
+	if err != nil {
+		return nil, err
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
 	return out, nil

--- a/internal/cmd/backup_directory_keep.go
+++ b/internal/cmd/backup_directory_keep.go
@@ -173,9 +173,9 @@ func fetchBackupCloudIdentityGroupMembers(ctx context.Context, svc *cloudidentit
 			if pageToken != "" {
 				call = call.PageToken(pageToken)
 			}
-			resp, err := call.Do()
-			if err != nil {
-				return nil, "", err
+			resp, callErr := call.Do()
+			if callErr != nil {
+				return nil, "", callErr
 			}
 			return resp.Memberships, resp.NextPageToken, nil
 		})

--- a/internal/cmd/backup_directory_keep.go
+++ b/internal/cmd/backup_directory_keep.go
@@ -133,27 +133,35 @@ func buildKeepBackupSnapshot(ctx context.Context, flags *RootFlags, shardMaxRows
 	}, nil
 }
 
-func fetchBackupCloudIdentityGroups(ctx context.Context, svc *cloudidentity.Service, account string) ([]*cloudidentity.GroupRelation, error) {
-	fetch := func(pageToken string) ([]*cloudidentity.GroupRelation, string, error) {
-		call := svc.Groups.Memberships.SearchTransitiveGroups("groups/-").
-			Query(searchTransitiveGroupsQuery(account)).
-			PageSize(1000).
-			Context(ctx)
-		if pageToken != "" {
-			call = call.PageToken(pageToken)
-		}
-		resp, err := call.Do()
-		if err != nil {
-			return nil, "", wrapCloudIdentityError(err, account)
-		}
-		return resp.Memberships, resp.NextPageToken, nil
-	}
+func fetchSortedBackupPages[T any](fetch func(pageToken string) ([]T, string, error), less func(a, b T) bool) ([]T, error) {
 	out, err := collectAllPages("", fetch)
 	if err != nil {
 		return nil, err
 	}
-	sort.Slice(out, func(i, j int) bool { return groupRelationEmail(out[i]) < groupRelationEmail(out[j]) })
+	sort.Slice(out, func(i, j int) bool { return less(out[i], out[j]) })
 	return out, nil
+}
+
+func fetchBackupCloudIdentityGroups(ctx context.Context, svc *cloudidentity.Service, account string) ([]*cloudidentity.GroupRelation, error) {
+	return fetchSortedBackupPages(
+		func(pageToken string) ([]*cloudidentity.GroupRelation, string, error) {
+			call := svc.Groups.Memberships.SearchTransitiveGroups("groups/-").
+				Query(searchTransitiveGroupsQuery(account)).
+				PageSize(1000).
+				Context(ctx)
+			if pageToken != "" {
+				call = call.PageToken(pageToken)
+			}
+			resp, err := call.Do()
+			if err != nil {
+				return nil, "", wrapCloudIdentityError(err, account)
+			}
+			return resp.Memberships, resp.NextPageToken, nil
+		},
+		func(a, b *cloudidentity.GroupRelation) bool {
+			return groupRelationEmail(a) < groupRelationEmail(b)
+		},
+	)
 }
 
 func fetchBackupCloudIdentityGroupMembers(ctx context.Context, svc *cloudidentity.Service, groups []*cloudidentity.GroupRelation) []groupsBackupMember {
@@ -197,43 +205,37 @@ func fetchBackupCloudIdentityGroupMembers(ctx context.Context, svc *cloudidentit
 }
 
 func fetchBackupAdminUsers(ctx context.Context, svc *admin.Service, domain string) ([]*admin.User, error) {
-	fetch := func(pageToken string) ([]*admin.User, string, error) {
-		call := svc.Users.List().Domain(domain).MaxResults(500).Context(ctx)
-		if pageToken != "" {
-			call = call.PageToken(pageToken)
-		}
-		resp, err := call.Do()
-		if err != nil {
-			return nil, "", err
-		}
-		return resp.Users, resp.NextPageToken, nil
-	}
-	out, err := collectAllPages("", fetch)
-	if err != nil {
-		return nil, err
-	}
-	sort.Slice(out, func(i, j int) bool { return out[i].PrimaryEmail < out[j].PrimaryEmail })
-	return out, nil
+	return fetchSortedBackupPages(
+		func(pageToken string) ([]*admin.User, string, error) {
+			call := svc.Users.List().Domain(domain).MaxResults(500).Context(ctx)
+			if pageToken != "" {
+				call = call.PageToken(pageToken)
+			}
+			resp, err := call.Do()
+			if err != nil {
+				return nil, "", err
+			}
+			return resp.Users, resp.NextPageToken, nil
+		},
+		func(a, b *admin.User) bool { return a.PrimaryEmail < b.PrimaryEmail },
+	)
 }
 
 func fetchBackupAdminGroups(ctx context.Context, svc *admin.Service, domain string) ([]*admin.Group, error) {
-	fetch := func(pageToken string) ([]*admin.Group, string, error) {
-		call := svc.Groups.List().Domain(domain).MaxResults(200).Context(ctx)
-		if pageToken != "" {
-			call = call.PageToken(pageToken)
-		}
-		resp, err := call.Do()
-		if err != nil {
-			return nil, "", err
-		}
-		return resp.Groups, resp.NextPageToken, nil
-	}
-	out, err := collectAllPages("", fetch)
-	if err != nil {
-		return nil, err
-	}
-	sort.Slice(out, func(i, j int) bool { return out[i].Email < out[j].Email })
-	return out, nil
+	return fetchSortedBackupPages(
+		func(pageToken string) ([]*admin.Group, string, error) {
+			call := svc.Groups.List().Domain(domain).MaxResults(200).Context(ctx)
+			if pageToken != "" {
+				call = call.PageToken(pageToken)
+			}
+			resp, err := call.Do()
+			if err != nil {
+				return nil, "", err
+			}
+			return resp.Groups, resp.NextPageToken, nil
+		},
+		func(a, b *admin.Group) bool { return a.Email < b.Email },
+	)
 }
 
 func fetchBackupAdminGroupMembers(ctx context.Context, svc *admin.Service, groups []*admin.Group) []adminBackupMember {
@@ -279,23 +281,20 @@ func fetchAllBackupAdminGroupMembers(ctx context.Context, svc *admin.Service, gr
 }
 
 func fetchBackupKeepNotes(ctx context.Context, svc *keepapi.Service) ([]*keepapi.Note, error) {
-	fetch := func(pageToken string) ([]*keepapi.Note, string, error) {
-		call := svc.Notes.List().PageSize(1000).Context(ctx)
-		if pageToken != "" {
-			call = call.PageToken(pageToken)
-		}
-		resp, err := call.Do()
-		if err != nil {
-			return nil, "", err
-		}
-		return resp.Notes, resp.NextPageToken, nil
-	}
-	out, err := collectAllPages("", fetch)
-	if err != nil {
-		return nil, err
-	}
-	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
-	return out, nil
+	return fetchSortedBackupPages(
+		func(pageToken string) ([]*keepapi.Note, string, error) {
+			call := svc.Notes.List().PageSize(1000).Context(ctx)
+			if pageToken != "" {
+				call = call.PageToken(pageToken)
+			}
+			resp, err := call.Do()
+			if err != nil {
+				return nil, "", err
+			}
+			return resp.Notes, resp.NextPageToken, nil
+		},
+		func(a, b *keepapi.Note) bool { return a.Name < b.Name },
+	)
 }
 
 func domainFromAccount(account string) string {

--- a/internal/cmd/backup_directory_keep_test.go
+++ b/internal/cmd/backup_directory_keep_test.go
@@ -1,0 +1,314 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"google.golang.org/api/cloudidentity/v1"
+)
+
+func TestFetchBackupCloudIdentityGroupsRejectsRepeatedPageToken(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	svc := newCloudIdentityTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !strings.Contains(r.URL.Path, "groups/-/memberships:searchTransitiveGroups") {
+			http.NotFound(w, r)
+			return
+		}
+		n := calls.Add(1)
+		if n > 2 {
+			http.Error(w, "unexpected extra group page request", http.StatusBadRequest)
+			return
+		}
+		wantToken := ""
+		if n == 2 {
+			wantToken = "stuck"
+		}
+		requireQuery(t, r, "pageToken", wantToken)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"memberships":   []map[string]any{{"groupKey": map[string]any{"id": "eng@example.com"}}},
+			"nextPageToken": "stuck",
+		})
+	}))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	got, err := fetchBackupCloudIdentityGroups(ctx, svc, "admin@example.com")
+	if err == nil || !strings.Contains(err.Error(), "repeated page token") {
+		t.Fatalf("err = %v after %d list calls", err, calls.Load())
+	}
+	if got != nil {
+		t.Fatalf("groups = %#v, want no partial result", got)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("list calls = %d, want 2", got)
+	}
+	t.Logf("err = %v after %d list calls", err, calls.Load())
+}
+
+func TestFetchBackupCloudIdentityGroupMembersRejectsRepeatedPageToken(t *testing.T) {
+	t.Parallel()
+
+	var listCalls atomic.Int32
+	svc := newCloudIdentityTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "groups:lookup"):
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"name": "groups/abc123"})
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "groups/abc123/memberships"):
+			n := listCalls.Add(1)
+			if n > 2 {
+				http.Error(w, "unexpected extra membership page request", http.StatusBadRequest)
+				return
+			}
+			wantToken := ""
+			if n == 2 {
+				wantToken = "stuck"
+			}
+			requireQuery(t, r, "pageToken", wantToken)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"memberships":   []map[string]any{{"preferredMemberKey": map[string]any{"id": "alice@example.com"}}},
+				"nextPageToken": "stuck",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	got := fetchBackupCloudIdentityGroupMembers(ctx, svc, []*cloudidentity.GroupRelation{
+		{GroupKey: &cloudidentity.EntityKey{Id: "eng@example.com"}},
+	})
+	if len(got) != 1 || !strings.Contains(got[0].Error, "repeated page token") {
+		t.Fatalf("members = %#v after %d list calls", got, listCalls.Load())
+	}
+	if got := listCalls.Load(); got != 2 {
+		t.Fatalf("list calls = %d, want 2", got)
+	}
+	t.Logf("member error = %s after %d list calls", got[0].Error, listCalls.Load())
+}
+
+func TestFetchBackupAdminUsersRejectsRepeatedPageToken(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	svc := newAdminTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !strings.HasSuffix(r.URL.Path, "/users") {
+			http.NotFound(w, r)
+			return
+		}
+		n := calls.Add(1)
+		if n > 2 {
+			http.Error(w, "unexpected extra user page request", http.StatusBadRequest)
+			return
+		}
+		wantToken := ""
+		if n == 2 {
+			wantToken = "stuck"
+		}
+		requireQuery(t, r, "pageToken", wantToken)
+		requireQuery(t, r, "domain", "example.com")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"users":         []map[string]any{{"primaryEmail": "ada@example.com"}},
+			"nextPageToken": "stuck",
+		})
+	}))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	got, err := fetchBackupAdminUsers(ctx, svc, "example.com")
+	if err == nil || !strings.Contains(err.Error(), "repeated page token") {
+		t.Fatalf("err = %v after %d list calls", err, calls.Load())
+	}
+	if got != nil {
+		t.Fatalf("users = %#v, want no partial result", got)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("list calls = %d, want 2", got)
+	}
+	t.Logf("err = %v after %d list calls", err, calls.Load())
+}
+
+func TestFetchBackupAdminGroupsRejectsRepeatedPageToken(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	svc := newAdminTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !strings.HasSuffix(r.URL.Path, "/groups") {
+			http.NotFound(w, r)
+			return
+		}
+		n := calls.Add(1)
+		if n > 2 {
+			http.Error(w, "unexpected extra admin group page request", http.StatusBadRequest)
+			return
+		}
+		wantToken := ""
+		if n == 2 {
+			wantToken = "stuck"
+		}
+		requireQuery(t, r, "pageToken", wantToken)
+		requireQuery(t, r, "domain", "example.com")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"groups":        []map[string]any{{"email": "eng@example.com"}},
+			"nextPageToken": "stuck",
+		})
+	}))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	got, err := fetchBackupAdminGroups(ctx, svc, "example.com")
+	if err == nil || !strings.Contains(err.Error(), "repeated page token") {
+		t.Fatalf("err = %v after %d list calls", err, calls.Load())
+	}
+	if got != nil {
+		t.Fatalf("groups = %#v, want no partial result", got)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("list calls = %d, want 2", got)
+	}
+	t.Logf("err = %v after %d list calls", err, calls.Load())
+}
+
+func TestFetchBackupKeepNotesRejectsRepeatedPageToken(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/v1/notes" {
+			http.NotFound(w, r)
+			return
+		}
+		n := calls.Add(1)
+		if n > 2 {
+			http.Error(w, "unexpected extra keep note page request", http.StatusBadRequest)
+			return
+		}
+		wantToken := ""
+		if n == 2 {
+			wantToken = "stuck"
+		}
+		requireQuery(t, r, "pageToken", wantToken)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"notes":         []map[string]any{{"name": "notes/abc"}},
+			"nextPageToken": "stuck",
+		})
+	}))
+	t.Cleanup(srv.Close)
+	svc := newKeepTestServiceFromServer(t, srv)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	got, err := fetchBackupKeepNotes(ctx, svc)
+	if err == nil || !strings.Contains(err.Error(), "repeated page token") {
+		t.Fatalf("err = %v after %d list calls", err, calls.Load())
+	}
+	if got != nil {
+		t.Fatalf("notes = %#v, want no partial result", got)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("list calls = %d, want 2", got)
+	}
+	t.Logf("err = %v after %d list calls", err, calls.Load())
+}
+
+func TestFetchBackupAdminUsersTwoDistinctPagesSucceed(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	svc := newAdminTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !strings.HasSuffix(r.URL.Path, "/users") {
+			http.NotFound(w, r)
+			return
+		}
+		n := calls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		if n == 1 {
+			requireQuery(t, r, "pageToken", "")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"users":         []map[string]any{{"primaryEmail": "zoe@example.com"}},
+				"nextPageToken": "page-2",
+			})
+			return
+		}
+		if n == 2 {
+			requireQuery(t, r, "pageToken", "page-2")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"users": []map[string]any{{"primaryEmail": "ada@example.com"}},
+			})
+			return
+		}
+		http.Error(w, "unexpected extra user page request", http.StatusBadRequest)
+	}))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	got, err := fetchBackupAdminUsers(ctx, svc, "example.com")
+	if err != nil {
+		t.Fatalf("err = %v after %d list calls", err, calls.Load())
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("list calls = %d, want 2", calls.Load())
+	}
+	if len(got) != 2 || got[0].PrimaryEmail != "ada@example.com" || got[1].PrimaryEmail != "zoe@example.com" {
+		t.Fatalf("users = %#v, want sorted ada then zoe", got)
+	}
+}
+
+func TestFetchBackupKeepNotesTwoDistinctPagesSucceed(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/v1/notes" {
+			http.NotFound(w, r)
+			return
+		}
+		n := calls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		if n == 1 {
+			requireQuery(t, r, "pageToken", "")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"notes":         []map[string]any{{"name": "notes/zzz"}},
+				"nextPageToken": "page-2",
+			})
+			return
+		}
+		if n == 2 {
+			requireQuery(t, r, "pageToken", "page-2")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"notes": []map[string]any{{"name": "notes/aaa"}},
+			})
+			return
+		}
+		http.Error(w, "unexpected extra keep note page request", http.StatusBadRequest)
+	}))
+	t.Cleanup(srv.Close)
+	svc := newKeepTestServiceFromServer(t, srv)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	got, err := fetchBackupKeepNotes(ctx, svc)
+	if err != nil {
+		t.Fatalf("err = %v after %d list calls", err, calls.Load())
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("list calls = %d, want 2", calls.Load())
+	}
+	if len(got) != 2 || got[0].Name != "notes/aaa" || got[1].Name != "notes/zzz" {
+		t.Fatalf("notes = %#v, want sorted aaa then zzz", got)
+	}
+}

--- a/internal/cmd/backup_directory_keep_test.go
+++ b/internal/cmd/backup_directory_keep_test.go
@@ -98,18 +98,16 @@ func TestFetchBackupCloudIdentityGroupMembersRejectsRepeatedPageToken(t *testing
 	t.Logf("member error = %s after %d list calls", got[0].Error, listCalls.Load())
 }
 
-func TestFetchBackupAdminUsersRejectsRepeatedPageToken(t *testing.T) {
-	t.Parallel()
-
-	var calls atomic.Int32
-	svc := newAdminTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodGet || !strings.HasSuffix(r.URL.Path, "/users") {
+func newStuckAdminBackupHandler(t *testing.T, calls *atomic.Int32, suffix, extra, key string, item map[string]any) http.Handler {
+	t.Helper()
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !strings.HasSuffix(r.URL.Path, suffix) {
 			http.NotFound(w, r)
 			return
 		}
 		n := calls.Add(1)
 		if n > 2 {
-			http.Error(w, "unexpected extra user page request", http.StatusBadRequest)
+			http.Error(w, extra, http.StatusBadRequest)
 			return
 		}
 		wantToken := ""
@@ -120,10 +118,17 @@ func TestFetchBackupAdminUsersRejectsRepeatedPageToken(t *testing.T) {
 		requireQuery(t, r, "domain", "example.com")
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
-			"users":         []map[string]any{{"primaryEmail": "ada@example.com"}},
+			key:             []map[string]any{item},
 			"nextPageToken": "stuck",
 		})
-	}))
+	})
+}
+
+func TestFetchBackupAdminUsersRejectsRepeatedPageToken(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	svc := newAdminTestService(t, newStuckAdminBackupHandler(t, &calls, "/users", "unexpected extra user page request", "users", map[string]any{"primaryEmail": "ada@example.com"}))
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -144,28 +149,7 @@ func TestFetchBackupAdminGroupsRejectsRepeatedPageToken(t *testing.T) {
 	t.Parallel()
 
 	var calls atomic.Int32
-	svc := newAdminTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodGet || !strings.HasSuffix(r.URL.Path, "/groups") {
-			http.NotFound(w, r)
-			return
-		}
-		n := calls.Add(1)
-		if n > 2 {
-			http.Error(w, "unexpected extra admin group page request", http.StatusBadRequest)
-			return
-		}
-		wantToken := ""
-		if n == 2 {
-			wantToken = "stuck"
-		}
-		requireQuery(t, r, "pageToken", wantToken)
-		requireQuery(t, r, "domain", "example.com")
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"groups":        []map[string]any{{"email": "eng@example.com"}},
-			"nextPageToken": "stuck",
-		})
-	}))
+	svc := newAdminTestService(t, newStuckAdminBackupHandler(t, &calls, "/groups", "unexpected extra admin group page request", "groups", map[string]any{"email": "eng@example.com"}))
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()


### PR DESCRIPTION
## What Problem This Solves

`gog backup push` with Groups, Admin, or Keep walks Google page tokens in `internal/cmd/backup_directory_keep.go`. Five helpers copied `nextPageToken` into the next request with no seen-set: Cloud Identity group search, Cloud Identity memberships, Admin users, Admin groups, and Keep notes.

When Google repeats a continuation token, those loops never terminate. Backup collection keeps requesting the same page and never finishes the snapshot.

Admin group members in the same file already use `loadPagedItems`, which calls `collectAllPages`. Interactive Groups and Admin listing already use that helper too. Backup listing for Groups, Admin users/groups, and Keep was still on the unguarded loop.

The same hang class is already closed for Chat and Classroom backup (#1063), Drive sync push listing (#1065), Drive audit permission listing (#1066), calendar and Gmail listing (#1004), and People/Gmail-from-contact/contacts-export listing (#1044, #1045, #1046). Drive backup listing is the open sibling #1078 (different file). This change does not touch `backup_drive.go`.

The unguarded loops landed in [`efc3df2e`](https://github.com/openclaw/gogcli/commit/efc3df2e) (2026-04-27, `feat(backup): expand google backup coverage`).

## Evidence

terminal output from the compiled `internal/cmd` listing binary after the patch. A stuck continuation token is rejected after two list calls, with no third request:

```console
$ gogcli-backup-paging.exe -test.run TestFetchBackupCloudIdentityGroupsRejectsRepeatedPageToken -test.v
    backup_directory_keep_test.go:54: err = pagination loop: repeated page token "stuck" after 2 list calls

$ gogcli-backup-paging.exe -test.run TestFetchBackupAdminUsersRejectsRepeatedPageToken -test.v
    backup_directory_keep_test.go:140: err = pagination loop: repeated page token "stuck" after 2 list calls

$ gogcli-backup-paging.exe -test.run TestFetchBackupKeepNotesRejectsRepeatedPageToken -test.v
    backup_directory_keep_test.go:225: err = pagination loop: repeated page token "stuck" after 2 list calls
```

Before the patch, the same stuck token made a third list request and returned HTTP 400 from the safety cap (`unexpected extra ... page request after 3 list calls`) instead of stopping on the repeated token.

## Real behavior proof

- **Behavior or issue addressed:** Groups, Admin, and Keep backup listing hung when Google repeated a page token. `gog backup push` with those services never finished those listings.
- **Real environment tested:** Windows, Go 1.27.1, branch `fix/backup-directory-page-token` at current HEAD, compiled `internal/cmd` listing binary.
- **Exact steps or command run after this patch:** Compiled the listing binary with `go`, then ran `gogcli-backup-paging.exe` with `-test.v` on the Groups, Admin users, Admin groups, Keep notes, and Cloud Identity membership hang-guard cases.
- **Evidence after fix:** terminal output from that binary shows `pagination loop: repeated page token "stuck"` after 2 list calls for Cloud Identity groups, Admin users, Admin groups, Keep notes, and Cloud Identity memberships.
- **Observed result after fix:** A repeated Groups, Admin, or Keep backup page token now stops with the shared paginator error after two requests. Distinct pages still concatenate. Admin users stay sorted by primary email. Keep notes stay sorted by name.
- **What was not tested:** Live Google Workspace Groups, Admin Directory, or Keep accounts. Drive backup listing is #1078, not this change.
