### PR TITLE
fix(drive): reject repeated tree inventory page tokens

### DIFF
--- a/internal/cmd/drive_reporting.go
+++ b/internal/cmd/drive_reporting.go
@@ -364,10 +364,7 @@ func listDriveChildren(ctx context.Context, svc *drive.Service, parentID string,
 		parentID = driveRootID
 	}
 	q := buildDriveListQuery(parentID, "")
-	out := make([]*drive.File, 0, 64)
-	var pageToken string
-
-	for {
+	fetch := func(pageToken string) ([]*drive.File, string, error) {
 		call := svc.Files.List().
 			Q(q).
 			PageSize(driveDefaultPageSize).
@@ -380,16 +377,11 @@ func listDriveChildren(ctx context.Context, svc *drive.Service, parentID string,
 		).Context(ctx)
 		resp, err := call.Do()
 		if err != nil {
-			return nil, err
+			return nil, "", err
 		}
-		out = append(out, resp.Files...)
-		if resp.NextPageToken == "" {
-			break
-		}
-		pageToken = resp.NextPageToken
+		return resp.Files, resp.NextPageToken, nil
 	}
-
-	return out, nil
+	return collectAllPages("", fetch)
 }
 
 func driveOwners(f *drive.File) []string {

--- a/internal/cmd/drive_reporting_test.go
+++ b/internal/cmd/drive_reporting_test.go
@@ -1,10 +1,14 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func TestExecuteDriveTreeJSON(t *testing.T) {
@@ -322,5 +326,174 @@ func TestDriveTreeRejectsFolderCycle(t *testing.T) {
 	}
 	if !strings.Contains(result.err.Error(), `drive folder cycle detected at "A/Root again" (id root)`) {
 		t.Fatalf("cycle error = %q", result.err)
+	}
+}
+
+func TestListDriveChildrenRejectsRepeatedPageToken(t *testing.T) {
+	t.Parallel()
+
+	var listCalls atomic.Int32
+	svc, closeSvc := newDriveTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !strings.HasSuffix(r.URL.Path, "/files") {
+			http.NotFound(w, r)
+			return
+		}
+		n := listCalls.Add(1)
+		if n > 2 {
+			http.Error(w, "unexpected extra page request", http.StatusBadRequest)
+			return
+		}
+		wantToken := ""
+		if n == 2 {
+			wantToken = "stuck"
+		}
+		requireSupportsAllDrives(t, r)
+		requireQuery(t, r, "includeItemsFromAllDrives", "true")
+		requireQuery(t, r, "corpora", "allDrives")
+		requireQuery(t, r, "pageSize", "1000")
+		requireQuery(t, r, "orderBy", "folder,name")
+		requireQuery(t, r, "pageToken", wantToken)
+		if q := r.URL.Query().Get("q"); !strings.Contains(q, "'root' in parents") {
+			t.Fatalf("query = %q, want root parent", q)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"files": []any{
+				map[string]any{"id": "child-1", "name": "a.txt", "mimeType": "text/plain"},
+			},
+			"nextPageToken": "stuck",
+		})
+	}))
+	defer closeSvc()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	files, err := listDriveChildren(ctx, svc, "", driveTreeFields, true)
+	if err == nil || !strings.Contains(err.Error(), "repeated page token") {
+		t.Fatalf("err = %v after %d list calls", err, listCalls.Load())
+	}
+	if files != nil {
+		t.Fatalf("unexpected partial children: %#v", files)
+	}
+	if got := listCalls.Load(); got != 2 {
+		t.Fatalf("list calls = %d, want 2", got)
+	}
+	t.Logf("err = %v after %d list calls", err, listCalls.Load())
+}
+
+func TestListDriveChildrenLaterPages(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name           string
+		failSecondPage bool
+	}{
+		{name: "success preserves page order"},
+		{name: "later error discards partial children", failSecondPage: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var listCalls atomic.Int32
+			svc, closeSvc := newDriveTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodGet || !strings.HasSuffix(r.URL.Path, "/files") {
+					http.NotFound(w, r)
+					return
+				}
+				requireSupportsAllDrives(t, r)
+				requireQuery(t, r, "pageSize", "1000")
+				requireQuery(t, r, "orderBy", "folder,name")
+				if q := r.URL.Query().Get("q"); !strings.Contains(q, "'parent' in parents") {
+					t.Fatalf("query = %q, want parent folder", q)
+				}
+				n := listCalls.Add(1)
+				w.Header().Set("Content-Type", "application/json")
+				switch n {
+				case 1:
+					requireQuery(t, r, "pageToken", "")
+					_, _ = io.WriteString(w, `{"files":[{"id":"child-1","name":"1.txt","mimeType":"text/plain"}],"nextPageToken":"page-2"}`)
+				case 2:
+					requireQuery(t, r, "pageToken", "page-2")
+					if tc.failSecondPage {
+						http.Error(w, `{"error":{"code":403,"message":"page two denied"}}`, http.StatusForbidden)
+						return
+					}
+					_, _ = io.WriteString(w, `{"files":[{"id":"child-2","name":"2.txt","mimeType":"text/plain"}]}`)
+				default:
+					http.Error(w, "unexpected extra page request", http.StatusBadRequest)
+				}
+			}))
+			defer closeSvc()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			files, err := listDriveChildren(ctx, svc, "parent", driveTreeFields, true)
+			if tc.failSecondPage {
+				if err == nil || !strings.Contains(err.Error(), "page two denied") || files != nil {
+					t.Fatalf("files = %#v, err = %v; want nil children and provider error", files, err)
+				}
+			} else if err != nil || len(files) != 2 || files[0].Id != "child-1" || files[1].Id != "child-2" {
+				t.Fatalf("files = %#v, err = %v; want both pages in order", files, err)
+			}
+			if got := listCalls.Load(); got != 2 {
+				t.Fatalf("list calls = %d, want 2", got)
+			}
+		})
+	}
+}
+
+func TestExecuteDriveReportingRejectsRepeatedPageToken(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{name: "tree", args: []string{"drive", "tree", "--parent", "root", "--depth", "1"}},
+		{name: "inventory", args: []string{"drive", "inventory", "--parent", "root", "--depth", "1"}},
+		{name: "du", args: []string{"drive", "du", "--parent", "root", "--depth", "1"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var listCalls atomic.Int32
+			svc, closeSvc := newDriveTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodGet || !strings.HasSuffix(r.URL.Path, "/files") {
+					http.NotFound(w, r)
+					return
+				}
+				n := listCalls.Add(1)
+				if n > 2 {
+					http.Error(w, "unexpected extra page request", http.StatusBadRequest)
+					return
+				}
+				requireSupportsAllDrives(t, r)
+				if n == 1 {
+					requireQuery(t, r, "pageToken", "")
+				} else {
+					requireQuery(t, r, "pageToken", "stuck")
+				}
+				if q := r.URL.Query().Get("q"); !strings.Contains(q, "'root' in parents") {
+					t.Fatalf("query = %q, want root parent", q)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"files": []any{
+						map[string]any{"id": "loop", "name": "stuck.txt", "mimeType": "text/plain"},
+					},
+					"nextPageToken": "stuck",
+				})
+			}))
+			defer closeSvc()
+
+			args := append([]string{"--json", "--account", "owner@example.com", "--no-input"}, tc.args...)
+			result := executeWithDriveTestService(t, args, svc)
+			wantError := `list Drive folder root: pagination loop: repeated page token "stuck"`
+			if result.err == nil || !strings.Contains(result.err.Error(), wantError) || ExitCode(result.err) != 1 {
+				t.Fatalf("err = %v, exit = %d, stderr = %q; want folder list error", result.err, ExitCode(result.err), result.stderr)
+			}
+			if result.stdout != "" || !strings.Contains(result.stderr, wantError) {
+				t.Fatalf("stdout = %q, stderr = %q; want only the list error", result.stdout, result.stderr)
+			}
+			if got := listCalls.Load(); got != 2 {
+				t.Fatalf("list calls = %d, want 2", got)
+			}
+			t.Logf("%v; no success output", result.err)
+		})
 	}
 }


