### PR TITLE
fix(calendar): reject repeated instance page tokens

### DIFF
--- a/internal/cmd/calendar_delete_test.go
+++ b/internal/cmd/calendar_delete_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"google.golang.org/api/calendar/v3"
@@ -67,6 +68,70 @@ func TestCalendarDeleteCmd_ScopeSingle(t *testing.T) {
 	}
 	if !payload.Deleted || payload.EventID != "ev_1" {
 		t.Fatalf("unexpected output: %#v", payload)
+	}
+}
+
+func TestCalendarDeleteCmd_ScopeSingleRejectsRepeatedPageToken(t *testing.T) {
+	var instanceCalls atomic.Int32
+	var deleted bool
+	svc, closeSvc := newCalendarServiceForTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimPrefix(r.URL.Path, "/calendar/v3")
+		switch {
+		case r.Method == http.MethodGet && path == "/calendars/cal@example.com/events/ev":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":         "ev",
+				"recurrence": []string{"RRULE:FREQ=DAILY"},
+			})
+			return
+		case r.Method == http.MethodGet && strings.HasPrefix(path, "/calendars/cal@example.com/events/ev/instances"):
+			if instanceCalls.Add(1) > 2 {
+				http.Error(w, "unexpected extra page request", http.StatusBadRequest)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"items": []map[string]any{
+					{
+						"id": "ev_other",
+						"originalStartTime": map[string]any{
+							"dateTime": "2025-01-03T10:00:00Z",
+						},
+					},
+				},
+				"nextPageToken": "stuck",
+			})
+			return
+		case r.Method == http.MethodDelete:
+			deleted = true
+			w.WriteHeader(http.StatusNoContent)
+			return
+		default:
+			http.NotFound(w, r)
+			return
+		}
+	}))
+	defer closeSvc()
+	ctx, output := newCalendarTestJSONContext(t, svc)
+
+	cmd := CalendarDeleteCmd{
+		CalendarID:        "cal@example.com",
+		EventID:           "ev",
+		Scope:             scopeSingle,
+		OriginalStartTime: "2025-01-02T10:00:00Z",
+	}
+	err := cmd.Run(ctx, &RootFlags{Account: "a@b.com", Force: true})
+	if err == nil || !strings.Contains(err.Error(), "repeated page token") {
+		t.Fatalf("err = %v after %d instance calls", err, instanceCalls.Load())
+	}
+	if instanceCalls.Load() != 2 {
+		t.Fatalf("instance calls = %d, want 2", instanceCalls.Load())
+	}
+	if deleted {
+		t.Fatalf("delete must not run after a pagination loop")
+	}
+	if output.Len() != 0 {
+		t.Fatalf("unexpected output: %s", output.Bytes())
 	}
 }
 

--- a/internal/cmd/calendar_recurrence.go
+++ b/internal/cmd/calendar_recurrence.go
@@ -65,29 +65,27 @@ func resolveRecurringInstanceID(ctx context.Context, svc *calendar.Service, cale
 		return "", err
 	}
 
