### PR TITLE
fix(backup): reject repeated Drive collaboration page tokens

### DIFF
--- a/internal/cmd/backup_drive_collaboration.go
+++ b/internal/cmd/backup_drive_collaboration.go
@@ -147,9 +147,7 @@ func fetchBackupDriveFileCollaboration(ctx context.Context, svc *drive.Service, 
 }
 
 func fetchBackupDrivePermissions(ctx context.Context, svc *drive.Service, fileID string) ([]*drive.Permission, error) {
-	var out []*drive.Permission
-	pageToken := ""
-	for {
+	out, err := collectAllPages("", func(pageToken string) ([]*drive.Permission, string, error) {
 		call := svc.Permissions.List(fileID).
 			PageSize(100).
 			SupportsAllDrives(true).
@@ -160,44 +158,32 @@ func fetchBackupDrivePermissions(ctx context.Context, svc *drive.Service, fileID
 		}
 		resp, err := call.Do()
 		if err != nil {
-			return nil, fmt.Errorf("drive file %s permissions: %w", fileID, err)
+			return nil, "", err
 		}
-		out = append(out, resp.Permissions...)
-		if resp.NextPageToken == "" {
-			break
-		}
-		pageToken = resp.NextPageToken
+		return resp.Permissions, resp.NextPageToken, nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("drive file %s permissions: %w", fileID, err)
 	}
 	return out, nil
 }
 
 func fetchBackupDriveComments(ctx context.Context, svc *drive.Service, fileID string) ([]*drive.Comment, error) {
-	var out []*drive.Comment
-	pageToken := ""
-	for {
-		comments, nextPageToken, err := listDriveComments(ctx, svc, fileID, driveCommentListOptions{
-			includeResolved: true,
-			includeQuoted:   true,
-			page:            pageToken,
-			max:             100,
-			mode:            driveCommentListModeExpanded,
-		})
-		if err != nil {
-			return nil, fmt.Errorf("drive file %s comments: %w", fileID, err)
-		}
-		out = append(out, comments...)
-		if nextPageToken == "" {
-			break
-		}
-		pageToken = nextPageToken
+	comments, _, err := listDriveComments(ctx, svc, fileID, driveCommentListOptions{
+		includeResolved: true,
+		includeQuoted:   true,
+		max:             100,
+		mode:            driveCommentListModeExpanded,
+		all:             true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("drive file %s comments: %w", fileID, err)
 	}
-	return out, nil
+	return comments, nil
 }
 
 func fetchBackupDriveRevisions(ctx context.Context, svc *drive.Service, fileID string) ([]*drive.Revision, error) {
-	var out []*drive.Revision
-	pageToken := ""
-	for {
+	out, err := collectAllPages("", func(pageToken string) ([]*drive.Revision, string, error) {
 		call := svc.Revisions.List(fileID).
 			PageSize(200).
 			Fields(gapi.Field(driveRevisionListFields)).
@@ -207,13 +193,12 @@ func fetchBackupDriveRevisions(ctx context.Context, svc *drive.Service, fileID s
 		}
 		resp, err := call.Do()
 		if err != nil {
-			return nil, fmt.Errorf("drive file %s revisions: %w", fileID, err)
+			return nil, "", err
 		}
-		out = append(out, resp.Revisions...)
-		if resp.NextPageToken == "" {
-			break
-		}
-		pageToken = resp.NextPageToken
+		return resp.Revisions, resp.NextPageToken, nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("drive file %s revisions: %w", fileID, err)
 	}
 	return out, nil
 }

--- a/internal/cmd/backup_drive_collaboration_test.go
+++ b/internal/cmd/backup_drive_collaboration_test.go
@@ -1,0 +1,247 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"google.golang.org/api/drive/v3"
+)
+
+type backupCollabPageCase struct {
+	name     string
+	path     string
+	pageSize string
+	key      string
+	item1    map[string]any
+	item2    map[string]any
+	extra    func(*testing.T, *http.Request)
+	ids      func(t *testing.T, ctx context.Context, svc *drive.Service) ([]string, error)
+}
+
+func backupCollabPageCases() []backupCollabPageCase {
+	return []backupCollabPageCase{
+		{
+			name:     "permissions",
+			path:     "/files/file-1/permissions",
+			pageSize: "100",
+			key:      "permissions",
+			item1:    map[string]any{"id": "perm-1", "type": "user", "role": "reader"},
+			item2:    map[string]any{"id": "perm-2", "type": "user", "role": "writer"},
+			extra:    requireSupportsAllDrives,
+			ids: func(t *testing.T, ctx context.Context, svc *drive.Service) ([]string, error) {
+				t.Helper()
+				got, err := fetchBackupDrivePermissions(ctx, svc, "file-1")
+				if err != nil {
+					return nil, err
+				}
+				out := make([]string, len(got))
+				for i, item := range got {
+					out[i] = item.Id
+				}
+				return out, nil
+			},
+		},
+		{
+			name:     "comments",
+			path:     "/files/file-1/comments",
+			pageSize: "100",
+			key:      "comments",
+			item1:    map[string]any{"id": "comment-1", "content": "hello"},
+			item2:    map[string]any{"id": "comment-2", "content": "second"},
+			ids: func(t *testing.T, ctx context.Context, svc *drive.Service) ([]string, error) {
+				t.Helper()
+				got, err := fetchBackupDriveComments(ctx, svc, "file-1")
+				if err != nil {
+					return nil, err
+				}
+				out := make([]string, len(got))
+				for i, item := range got {
+					out[i] = item.Id
+				}
+				return out, nil
+			},
+		},
+		{
+			name:     "revisions",
+			path:     "/files/file-1/revisions",
+			pageSize: "200",
+			key:      "revisions",
+			item1:    map[string]any{"id": "rev-1", "modifiedTime": "2026-04-01T10:00:00Z"},
+			item2:    map[string]any{"id": "rev-2", "modifiedTime": "2026-04-02T10:00:00Z"},
+			ids: func(t *testing.T, ctx context.Context, svc *drive.Service) ([]string, error) {
+				t.Helper()
+				got, err := fetchBackupDriveRevisions(ctx, svc, "file-1")
+				if err != nil {
+					return nil, err
+				}
+				out := make([]string, len(got))
+				for i, item := range got {
+					out[i] = item.Id
+				}
+				return out, nil
+			},
+		},
+	}
+}
+
+func TestFetchBackupDriveCollaborationRejectsRepeatedPageToken(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range backupCollabPageCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var calls atomic.Int32
+			svc, closeSvc := newDriveTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodGet || !strings.HasSuffix(r.URL.Path, tc.path) {
+					http.NotFound(w, r)
+					return
+				}
+				n := calls.Add(1)
+				if n > 2 {
+					http.Error(w, "unexpected extra "+tc.name+" page request", http.StatusBadRequest)
+					return
+				}
+				wantToken := ""
+				if n == 2 {
+					wantToken = "stuck"
+				}
+				requireQuery(t, r, "pageToken", wantToken)
+				requireQuery(t, r, "pageSize", tc.pageSize)
+				if tc.extra != nil {
+					tc.extra(t, r)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					tc.key:          []map[string]any{tc.item1},
+					"nextPageToken": "stuck",
+				})
+			}))
+			defer closeSvc()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			got, err := tc.ids(t, ctx, svc)
+			if err == nil || !strings.Contains(err.Error(), "repeated page token") {
+				t.Fatalf("err = %v after %d list calls", err, calls.Load())
+			}
+			if got != nil {
+				t.Fatalf("%s = %#v, want no partial result", tc.name, got)
+			}
+			if n := calls.Load(); n != 2 {
+				t.Fatalf("list calls = %d, want 2", n)
+			}
+			t.Logf("err = %v after %d list calls", err, calls.Load())
+		})
+	}
+}
+
+func TestFetchBackupDriveCollaborationTwoDistinctPagesSucceed(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range backupCollabPageCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var calls atomic.Int32
+			svc, closeSvc := newDriveTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodGet || !strings.HasSuffix(r.URL.Path, tc.path) {
+					http.NotFound(w, r)
+					return
+				}
+				n := calls.Add(1)
+				if tc.extra != nil {
+					tc.extra(t, r)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				if n == 1 {
+					requireQuery(t, r, "pageToken", "")
+					_ = json.NewEncoder(w).Encode(map[string]any{
+						tc.key:          []map[string]any{tc.item1},
+						"nextPageToken": "page-2",
+					})
+					return
+				}
+				if n == 2 {
+					requireQuery(t, r, "pageToken", "page-2")
+					_ = json.NewEncoder(w).Encode(map[string]any{
+						tc.key: []map[string]any{tc.item2},
+					})
+					return
+				}
+				http.Error(w, "unexpected extra "+tc.name+" page request", http.StatusBadRequest)
+			}))
+			defer closeSvc()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			got, err := tc.ids(t, ctx, svc)
+			if err != nil {
+				t.Fatalf("err = %v after %d list calls", err, calls.Load())
+			}
+			if calls.Load() != 2 {
+				t.Fatalf("list calls = %d, want 2", calls.Load())
+			}
+			want1, _ := tc.item1["id"].(string)
+			want2, _ := tc.item2["id"].(string)
+			if len(got) != 2 || got[0] != want1 || got[1] != want2 {
+				t.Fatalf("%s = %#v, want both pages concatenated", tc.name, got)
+			}
+		})
+	}
+}
+
+func TestFetchBackupDriveCollaborationRecordsRepeatedPageToken(t *testing.T) {
+	t.Parallel()
+
+	var permCalls atomic.Int32
+	svc, closeSvc := newDriveTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/files/file-1/permissions"):
+			n := permCalls.Add(1)
+			if n > 2 {
+				http.Error(w, "unexpected extra permission page request", http.StatusBadRequest)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"permissions":   []map[string]any{{"id": "perm-1", "type": "user", "role": "reader"}},
+				"nextPageToken": "stuck",
+			})
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/files/file-1/comments"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"comments": []map[string]any{{"id": "comment-1", "content": "hello"}},
+			})
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/files/file-1/revisions"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"revisions": []map[string]any{{"id": "rev-1", "modifiedTime": "2026-04-02T10:00:00Z"}},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer closeSvc()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	got, counts := fetchBackupDriveCollaboration(ctx, svc, []driveBackupFile{
+		{File: &drive.File{Id: "file-1"}},
+	})
+	if permCalls.Load() != 2 {
+		t.Fatalf("permission list calls = %d, want 2", permCalls.Load())
+	}
+	if counts["drive.collab.errors"] != 1 || counts["drive.comments"] != 1 || counts["drive.revisions"] != 1 {
+		t.Fatalf("unexpected counts: %#v", counts)
+	}
+	if len(got.Permissions) != 1 || got.Permissions[0].FileID != "file-1" || !strings.Contains(got.Permissions[0].Error, "repeated page token") {
+		t.Fatalf("permission row = %#v, want repeated page token error", got.Permissions)
+	}
+	if len(got.Comments) != 1 || got.Comments[0].Comment == nil || got.Comments[0].Comment.Id != "comment-1" {
+		t.Fatalf("comments = %#v", got.Comments)
+	}
+}


