### PR TITLE
fix(backup): reject repeated Workspace backup page tokens

### DIFF
--- a/internal/cmd/backup_workspace.go
+++ b/internal/cmd/backup_workspace.go
@@ -259,30 +259,21 @@ func capDriveFiles(files []*drive.File, maxFiles int) []*drive.File {
 }
 
 func fetchBackupFormResponses(ctx context.Context, svc *formsapi.Service, formID string) ([]*formsapi.FormResponse, error) {
-	var out []*formsapi.FormResponse
-	pageToken := ""
-	for {
+	return collectAllPages("", func(pageToken string) ([]*formsapi.FormResponse, string, error) {
 		call := svc.Forms.Responses.List(formID).PageSize(5000).Context(ctx)
 		if pageToken != "" {
 			call = call.PageToken(pageToken)
 		}
 		resp, err := call.Do()
 		if err != nil {
-			return nil, err
+			return nil, "", err
 		}
-		out = append(out, resp.Responses...)
-		if resp.NextPageToken == "" {
-			break
-		}
-		pageToken = resp.NextPageToken
-	}
-	return out, nil
+		return resp.Responses, resp.NextPageToken, nil
+	})
 }
 
 func fetchDriveFilesByMime(ctx context.Context, svc *drive.Service, mimeType string) ([]*drive.File, error) {
-	var out []*drive.File
-	pageToken := ""
-	for {
+	out, err := collectAllPages("", func(pageToken string) ([]*drive.File, string, error) {
 		call := svc.Files.List().
 			Q(fmt.Sprintf("mimeType = '%s' and trashed = false", mimeType)).
 			PageSize(1000).
@@ -295,13 +286,12 @@ func fetchDriveFilesByMime(ctx context.Context, svc *drive.Service, mimeType str
 		}
 		resp, err := call.Do()
 		if err != nil {
-			return nil, err
+			return nil, "", err
 		}
-		out = append(out, resp.Files...)
-		if resp.NextPageToken == "" {
-			break
-		}
-		pageToken = resp.NextPageToken
+		return resp.Files, resp.NextPageToken, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Id < out[j].Id })
 	return out, nil

--- a/internal/cmd/backup_workspace_test.go
+++ b/internal/cmd/backup_workspace_test.go
@@ -1,0 +1,195 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestFetchBackupFormResponsesRejectsRepeatedPageToken(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !strings.Contains(r.URL.Path, "/forms/form-1/responses") {
+			http.NotFound(w, r)
+			return
+		}
+		n := calls.Add(1)
+		if n > 2 {
+			http.Error(w, "unexpected extra form response page request", http.StatusBadRequest)
+			return
+		}
+		wantToken := ""
+		if n == 2 {
+			wantToken = "stuck"
+		}
+		requireQuery(t, r, "pageToken", wantToken)
+		requireQuery(t, r, "pageSize", "5000")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"responses":     []map[string]any{{"responseId": "r1"}},
+			"nextPageToken": "stuck",
+		})
+	}))
+	defer srv.Close()
+
+	svc := newFormsTestService(t, t.Context(), srv)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	got, err := fetchBackupFormResponses(ctx, svc, "form-1")
+	if err == nil || !strings.Contains(err.Error(), "repeated page token") {
+		t.Fatalf("err = %v after %d list calls", err, calls.Load())
+	}
+	if got != nil {
+		t.Fatalf("responses = %#v, want no partial result", got)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("list calls = %d, want 2", got)
+	}
+	t.Logf("err = %v after %d list calls", err, calls.Load())
+}
+
+func TestFetchDriveFilesByMimeRejectsRepeatedPageToken(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	svc, closeSvc := newDriveTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !strings.HasSuffix(r.URL.Path, "/files") {
+			http.NotFound(w, r)
+			return
+		}
+		n := calls.Add(1)
+		if n > 2 {
+			http.Error(w, "unexpected extra workspace file page request", http.StatusBadRequest)
+			return
+		}
+		wantToken := ""
+		if n == 2 {
+			wantToken = "stuck"
+		}
+		requireQuery(t, r, "pageToken", wantToken)
+		requireQuery(t, r, "pageSize", "1000")
+		requireQuery(t, r, "q", "mimeType = 'application/vnd.google-apps.form' and trashed = false")
+		requireQuery(t, r, "orderBy", "modifiedTime desc")
+		requireSupportsAllDrives(t, r)
+		requireQuery(t, r, "includeItemsFromAllDrives", "true")
+		requireQuery(t, r, "corpora", "allDrives")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"files":         []map[string]any{{"id": "file-1", "name": "Survey"}},
+			"nextPageToken": "stuck",
+		})
+	}))
+	defer closeSvc()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	got, err := fetchDriveFilesByMime(ctx, svc, driveMimeGoogleForm)
+	if err == nil || !strings.Contains(err.Error(), "repeated page token") {
+		t.Fatalf("err = %v after %d list calls", err, calls.Load())
+	}
+	if got != nil {
+		t.Fatalf("files = %#v, want no partial result", got)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("list calls = %d, want 2", got)
+	}
+	t.Logf("err = %v after %d list calls", err, calls.Load())
+}
+
+func TestFetchBackupFormResponsesTwoDistinctPagesSucceed(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !strings.Contains(r.URL.Path, "/forms/form-1/responses") {
+			http.NotFound(w, r)
+			return
+		}
+		n := calls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		if n == 1 {
+			requireQuery(t, r, "pageToken", "")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"responses":     []map[string]any{{"responseId": "r1"}},
+				"nextPageToken": "page-2",
+			})
+			return
+		}
+		if n == 2 {
+			requireQuery(t, r, "pageToken", "page-2")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"responses": []map[string]any{{"responseId": "r2"}},
+			})
+			return
+		}
+		http.Error(w, "unexpected extra form response page request", http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	svc := newFormsTestService(t, t.Context(), srv)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	got, err := fetchBackupFormResponses(ctx, svc, "form-1")
+	if err != nil {
+		t.Fatalf("err = %v after %d list calls", err, calls.Load())
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("list calls = %d, want 2", calls.Load())
+	}
+	if len(got) != 2 || got[0].ResponseId != "r1" || got[1].ResponseId != "r2" {
+		t.Fatalf("responses = %#v, want both pages concatenated", got)
+	}
+}
+
+func TestFetchDriveFilesByMimeTwoDistinctPagesSucceed(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	svc, closeSvc := newDriveTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !strings.HasSuffix(r.URL.Path, "/files") {
+			http.NotFound(w, r)
+			return
+		}
+		n := calls.Add(1)
+		requireSupportsAllDrives(t, r)
+		requireQuery(t, r, "corpora", "allDrives")
+		w.Header().Set("Content-Type", "application/json")
+		if n == 1 {
+			requireQuery(t, r, "pageToken", "")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"files":         []map[string]any{{"id": "zzz", "name": "Late"}},
+				"nextPageToken": "page-2",
+			})
+			return
+		}
+		if n == 2 {
+			requireQuery(t, r, "pageToken", "page-2")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"files": []map[string]any{{"id": "aaa", "name": "Early"}},
+			})
+			return
+		}
+		http.Error(w, "unexpected extra workspace file page request", http.StatusBadRequest)
+	}))
+	defer closeSvc()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	got, err := fetchDriveFilesByMime(ctx, svc, driveMimeGoogleDoc)
+	if err != nil {
+		t.Fatalf("err = %v after %d list calls", err, calls.Load())
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("list calls = %d, want 2", calls.Load())
+	}
+	if len(got) != 2 || got[0].Id != "aaa" || got[1].Id != "zzz" {
+		t.Fatalf("files = %#v, want sorted ids aaa then zzz", got)
+	}
+}


