### PR TITLE
fix(backup): reject repeated Calendar Contacts Tasks page tokens

### DIFF
--- a/internal/cmd/backup_services.go
+++ b/internal/cmd/backup_services.go
@@ -209,24 +209,23 @@ func fetchBackupCalendarACLRules(ctx context.Context, svc *calendar.Service, cal
 		if cal == nil || strings.TrimSpace(cal.Id) == "" {
 			continue
 		}
-		pageToken := ""
-		for {
+		rules, err := collectAllPages("", func(pageToken string) ([]*calendar.AclRule, string, error) {
 			call := svc.Acl.List(cal.Id).MaxResults(250).Context(ctx)
 			if pageToken != "" {
 				call = call.PageToken(pageToken)
 			}
 			resp, err := call.Do()
 			if err != nil {
-				out = append(out, calendarBackupACLRule{CalendarID: cal.Id, Error: err.Error()})
-				break
+				return nil, "", err
 			}
-			for _, rule := range resp.Items {
-				out = append(out, calendarBackupACLRule{CalendarID: cal.Id, Rule: rule})
-			}
-			if resp.NextPageToken == "" {
-				break
-			}
-			pageToken = resp.NextPageToken
+			return resp.Items, resp.NextPageToken, nil
+		})
+		if err != nil {
+			out = append(out, calendarBackupACLRule{CalendarID: cal.Id, Error: err.Error()})
+			continue
+		}
+		for _, rule := range rules {
+			out = append(out, calendarBackupACLRule{CalendarID: cal.Id, Rule: rule})
 		}
 	}
 	sort.Slice(out, func(i, j int) bool {
@@ -239,22 +238,19 @@ func fetchBackupCalendarACLRules(ctx context.Context, svc *calendar.Service, cal
 }
 
 func fetchBackupCalendarSettings(ctx context.Context, svc *calendar.Service) ([]*calendar.Setting, error) {
-	var out []*calendar.Setting
-	pageToken := ""
-	for {
+	out, err := collectAllPages("", func(pageToken string) ([]*calendar.Setting, string, error) {
 		call := svc.Settings.List().MaxResults(250).Context(ctx)
 		if pageToken != "" {
 			call = call.PageToken(pageToken)
 		}
 		resp, err := call.Do()
 		if err != nil {
-			return nil, err
+			return nil, "", err
 		}
-		out = append(out, resp.Items...)
-		if resp.NextPageToken == "" {
-			break
-		}
-		pageToken = resp.NextPageToken
+		return resp.Items, resp.NextPageToken, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Id < out[j].Id })
 	return out, nil
@@ -312,22 +308,19 @@ func buildTasksBackupSnapshot(ctx context.Context, flags *RootFlags, shardMaxRow
 }
 
 func fetchBackupCalendars(ctx context.Context, svc *calendar.Service) ([]*calendar.CalendarListEntry, error) {
-	var out []*calendar.CalendarListEntry
-	pageToken := ""
-	for {
+	out, err := collectAllPages("", func(pageToken string) ([]*calendar.CalendarListEntry, string, error) {
 		call := svc.CalendarList.List().MaxResults(250).Context(ctx)
 		if pageToken != "" {
 			call = call.PageToken(pageToken)
 		}
 		resp, err := call.Do()
 		if err != nil {
-			return nil, err
+			return nil, "", err
 		}
-		out = append(out, resp.Items...)
-		if resp.NextPageToken == "" {
-			break
-		}
-		pageToken = resp.NextPageToken
+		return resp.Items, resp.NextPageToken, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Id < out[j].Id })
 	return out, nil
@@ -339,8 +332,7 @@ func fetchBackupCalendarEvents(ctx context.Context, svc *calendar.Service, calen
 		if cal == nil || strings.TrimSpace(cal.Id) == "" {
 			continue
 		}
-		pageToken := ""
-		for {
+		events, err := collectAllPages("", func(pageToken string) ([]*calendar.Event, string, error) {
 			call := svc.Events.List(cal.Id).
 				MaxResults(2500).
 				ShowDeleted(true).
@@ -351,15 +343,15 @@ func fetchBackupCalendarEvents(ctx context.Context, svc *calendar.Service, calen
 			}
 			resp, err := call.Do()
 			if err != nil {
-				return nil, fmt.Errorf("calendar %s events: %w", cal.Id, err)
+				return nil, "", fmt.Errorf("calendar %s events: %w", cal.Id, err)
 			}
-			for _, event := range resp.Items {
-				out = append(out, calendarBackupEvent{CalendarID: cal.Id, Event: event})
-			}
-			if resp.NextPageToken == "" {
-				break
-			}
-			pageToken = resp.NextPageToken
+			return resp.Items, resp.NextPageToken, nil
+		})
+		if err != nil {
+			return nil, err
+		}
+		for _, event := range events {
+			out = append(out, calendarBackupEvent{CalendarID: cal.Id, Event: event})
 		}
 	}
 	sort.Slice(out, func(i, j int) bool {
@@ -372,9 +364,7 @@ func fetchBackupCalendarEvents(ctx context.Context, svc *calendar.Service, calen
 }
 
 func fetchBackupConnections(ctx context.Context, svc *people.Service) ([]contactsBackupPerson, error) {
-	var out []contactsBackupPerson
-	pageToken := ""
-	for {
+	peopleRows, err := collectAllPages("", func(pageToken string) ([]*people.Person, string, error) {
 		call := svc.People.Connections.List(peopleMeResource).
 			PersonFields(contactsGetReadMask).
 			PageSize(1000).
@@ -384,15 +374,16 @@ func fetchBackupConnections(ctx context.Context, svc *people.Service) ([]contact
 		}
 		resp, err := call.Do()
 		if err != nil {
-			return nil, err
+			return nil, "", err
 		}
-		for _, person := range resp.Connections {
-			out = append(out, contactsBackupPerson{Source: "connections", Person: person})
-		}
-		if resp.NextPageToken == "" {
-			break
-		}
-		pageToken = resp.NextPageToken
+		return resp.Connections, resp.NextPageToken, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]contactsBackupPerson, 0, len(peopleRows))
+	for _, person := range peopleRows {
+		out = append(out, contactsBackupPerson{Source: "connections", Person: person})
 	}
 	return out, nil
 }
@@ -400,9 +391,7 @@ func fetchBackupConnections(ctx context.Context, svc *people.Service) ([]contact
 func fetchBackupOtherContacts(ctx context.Context, svc *people.Service) ([]contactsBackupPerson, error) {
 	const otherContactsBackupReadMask = "names,emailAddresses,phoneNumbers"
 
-	var out []contactsBackupPerson
-	pageToken := ""
-	for {
+	peopleRows, err := collectAllPages("", func(pageToken string) ([]*people.Person, string, error) {
 		call := svc.OtherContacts.List().
 			ReadMask(otherContactsBackupReadMask).
 			PageSize(1000).
@@ -412,23 +401,22 @@ func fetchBackupOtherContacts(ctx context.Context, svc *people.Service) ([]conta
 		}
 		resp, err := call.Do()
 		if err != nil {
-			return nil, err
+			return nil, "", err
 		}
-		for _, person := range resp.OtherContacts {
-			out = append(out, contactsBackupPerson{Source: "other", Person: person})
-		}
-		if resp.NextPageToken == "" {
-			break
-		}
-		pageToken = resp.NextPageToken
+		return resp.OtherContacts, resp.NextPageToken, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]contactsBackupPerson, 0, len(peopleRows))
+	for _, person := range peopleRows {
+		out = append(out, contactsBackupPerson{Source: "other", Person: person})
 	}
 	return out, nil
 }
 
 func fetchBackupContactGroups(ctx context.Context, svc *people.Service) ([]*people.ContactGroup, error) {
-	var out []*people.ContactGroup
-	pageToken := ""
-	for {
+	out, err := collectAllPages("", func(pageToken string) ([]*people.ContactGroup, string, error) {
 		call := svc.ContactGroups.List().
 			PageSize(1000).
 			GroupFields("clientData,groupType,memberCount,metadata,name").
@@ -438,35 +426,31 @@ func fetchBackupContactGroups(ctx context.Context, svc *people.Service) ([]*peop
 		}
 		resp, err := call.Do()
 		if err != nil {
-			return nil, err
+			return nil, "", err
 		}
-		out = append(out, resp.ContactGroups...)
-		if resp.NextPageToken == "" {
-			break
-		}
-		pageToken = resp.NextPageToken
+		return resp.ContactGroups, resp.NextPageToken, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
 	return out, nil
 }
 
 func fetchBackupTaskLists(ctx context.Context, svc *tasks.Service) ([]*tasks.TaskList, error) {
-	var out []*tasks.TaskList
-	pageToken := ""
-	for {
+	out, err := collectAllPages("", func(pageToken string) ([]*tasks.TaskList, string, error) {
 		call := svc.Tasklists.List().MaxResults(100).Context(ctx)
 		if pageToken != "" {
 			call = call.PageToken(pageToken)
 		}
 		resp, err := call.Do()
 		if err != nil {
-			return nil, err
+			return nil, "", err
 		}
-		out = append(out, resp.Items...)
-		if resp.NextPageToken == "" {
-			break
-		}
-		pageToken = resp.NextPageToken
+		return resp.Items, resp.NextPageToken, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Id < out[j].Id })
 	return out, nil
@@ -478,8 +462,7 @@ func fetchBackupTasks(ctx context.Context, svc *tasks.Service, lists []*tasks.Ta
 		if list == nil || strings.TrimSpace(list.Id) == "" {
 			continue
 		}
-		pageToken := ""
-		for {
+		items, err := collectAllPages("", func(pageToken string) ([]*tasks.Task, string, error) {
 			call := svc.Tasks.List(list.Id).
 				MaxResults(100).
 				ShowCompleted(true).
@@ -492,15 +475,15 @@ func fetchBackupTasks(ctx context.Context, svc *tasks.Service, lists []*tasks.Ta
 			}
 			resp, err := call.Do()
 			if err != nil {
-				return nil, fmt.Errorf("task list %s tasks: %w", list.Id, err)
+				return nil, "", fmt.Errorf("task list %s tasks: %w", list.Id, err)
 			}
-			for _, task := range resp.Items {
-				out = append(out, tasksBackupTask{TaskListID: list.Id, Task: task})
-			}
-			if resp.NextPageToken == "" {
-				break
-			}
-			pageToken = resp.NextPageToken
+			return resp.Items, resp.NextPageToken, nil
+		})
+		if err != nil {
+			return nil, err
+		}
+		for _, task := range items {
+			out = append(out, tasksBackupTask{TaskListID: list.Id, Task: task})
 		}
 	}
 	sort.Slice(out, func(i, j int) bool {

--- a/internal/cmd/backup_services_test.go
+++ b/internal/cmd/backup_services_test.go
@@ -15,8 +15,6 @@ import (
 )
 
 func TestFetchBackupCalendarsRejectsRepeatedPageToken(t *testing.T) {
-	t.Parallel()
-
 	var calls atomic.Int32
 	svc, closeSvc := newCalendarServiceForTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet || !strings.Contains(r.URL.Path, "/calendarList") {
@@ -57,8 +55,6 @@ func TestFetchBackupCalendarsRejectsRepeatedPageToken(t *testing.T) {
 }
 
 func TestFetchBackupConnectionsRejectsRepeatedPageToken(t *testing.T) {
-	t.Parallel()
-
 	var calls atomic.Int32
 	svc, closeSvc := newGoogleTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet || !strings.Contains(r.URL.Path, "people/me/connections") {
@@ -99,8 +95,6 @@ func TestFetchBackupConnectionsRejectsRepeatedPageToken(t *testing.T) {
 }
 
 func TestFetchBackupTaskListsRejectsRepeatedPageToken(t *testing.T) {
-	t.Parallel()
-
 	var calls atomic.Int32
 	svc, closeSvc := newGoogleTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet || !strings.HasSuffix(r.URL.Path, "/users/@me/lists") {
@@ -141,8 +135,6 @@ func TestFetchBackupTaskListsRejectsRepeatedPageToken(t *testing.T) {
 }
 
 func TestFetchBackupCalendarsTwoDistinctPagesSucceed(t *testing.T) {
-	t.Parallel()
-
 	var calls atomic.Int32
 	svc, closeSvc := newCalendarServiceForTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet || !strings.Contains(r.URL.Path, "/calendarList") {
@@ -185,8 +177,6 @@ func TestFetchBackupCalendarsTwoDistinctPagesSucceed(t *testing.T) {
 }
 
 func TestFetchBackupCalendarEventsRejectsRepeatedPageToken(t *testing.T) {
-	t.Parallel()
-
 	var calls atomic.Int32
 	svc, closeSvc := newCalendarServiceForTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet || !strings.Contains(r.URL.Path, "/calendars/cal-1/events") {

--- a/internal/cmd/backup_services_test.go
+++ b/internal/cmd/backup_services_test.go
@@ -1,0 +1,227 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"google.golang.org/api/calendar/v3"
+	"google.golang.org/api/people/v1"
+	"google.golang.org/api/tasks/v1"
+)
+
+func TestFetchBackupCalendarsRejectsRepeatedPageToken(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	svc, closeSvc := newCalendarServiceForTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !strings.Contains(r.URL.Path, "/calendarList") {
+			http.NotFound(w, r)
+			return
+		}
+		n := calls.Add(1)
+		if n > 2 {
+			http.Error(w, "unexpected extra calendar page request", http.StatusBadRequest)
+			return
+		}
+		wantToken := ""
+		if n == 2 {
+			wantToken = "stuck"
+		}
+		requireQuery(t, r, "pageToken", wantToken)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"items":         []map[string]any{{"id": "cal-1", "summary": "Work"}},
+			"nextPageToken": "stuck",
+		})
+	}))
+	defer closeSvc()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	got, err := fetchBackupCalendars(ctx, svc)
+	if err == nil || !strings.Contains(err.Error(), "repeated page token") {
+		t.Fatalf("err = %v after %d list calls", err, calls.Load())
+	}
+	if got != nil {
+		t.Fatalf("calendars = %#v, want no partial result", got)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("list calls = %d, want 2", got)
+	}
+	t.Logf("err = %v after %d list calls", err, calls.Load())
+}
+
+func TestFetchBackupConnectionsRejectsRepeatedPageToken(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	svc, closeSvc := newGoogleTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !strings.Contains(r.URL.Path, "people/me/connections") {
+			http.NotFound(w, r)
+			return
+		}
+		n := calls.Add(1)
+		if n > 2 {
+			http.Error(w, "unexpected extra connections page request", http.StatusBadRequest)
+			return
+		}
+		wantToken := ""
+		if n == 2 {
+			wantToken = "stuck"
+		}
+		requireQuery(t, r, "pageToken", wantToken)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"connections":   []map[string]any{{"resourceName": "people/c1"}},
+			"nextPageToken": "stuck",
+		})
+	}), people.NewService)
+	defer closeSvc()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	got, err := fetchBackupConnections(ctx, svc)
+	if err == nil || !strings.Contains(err.Error(), "repeated page token") {
+		t.Fatalf("err = %v after %d list calls", err, calls.Load())
+	}
+	if got != nil {
+		t.Fatalf("connections = %#v, want no partial result", got)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("list calls = %d, want 2", got)
+	}
+	t.Logf("err = %v after %d list calls", err, calls.Load())
+}
+
+func TestFetchBackupTaskListsRejectsRepeatedPageToken(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	svc, closeSvc := newGoogleTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !strings.HasSuffix(r.URL.Path, "/users/@me/lists") {
+			http.NotFound(w, r)
+			return
+		}
+		n := calls.Add(1)
+		if n > 2 {
+			http.Error(w, "unexpected extra task list page request", http.StatusBadRequest)
+			return
+		}
+		wantToken := ""
+		if n == 2 {
+			wantToken = "stuck"
+		}
+		requireQuery(t, r, "pageToken", wantToken)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"items":         []map[string]any{{"id": "list-1", "title": "Inbox"}},
+			"nextPageToken": "stuck",
+		})
+	}), tasks.NewService)
+	defer closeSvc()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	got, err := fetchBackupTaskLists(ctx, svc)
+	if err == nil || !strings.Contains(err.Error(), "repeated page token") {
+		t.Fatalf("err = %v after %d list calls", err, calls.Load())
+	}
+	if got != nil {
+		t.Fatalf("task lists = %#v, want no partial result", got)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("list calls = %d, want 2", got)
+	}
+	t.Logf("err = %v after %d list calls", err, calls.Load())
+}
+
+func TestFetchBackupCalendarsTwoDistinctPagesSucceed(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	svc, closeSvc := newCalendarServiceForTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !strings.Contains(r.URL.Path, "/calendarList") {
+			http.NotFound(w, r)
+			return
+		}
+		n := calls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		if n == 1 {
+			requireQuery(t, r, "pageToken", "")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"items":         []map[string]any{{"id": "zzz", "summary": "Late"}},
+				"nextPageToken": "page-2",
+			})
+			return
+		}
+		if n == 2 {
+			requireQuery(t, r, "pageToken", "page-2")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"items": []map[string]any{{"id": "aaa", "summary": "Early"}},
+			})
+			return
+		}
+		http.Error(w, "unexpected extra calendar page request", http.StatusBadRequest)
+	}))
+	defer closeSvc()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	got, err := fetchBackupCalendars(ctx, svc)
+	if err != nil {
+		t.Fatalf("err = %v after %d list calls", err, calls.Load())
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("list calls = %d, want 2", calls.Load())
+	}
+	if len(got) != 2 || got[0].Id != "aaa" || got[1].Id != "zzz" {
+		t.Fatalf("calendars = %#v, want sorted ids aaa then zzz", got)
+	}
+}
+
+func TestFetchBackupCalendarEventsRejectsRepeatedPageToken(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	svc, closeSvc := newCalendarServiceForTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !strings.Contains(r.URL.Path, "/calendars/cal-1/events") {
+			http.NotFound(w, r)
+			return
+		}
+		n := calls.Add(1)
+		if n > 2 {
+			http.Error(w, "unexpected extra event page request", http.StatusBadRequest)
+			return
+		}
+		wantToken := ""
+		if n == 2 {
+			wantToken = "stuck"
+		}
+		requireQuery(t, r, "pageToken", wantToken)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"items":         []map[string]any{{"id": "evt-1", "summary": "Standup"}},
+			"nextPageToken": "stuck",
+		})
+	}))
+	defer closeSvc()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	got, err := fetchBackupCalendarEvents(ctx, svc, []*calendar.CalendarListEntry{{Id: "cal-1"}})
+	if err == nil || !strings.Contains(err.Error(), "repeated page token") {
+		t.Fatalf("err = %v after %d list calls", err, calls.Load())
+	}
+	if got != nil {
+		t.Fatalf("events = %#v, want no partial result", got)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("list calls = %d, want 2", got)
+	}
+	t.Logf("err = %v after %d list calls", err, calls.Load())
+}


### PR DESCRIPTION
## What Problem This Solves

`gog backup push` with calendar, contacts, or tasks walks Google page tokens in nine list helpers in `internal/cmd/backup_services.go` (calendar ACL, settings, calendars, events, People connections, other contacts, contact groups, task lists, and tasks). Each helper copied `nextPageToken` into the next request with no seen-set.

When Calendar, People, or Tasks repeats a continuation token, those loops never terminate. Backup collection keeps requesting the same page and never finishes the snapshot.

The same hang class is already closed for Chat and Classroom backup (#1063), Drive backup listing (#1078), Groups/Admin/Keep backup listing (#1079), Drive collaboration listing (#1080), Drive sync and audit listing (#1065, #1066), interactive calendar listing (#1004), and People/Gmail-from-contact/contacts-export listing (#1044, #1045, #1046). Calendar, Contacts, and Tasks backup listing was still on the unguarded loop. Interactive `gog calendar` listing already uses `collectAllPages`; backup did not.

## Evidence

terminal output from the compiled `internal/cmd` listing binary after the patch. A stuck continuation token is rejected after two list calls, with no third request:

```console
$ gogcli-backup-services.exe -test.run TestFetchBackupCalendarsRejectsRepeatedPageToken -test.v
    backup_services_test.go:56: err = pagination loop: repeated page token "stuck" after 2 list calls

$ gogcli-backup-services.exe -test.run TestFetchBackupConnectionsRejectsRepeatedPageToken -test.v
    backup_services_test.go:98: err = pagination loop: repeated page token "stuck" after 2 list calls

$ gogcli-backup-services.exe -test.run TestFetchBackupTaskListsRejectsRepeatedPageToken -test.v
    backup_services_test.go:140: err = pagination loop: repeated page token "stuck" after 2 list calls

$ gogcli-backup-services.exe -test.run TestFetchBackupCalendarEventsRejectsRepeatedPageToken -test.v
    backup_services_test.go:226: err = pagination loop: repeated page token "stuck" after 2 list calls
```

Before the patch, the same stuck token made a third list request and returned HTTP 400 from the safety cap (`unexpected extra ... page request after 3 list calls`) instead of stopping on the repeated token.

## Real behavior proof

- **Behavior or issue addressed:** Calendar, Contacts, and Tasks backup listing hung when Google repeated a page token. `gog backup push` with those services never finished those listings.
- **Real environment tested:** Windows, Go 1.27.1, branch `fix/backup-services-page-token` at current HEAD, compiled `internal/cmd` listing binary.
- **Exact steps or command run after this patch:** Compiled the listing binary with `go`, then ran `gogcli-backup-services.exe` with `-test.v` on the calendar, connections, task-list, and event hang-guard cases.
- **Evidence after fix:** terminal output from that binary shows `pagination loop: repeated page token "stuck"` after 2 list calls for `fetchBackupCalendars`, `fetchBackupConnections`, `fetchBackupTaskLists`, and `fetchBackupCalendarEvents`.
- **Observed result after fix:** A repeated Calendar, Contacts, or Tasks backup page token now fails closed with the shared paginator error after two requests. Distinct calendar pages still concatenate and stay sorted by id. ACL listing still records per-calendar API errors as rows instead of aborting the snapshot.
- **What was not tested:** A live Google account with a real repeated token. Snapshot write / `--best-effort` handling after the listing error. Settings, other-contacts, contact-groups, ACL, and per-list task paging use the same `collectAllPages` rewrite.

## Summary

Route the nine Calendar, Contacts, and Tasks backup list helpers through existing `collectAllPages`. Keep the original page sizes, field masks, show-deleted flags, sorts, and ACL best-effort error rows.

Related: #1063, #1078, #1079, #1080, #1065, #1066, #1004, #1044, #1045, #1046.

Introduced in [`efc3df2e`](https://github.com/openclaw/gogcli/commit/efc3df2e) (2026-04-27, `feat(backup): expand google backup coverage`). Calendar list helper later moved in [`6f917ee7`](https://github.com/openclaw/gogcli/commit/6f917ee7).
