### PR TITLE
fix(contacts): reject repeated dedupe page tokens

### DIFF
--- a/internal/cmd/contacts_dedupe.go
+++ b/internal/cmd/contacts_dedupe.go
@@ -148,37 +148,45 @@ func contactsDedupeGetResources(ctx context.Context, svc *people.Service, resour
 }
 
 func contactsDedupeList(ctx context.Context, svc *people.Service, maxResults int64) ([]*people.Person, error) {
-	var out []*people.Person
-	pageToken := ""
-	for {
+	fetched := 0
+	fetch := func(pageToken string) ([]*people.Person, string, error) {
 		pageSize := int64(500)
-		if maxResults > 0 && maxResults-int64(len(out)) < pageSize {
-			pageSize = maxResults - int64(len(out))
+		if maxResults > 0 {
+			remaining := maxResults - int64(fetched)
+			if remaining <= 0 {
+				return nil, "", nil
+			}
+			if remaining < pageSize {
+				pageSize = remaining
+			}
 		}
-		resp, err := svc.People.Connections.List(peopleMeResource).
+		call := svc.People.Connections.List(peopleMeResource).
 			PersonFields(contactsReadMask).
 			PageSize(pageSize).
-			PageToken(pageToken).
 			RequestSyncToken(false).
-			Sources("READ_SOURCE_TYPE_CONTACT").
-			Context(ctx).
-			Do()
+			Sources(contactsDedupeContactSource).
+			Context(ctx)
+		if pageToken != "" {
+			call = call.PageToken(pageToken)
+		}
+		resp, err := call.Do()
 		if err != nil {
-			return nil, err
+			return nil, "", err
 		}
+		var page []*people.Person
 		for _, p := range resp.Connections {
-			if p != nil {
-				out = append(out, p)
+			if p == nil {
+				continue
 			}
-			if maxResults > 0 && int64(len(out)) >= maxResults {
-				return out, nil
+			page = append(page, p)
+			fetched++
+			if maxResults > 0 && int64(fetched) >= maxResults {
+				return page, "", nil
 			}
 		}
-		if resp.NextPageToken == "" {
-			return out, nil
-		}
-		pageToken = resp.NextPageToken
+		return page, resp.NextPageToken, nil
 	}
+	return collectAllPages("", fetch)
 }
 
 type contactsDedupeGroup struct {

--- a/internal/cmd/contacts_dedupe_test.go
+++ b/internal/cmd/contacts_dedupe_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"reflect"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"google.golang.org/api/people/v1"
@@ -163,6 +164,43 @@ func TestContactsDedupeExecuteJSON(t *testing.T) {
 	if !reflect.DeepEqual(parsed.Groups[0].MatchedOn, []string{"email:ada@example.com"}) {
 		t.Fatalf("matched_on = %#v", parsed.Groups[0].MatchedOn)
 	}
+}
+
+func TestContactsDedupeExecuteRejectsRepeatedPageToken(t *testing.T) {
+	var listCalls atomic.Int32
+	svc, closeSrv := newPeopleService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/v1/people/me/connections" {
+			http.NotFound(w, r)
+			return
+		}
+		if listCalls.Add(1) > 2 {
+			http.Error(w, "unexpected extra connections page request", http.StatusBadRequest)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"connections": []map[string]any{{
+				"resourceName":   "people/1",
+				"names":          []map[string]any{{"displayName": "Ada"}},
+				"emailAddresses": []map[string]any{{"value": "ada@example.com"}},
+			}},
+			"nextPageToken": "stuck",
+		})
+	}))
+	defer closeSrv()
+
+	result := executeWithPeopleTestServices(t, []string{"--json", "--account", "a@example.com", "contacts", "dedupe"}, peopleTestServices{
+		Contacts: fixedPeopleTestService(svc),
+	})
+	if result.err == nil || !strings.Contains(result.err.Error(), "repeated page token") {
+		t.Fatalf("err = %v after %d list calls", result.err, listCalls.Load())
+	}
+	if got := listCalls.Load(); got != 2 {
+		t.Fatalf("list calls = %d, want 2", got)
+	}
+	if result.stdout != "" {
+		t.Fatalf("unexpected partial output: %q", result.stdout)
+	}
+	t.Logf("err = %v after %d list calls", result.err, listCalls.Load())
 }
 
 func testDedupePerson(resource, name string, emails, phones []string) *people.Person {


### PR DESCRIPTION
## What Problem This Solves

`gog contacts dedupe` lists personal connections with `pageToken = resp.NextPageToken` and no seen-set. The public default is `--max 0`, which means scan every page. If Google repeats `nextPageToken`, dedupe never finishes and the CLI hangs until the process is killed.

## Why

The repo already has this guard. `collectAllPages` errors with `pagination loop: repeated page token`. Calendar listing uses it after [#1004](https://github.com/openclaw/gogcli/pull/1004). People raw email resolve uses it in [#1044](https://github.com/openclaw/gogcli/pull/1044). The Gmail `--from-contact` fallback uses it in [#1045](https://github.com/openclaw/gogcli/pull/1045). Contacts export group listing uses it in [#1046](https://github.com/openclaw/gogcli/pull/1046). Dedupe listing lives in the same `cmd` package, so it now calls that helper instead of growing a second loop. `--max` still stops the scan early by returning an empty next token once the requested count is reached.

## User Impact

A stuck Connections page token now fails with `repeated page token` instead of hanging `gog contacts dedupe` on the default all-pages scan.

## Evidence

terminal output from the unpatched connections listing loop versus this patch. A People httptest server always returns `nextPageToken=stuck` from `people.me.connections.list`. The public command is `gog contacts dedupe` with default `--max 0`.

Unpatched (the HTTP peer answers immediately; the handler returns HTTP 400 after a third list call so the loop cannot run forever):

```console
$ go test ./internal/cmd -run TestContactsDedupeExecuteRejectsRepeatedPageToken -count=1 -timeout 60s -v
=== RUN   TestContactsDedupeExecuteRejectsRepeatedPageToken
    contacts_dedupe_test.go:195: err = googleapi: got HTTP response code 400 with body: unexpected extra connections page request
         after 3 list calls
--- FAIL: TestContactsDedupeExecuteRejectsRepeatedPageToken (0.06s)
FAIL
```

Patched (same command, same stuck token, returns immediately):

```console
$ go test ./internal/cmd -run TestContactsDedupeExecuteRejectsRepeatedPageToken -count=1 -timeout 60s -v
=== RUN   TestContactsDedupeExecuteRejectsRepeatedPageToken
    contacts_dedupe_test.go:203: err = pagination loop: repeated page token "stuck" after 2 list calls
--- PASS: TestContactsDedupeExecuteRejectsRepeatedPageToken (0.07s)
PASS
ok  	github.com/openclaw/gogcli/internal/cmd	2.522s
```

Live CLI still exposes the default all-pages scan:

```console
$ bin/gog contacts dedupe --help
Usage: gog contacts (contact) dedupe [flags]
      --match="email,phone"      Match fields: email,phone,name
      --max=0                    Max contacts to scan (0 = all)
```

`go test ./internal/cmd -count=1 -run TestContactsDedupe` completed on this tree. `gofmt` is clean. `golangci-lint run ./internal/cmd` reported 0 issues.

## Real behavior proof

- **Behavior or issue addressed:** Repeated Google `nextPageToken` values could hang `gog contacts dedupe` while listing `people.me.connections` on the default `--max 0` scan.
- **Real environment tested:** Windows amd64, Go go1.27.1, worktree at `C:\Users\sebta\.grok\tmp\pr-gate-batch\gogcli-f020` on `fix/contacts-dedupe-page-token` from `origin/main` at [`25703c78`](https://github.com/openclaw/gogcli/commit/25703c78).
- **Exact steps or command run after this patch:** From that worktree, ran `go test ./internal/cmd -run TestContactsDedupeExecuteRejectsRepeatedPageToken -count=1 -timeout 60s -v` against a People httptest that always returns `nextPageToken=stuck` from `people.me.connections.list`, then ran `bin/gog contacts dedupe --help` on the binary built from this branch.
- **Evidence after fix:** terminal output above. Connections listing now returns `pagination loop: repeated page token "stuck"` after 2 list calls (0.07s). The unpatched loop made 3 list calls and only stopped when the handler returned HTTP 400.
- **Observed result after fix:** The stuck token no longer pages forever. `contactsDedupeList` returns the repeated-token error on the next page instead of hanging. `gog contacts dedupe --help` still shows `--max=0` as scan all pages.
- **What was not tested:** A live `people.connections.list` response that actually repeats a token. That requires a faulty Google page, which we cannot force from a healthy account.

## Related

- Same-repo guard already used by `collectAllPages` in `internal/cmd/paging.go`, by calendar listing in [#1004](https://github.com/openclaw/gogcli/pull/1004), by People raw email resolve in [#1044](https://github.com/openclaw/gogcli/pull/1044), by the Gmail `--from-contact` fallback in [#1045](https://github.com/openclaw/gogcli/pull/1045), and by contacts export group listing in [#1046](https://github.com/openclaw/gogcli/pull/1046).
- Unguarded Connections paging dates to [`62a7257ab`](https://github.com/openclaw/gogcli/commit/62a7257ab) (`feat(contacts): add dedupe preview`, [#555](https://github.com/openclaw/gogcli/pull/555), 2026-05-05, 123 days ago).