-	call := svc.Events.Instances(calendarID, recurringEventID).
-		ShowDeleted(false).
-		TimeMin(timeMin).
-		TimeMax(timeMax)
-
-	for {
-		resp, err := call.Context(ctx).Do()
-		if err != nil {
-			return "", err
-		}
-		for _, item := range resp.Items {
-			if matchesOriginalStart(item, originalStart) {
-				return item.Id, nil
-			}
-		}
-		if resp.NextPageToken == "" {
-			break
-		}
-		call = svc.Events.Instances(calendarID, recurringEventID).
+	items, err := collectAllPages("", func(pageToken string) ([]*calendar.Event, string, error) {
+		call := svc.Events.Instances(calendarID, recurringEventID).
 			ShowDeleted(false).
 			TimeMin(timeMin).
-			TimeMax(timeMax).
-			PageToken(resp.NextPageToken)
+			TimeMax(timeMax)
+		if pageToken != "" {
+			call = call.PageToken(pageToken)
+		}
+		resp, err := call.Context(ctx).Do()
+		if err != nil {
+			return nil, "", err
+		}
+		return resp.Items, resp.NextPageToken, nil
+	})
+	if err != nil {
+		return "", err
+	}
+	for _, item := range items {
+		if matchesOriginalStart(item, originalStart) {
+			return item.Id, nil
+		}
 	}
 
 	return "", fmt.Errorf("no instance found for original start %q", originalStart)

--- a/internal/cmd/calendar_recurrence.go
+++ b/internal/cmd/calendar_recurrence.go
@@ -73,9 +73,9 @@ func resolveRecurringInstanceID(ctx context.Context, svc *calendar.Service, cale
 		if pageToken != "" {
 			call = call.PageToken(pageToken)
 		}
-		resp, err := call.Context(ctx).Do()
-		if err != nil {
-			return nil, "", err
+		resp, doErr := call.Context(ctx).Do()
+		if doErr != nil {
+			return nil, "", doErr
 		}
 		return resp.Items, resp.NextPageToken, nil
 	})

--- a/internal/cmd/calendar_recurrence_test.go
+++ b/internal/cmd/calendar_recurrence_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -152,5 +153,112 @@ func TestResolveRecurringParentEvent_Instance(t *testing.T) {
 	}
 	if len(recurrence) != 1 || recurrence[0] != "RRULE:FREQ=WEEKLY" {
 		t.Fatalf("unexpected recurrence: %#v", recurrence)
+	}
+}
+
+func TestResolveRecurringInstanceIDRejectsRepeatedPageToken(t *testing.T) {
+	var listCalls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimPrefix(r.URL.Path, "/calendar/v3")
+		if !(r.Method == http.MethodGet && strings.HasPrefix(path, "/calendars/cal/events/ev_master/instances")) {
+			http.NotFound(w, r)
+			return
+		}
+		if listCalls.Add(1) > 2 {
+			http.Error(w, "unexpected extra page request", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"items": []map[string]any{
+				{
+					"id": "ev_other",
+					"originalStartTime": map[string]any{
+						"dateTime": "2025-01-03T10:00:00Z",
+					},
+				},
+			},
+			"nextPageToken": "stuck",
+		})
+	}))
+	defer srv.Close()
+
+	svc, err := calendar.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	got, err := resolveRecurringInstanceID(context.Background(), svc, "cal", "ev_master", "2025-01-02T10:00:00Z")
+	if err == nil || !strings.Contains(err.Error(), "repeated page token") {
+		t.Fatalf("err = %v after %d list calls, got = %q", err, listCalls.Load(), got)
+	}
+	if got := listCalls.Load(); got != 2 {
+		t.Fatalf("list calls = %d, want 2", got)
+	}
+}
+
+func TestResolveRecurringInstanceIDFindsMatchOnLaterPage(t *testing.T) {
+	originalStart := "2025-01-02T10:00:00Z"
+	var listCalls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimPrefix(r.URL.Path, "/calendar/v3")
+		if !(r.Method == http.MethodGet && strings.HasPrefix(path, "/calendars/cal/events/ev_master/instances")) {
+			http.NotFound(w, r)
+			return
+		}
+		listCalls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Query().Get("pageToken") {
+		case "":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"items": []map[string]any{
+					{
+						"id": "ev_other",
+						"originalStartTime": map[string]any{
+							"dateTime": "2025-01-03T10:00:00Z",
+						},
+					},
+				},
+				"nextPageToken": "page-2",
+			})
+		case "page-2":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"items": []map[string]any{
+					{
+						"id": "ev_1",
+						"originalStartTime": map[string]any{
+							"dateTime": originalStart,
+						},
+					},
+				},
+			})
+		default:
+			http.Error(w, "unexpected extra page request", http.StatusBadRequest)
+		}
+	}))
+	defer srv.Close()
+
+	svc, err := calendar.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	got, err := resolveRecurringInstanceID(context.Background(), svc, "cal", "ev_master", originalStart)
+	if err != nil {
+		t.Fatalf("resolveRecurringInstanceID: %v", err)
+	}
+	if got != "ev_1" {
+		t.Fatalf("unexpected instance id: %q", got)
+	}
+	if listCalls.Load() != 2 {
+		t.Fatalf("list calls = %d, want 2", listCalls.Load())
 	}
 }


### PR DESCRIPTION
## What Problem This Solves

`gog calendar delete` and `gog calendar update` with `--scope single` or `--scope future` resolve the target instance through `Events.Instances`. That helper rebuilt each page request from `NextPageToken` and never recorded tokens it had already used. If Google returned the same token again, instance lookup never finished, so the command never deleted or patched the event.

The same unguarded rebuild has already been fixed for CalendarList (`#1004`) and other `cmd` list helpers. Recurring instance lookup was still on the old loop, introduced with calendar recurrence parity in `#38` (`1d595747`, 2026-01-08).

## Evidence

Public path: `CalendarDeleteCmd.Run` and the update/edit commands call `resolveRecurringScopeResolution`, which calls `resolveRecurringInstanceID` whenever `--scope` is `single` or `future` and `--original-start` is set.

A local Calendar Instances peer that always returns `nextPageToken=stuck` (and a non-matching item) shows the hang versus the fail-closed walk. The unguarded rebuild kept requesting until the peer refused after 40 calls. The seen-token walk stopped after two calls.

```
$ go run C:/Users/sebta/.grok/tmp/instance-page-token-proof.go
OLD: unguarded Events.Instances rebuild
old calls=41 err=googleapi: got HTTP response code 429 with body: stopped after 40 requests
NEW: collectAllPages seen-token walk
new calls=2 err=pagination loop: repeated page token "stuck"
```

The same peer through `CalendarDeleteCmd` with `--scope single` and `--original-start 2025-01-02T10:00:00Z` now returns that pagination error, makes two instance list calls, writes no JSON, and never sends DELETE.

## Real behavior proof

- **Behavior or issue addressed:** Recurring instance lookup for calendar edit and delete hangs if `Events.Instances` repeats a page token.
- **Real environment tested:** Windows, Go 1.27.1, openclaw/gogcli at `25703c78` plus this patch, generated Calendar client against a local Instances peer.
- **Exact steps or command run after this patch:**

  ```
  go run C:/Users/sebta/.grok/tmp/instance-page-token-proof.go
  ```

- **Evidence after fix:** terminal output from the patched walk:

  ```
  OLD: unguarded Events.Instances rebuild
  old calls=41 err=googleapi: got HTTP response code 429 with body: stopped after 40 requests
  NEW: collectAllPages seen-token walk
  new calls=2 err=pagination loop: repeated page token "stuck"
  ```

- **Observed result after fix:** The unguarded rebuild issued 41 instance list requests. After the patch, the same peer stops after two requests with `pagination loop: repeated page token "stuck"`. `calendar delete --scope single` does not emit a result or send DELETE once lookup fails.
- **What was not tested:** A live Google Calendar account returning a repeated Instances token.

Related: [#1004](https://github.com/openclaw/gogcli/pull/1004), [#38](https://github.com/openclaw/gogcli/pull/38), [#1066](https://github.com/openclaw/gogcli/pull/1066).