### PR DESCRIPTION
## What Problem This Solves

`gog backup push` with workspace lists Google Forms responses (`Forms.Responses.List`) and native Drive files by MIME (`Files.List`) by walking Google page tokens. Both helpers in `internal/cmd/backup_workspace.go` copied `nextPageToken` into the next request with no seen-set.

When Forms or Drive repeats a continuation token, those loops never terminate. Backup collection keeps requesting the same page and never finishes a workspace snapshot.

The same hang class is already closed for Chat and Classroom backup (#1063), Drive sync push listing (#1065), Drive audit permission listing (#1066), calendar and Gmail listing (#1004), and People/Gmail-from-contact/contacts-export listing (#1044, #1045, #1046). Sibling PRs cover Drive backup (#1078), Groups/Admin/Keep (#1079), Drive collaboration (#1080), and Calendar/Contacts/Tasks (#1081). Workspace backup listing was still on the unguarded loop.

## Evidence

terminal output from the compiled `internal/cmd` listing binary after the patch. A stuck continuation token is rejected after two list calls, with no third request:

```console
$ gogcli-backup-workspace.exe -test.run TestFetchBackupFormResponsesRejectsRepeatedPageToken -test.v
    backup_workspace_test.go:55: err = pagination loop: repeated page token "stuck" after 2 list calls

$ gogcli-backup-workspace.exe -test.run TestFetchDriveFilesByMimeRejectsRepeatedPageToken -test.v
    backup_workspace_test.go:103: err = pagination loop: repeated page token "stuck" after 2 list calls
```

Before the patch, the same stuck token made a third list request and returned HTTP 400 from the safety cap (`unexpected extra ... page request after 3 list calls`) instead of stopping on the repeated token.

## Real behavior proof

- **Behavior or issue addressed:** Workspace backup form-response listing and Drive-by-mime listing hung when Google repeated a page token. `gog backup push` with workspace never finished those listings.
- **Real environment tested:** Windows, Go 1.27.1, branch `fix/backup-workspace-page-token` at current HEAD, compiled `internal/cmd` listing binary.
- **Exact steps or command run after this patch:** Compiled the listing binary with `go`, then ran `gogcli-backup-workspace.exe` with `-test.v` on the form-response and Drive-by-mime hang-guard cases.
- **Evidence after fix:** terminal output from that binary shows `pagination loop: repeated page token "stuck"` after 2 list calls for both `fetchBackupFormResponses` and `fetchDriveFilesByMime`.
- **Observed result after fix:** A repeated Workspace backup page token now fails closed with the shared paginator error after two requests. Distinct pages still concatenate. Drive-by-mime files stay sorted by id. File listing still uses `driveFilesListCallWithDriveSupport` (`corpora=allDrives`).
- **What was not tested:** A live Google Workspace account with a real repeated token. Snapshot write / `--best-effort` handling after the listing error.

## Summary

Route `fetchBackupFormResponses` and `fetchDriveFilesByMime` through existing `collectAllPages`. Keep the original field lists, page sizes, MIME query, order, shared-drive flags, and file sort.

Related: #1063, #1065, #1066, #1004, #1044, #1045, #1046, #1078, #1079, #1080, #1081.

Introduced in `068ff0e5` (2026-04-27, `feat(backup): expand workspace backup coverage`).