### PR DESCRIPTION
## What Problem This Solves

`gog drive tree`, `gog drive inventory`, and `gog drive du` walk folder children through `listDriveChildren` in `internal/cmd/drive_reporting.go`. That helper copied `nextPageToken` into the next `Files.List` request with no seen-set.

When Drive repeats a continuation token, the loop never terminates. Tree, inventory, and disk-usage scans keep requesting the same page and never return.

The same hang class is already closed for Drive sync push listing (#1065), Drive audit permission listing (#1066), calendar and Gmail listing (#1004), and People/Gmail-from-contact/contacts-export listing (#1044, #1045, #1046). Folder children used by the read-only reporting commands were still on the unguarded loop.

## Evidence

terminal output from the compiled `internal/cmd` listing binary after the patch. A stuck continuation token is rejected after two list calls, with no third request. The same error reaches the public commands:

```console
$ gogcli-drive-reporting.exe -test.run TestListDriveChildrenRejectsRepeatedPageToken -test.v
    drive_reporting_test.go:381: err = pagination loop: repeated page token "stuck" after 2 list calls

$ gogcli-drive-reporting.exe -test.run TestExecuteDriveReportingRejectsRepeatedPageToken -test.v
    drive_reporting_test.go:496: list Drive folder root: pagination loop: repeated page token "stuck"; no success output
--- PASS: TestExecuteDriveReportingRejectsRepeatedPageToken/tree
--- PASS: TestExecuteDriveReportingRejectsRepeatedPageToken/inventory
--- PASS: TestExecuteDriveReportingRejectsRepeatedPageToken/du
```

Before the patch, the same stuck token made a third list request and returned HTTP 400 from the safety cap (`unexpected extra page request after 3 list calls`) instead of stopping on the repeated token.

## Real behavior proof

- **Behavior or issue addressed:** Drive tree, inventory, and du hung when Google repeated a folder-list page token. Those commands never finished a folder walk.
- **Real environment tested:** Windows, Go 1.27.1, branch `fix/drive-children-page-token` from `origin/main` at `25703c78`, compiled `internal/cmd` listing binary.
- **Exact steps or command run after this patch:** Compiled the listing binary with `go`, then ran `gogcli-drive-reporting.exe` with `-test.v` on the helper hang-guard and the public `drive tree` / `drive inventory` / `drive du` command path.
- **Evidence after fix:** terminal output from that binary shows `pagination loop: repeated page token "stuck"` after 2 list calls for `listDriveChildren`, and `list Drive folder root: pagination loop: repeated page token "stuck"` with empty stdout for tree, inventory, and du.
- **Observed result after fix:** A repeated Drive children page token now fails closed with the shared paginator error after two requests. Distinct pages still concatenate in order. A later provider error still discards partial children. Query, page size 1000, `orderBy=folder,name`, and `driveFilesListCallWithDriveSupport` (`corpora=allDrives`) are unchanged.
- **What was not tested:** A live Google Drive account with a real repeated token.

## Summary

Route `listDriveChildren` through existing `collectAllPages`. Keep the original query, fields, page size, order, shared-drive flags, and empty-parent default to `root`.

Related: #1065, #1066, #1004, #1044, #1045, #1046.

Introduced in `e9c496ef` (2026-05-05, `feat(drive): add read-only reporting commands`, #554).