### PR DESCRIPTION
## What Problem This Solves

`gog backup push --drive-collaboration` lists Drive permissions, comments, and revisions for each file. The three helpers in `internal/cmd/backup_drive_collaboration.go` copied `nextPageToken` into the next request with no seen-set.

When Drive repeats a continuation token, those loops never terminate. Backup collection keeps requesting the same permission, comment, or revision page and never finishes the collaboration snapshot.

The same hang class is already closed for Chat and Classroom backup (#1063), Drive sync push listing (#1065), Drive audit permission listing (#1066), calendar and Gmail listing (#1004), and People/Gmail-from-contact/contacts-export listing (#1044, #1045, #1046). Drive backup file listing is covered separately in #1078. Collaboration listing was still on the unguarded loop.

## Evidence

terminal output from the compiled `internal/cmd` listing binary after the patch. A stuck continuation token is rejected after two list calls, with no third request:

```console
$ gogcli-backup-collab-paging.exe -test.run TestFetchBackupDriveCollaborationRejectsRepeatedPageToken -test.v
    backup_drive_collaboration_test.go:139: err = drive file file-1 comments: pagination loop: repeated page token "stuck" after 2 list calls
    backup_drive_collaboration_test.go:139: err = drive file file-1 revisions: pagination loop: repeated page token "stuck" after 2 list calls
    backup_drive_collaboration_test.go:139: err = drive file file-1 permissions: pagination loop: repeated page token "stuck" after 2 list calls
```

Before the patch, the same stuck token made a third list request and returned HTTP 400 from the safety cap (`unexpected extra ... page request after 3 list calls`) instead of stopping on the repeated token.

## Real behavior proof

- **Behavior or issue addressed:** Drive backup collaboration listing hung when Google repeated a page token. `gog backup push --drive-collaboration` never finished permission, comment, or revision pages.
- **Real environment tested:** Windows, Go 1.27.1, branch `fix/backup-collab-page-token` at current HEAD, compiled `internal/cmd` listing binary against a local httptest Drive endpoint.
- **Exact steps or command run after this patch:** Compiled the listing binary with `go`, then ran `gogcli-backup-collab-paging.exe` with `-test.v` on the permission, comment, and revision hang-guard cases.
- **Evidence after fix:** terminal output from that binary shows `pagination loop: repeated page token "stuck"` after 2 list calls for permissions, comments, and revisions.
- **Observed result after fix:** A repeated Drive collaboration page token now fails closed with the shared paginator error after two requests. Distinct pages still concatenate. Comments reuse `listDriveComments` with `all: true`. Permission listing still sends `supportsAllDrives=true` and `pageSize=100`. Revision listing still uses `pageSize=200`.
- **What was not tested:** A live Google Drive account with a real repeated token. Encrypted shard write after the listing error.

## Summary

Route `fetchBackupDrivePermissions` and `fetchBackupDriveRevisions` through existing `collectAllPages`. Reuse `listDriveComments` with `all: true` for comments. Keep the original field lists, page sizes, and shared-drive flags.

Related: #1063, #1065, #1066, #1004, #1044, #1045, #1046, #1078.

Introduced in `efc3df2e` (2026-04-27, `feat(backup): expand google backup coverage`).
