### PR TITLE
fix(gmail): reject repeated archive search page tokens

### DIFF
--- a/internal/cmd/gmail_archive.go
+++ b/internal/cmd/gmail_archive.go
@@ -256,6 +256,7 @@ func searchMessageIDs(ctx context.Context, svc *gmail.Service, query string, lim
 	var ids []string
 	pageToken := ""
 	remaining := limit
+	seenTokens := map[string]struct{}{}
 
 	for {
 		batchSize := remaining
@@ -280,10 +281,15 @@ func searchMessageIDs(ctx context.Context, svc *gmail.Service, query string, lim
 		}
 
 		remaining -= int64(len(resp.Messages))
-		if resp.NextPageToken == "" || remaining <= 0 {
+		next := strings.TrimSpace(resp.NextPageToken)
+		if next == "" || remaining <= 0 {
 			break
 		}
-		pageToken = resp.NextPageToken
+		if _, exists := seenTokens[next]; exists {
+			return nil, fmt.Errorf("pagination loop: repeated page token %q", next)
+		}
+		seenTokens[next] = struct{}{}
+		pageToken = next
 	}
 
 	return ids, nil

--- a/internal/cmd/gmail_archive_test.go
+++ b/internal/cmd/gmail_archive_test.go
@@ -8,7 +8,9 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"google.golang.org/api/gmail/v1"
 
@@ -310,4 +312,124 @@ func TestGmailBulkOps_QueryInvalidMaxFailsBeforeDryRun(t *testing.T) {
 			}
 		})
 	}
+}
+
+func stuckGmailSearchListHandler(t *testing.T, listCalls *atomic.Int32) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimPrefix(r.URL.Path, "/gmail/v1")
+		if r.Method != http.MethodGet || path != "/users/me/messages" {
+			http.NotFound(w, r)
+			return
+		}
+		if listCalls.Add(1) > 2 {
+			http.Error(w, "too many list requests", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"messages":      []map[string]any{{"id": "m1"}},
+			"nextPageToken": "stuck",
+		})
+	}
+}
+
+func TestSearchMessageIDsRejectsRepeatedPageToken(t *testing.T) {
+	var listCalls atomic.Int32
+	svc, cleanup := newGmailServiceForTest(t, stuckGmailSearchListHandler(t, &listCalls))
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	ids, err := searchMessageIDs(ctx, svc, "in:inbox", 50)
+	if err == nil || !strings.Contains(err.Error(), "repeated page token") {
+		t.Fatalf("err = %v after %d list calls, ids=%v", err, listCalls.Load(), ids)
+	}
+	if got := listCalls.Load(); got != 2 {
+		t.Fatalf("list calls = %d, want 2", got)
+	}
+	t.Logf("err = %v after %d list calls", err, listCalls.Load())
+}
+
+func TestSearchMessageIDsRejectsRepeatedEmptyPageToken(t *testing.T) {
+	var listCalls atomic.Int32
+	svc, cleanup := newGmailServiceForTest(t, func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimPrefix(r.URL.Path, "/gmail/v1")
+		if r.Method != http.MethodGet || path != "/users/me/messages" {
+			http.NotFound(w, r)
+			return
+		}
+		listCalls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"nextPageToken": "stuck",
+		})
+	})
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+	ids, err := searchMessageIDs(ctx, svc, "in:inbox", 50)
+	if err == nil || !strings.Contains(err.Error(), "repeated page token") {
+		t.Fatalf("err = %v after %d list calls, ids=%v", err, listCalls.Load(), ids)
+	}
+	if got := listCalls.Load(); got != 2 {
+		t.Fatalf("list calls = %d, want 2", got)
+	}
+	t.Logf("err = %v after %d list calls", err, listCalls.Load())
+}
+
+func TestSearchMessageIDsFollowsDistinctPageTokens(t *testing.T) {
+	var listCalls atomic.Int32
+	svc, cleanup := newGmailServiceForTest(t, func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimPrefix(r.URL.Path, "/gmail/v1")
+		if r.Method != http.MethodGet || path != "/users/me/messages" {
+			http.NotFound(w, r)
+			return
+		}
+		n := listCalls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Query().Get("pageToken") == "" {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"messages":      []map[string]any{{"id": "m1"}},
+				"nextPageToken": "page-2",
+			})
+			return
+		}
+		if r.URL.Query().Get("pageToken") != "page-2" || n != 2 {
+			t.Fatalf("unexpected list call %d token=%q", n, r.URL.Query().Get("pageToken"))
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"messages": []map[string]any{{"id": "m2"}},
+		})
+	})
+	defer cleanup()
+
+	ids, err := searchMessageIDs(context.Background(), svc, "in:inbox", 50)
+	if err != nil {
+		t.Fatalf("searchMessageIDs: %v", err)
+	}
+	if strings.Join(ids, ",") != "m1,m2" {
+		t.Fatalf("ids = %v, want [m1 m2]", ids)
+	}
+	if got := listCalls.Load(); got != 2 {
+		t.Fatalf("list calls = %d, want 2", got)
+	}
+}
+
+func TestGmailArchiveCmd_QueryRejectsRepeatedPageToken(t *testing.T) {
+	var listCalls atomic.Int32
+	svc, cleanup := newGmailServiceForTest(t, stuckGmailSearchListHandler(t, &listCalls))
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(withGmailTestService(context.Background(), svc), 10*time.Second)
+	defer cancel()
+	err := runKong(t, &GmailArchiveCmd{}, []string{"--query", "in:inbox", "--max", "50"}, ctx, &RootFlags{Account: "a@b.com"})
+	if err == nil || !strings.Contains(err.Error(), "repeated page token") {
+		t.Fatalf("err = %v after %d list calls", err, listCalls.Load())
+	}
+	if got := listCalls.Load(); got != 2 {
+		t.Fatalf("list calls = %d, want 2", got)
+	}
+	t.Logf("err = %v after %d list calls", err, listCalls.Load())
 }


### PR DESCRIPTION
## What Problem This Solves

`gog gmail archive --query` and `gog gmail autoreply` resolve matching IDs through `searchMessageIDs`. That helper assigned `pageToken = resp.NextPageToken` until the token was empty or `--max` was reached. If Google repeats `nextPageToken` while `remaining > 0`, the loop never finishes.

An empty list page is the hang. `remaining` only shrinks by `len(resp.Messages)`. A stuck token with no messages leaves `remaining` unchanged, so `gog gmail archive -q 'in:inbox'` keeps calling `users.messages.list` until the process is killed.

## Why

Gmail backup ID listing already rejects a repeated token with a local `seenTokens` map ([#1004](https://github.com/openclaw/gogcli/pull/1004)). `searchMessageIDs` cannot switch to `collectAllPages` because it still has to honor `--max` and the 500-result page cap. This change uses the same seen-token check before assigning the next token.

## User Impact

A stuck Gmail `nextPageToken` now fails with `pagination loop: repeated page token` instead of hanging `gog gmail archive --query` or `gog gmail autoreply`. Distinct page tokens still walk normally.

## Evidence

terminal output from the unpatched search loop versus this patch. A local Gmail `users.messages.list` peer always returns `nextPageToken=stuck`.

Unpatched (the HTTP peer answers immediately; the hang guard returns 400 on the third list call so the loop cannot run forever):

```console
$ go test ./internal/cmd -count=1 -timeout 60s -run "TestSearchMessageIDsRejectsRepeatedPageToken|TestGmailArchiveCmd_QueryRejectsRepeatedPageToken"
--- FAIL: TestSearchMessageIDsRejectsRepeatedPageToken (0.00s)
    gmail_archive_test.go:346: err = googleapi: got HTTP response code 400 with body: too many list requests
         after 3 list calls, ids=[]
--- FAIL: TestGmailArchiveCmd_QueryRejectsRepeatedPageToken (0.00s)
    gmail_archive_test.go:400: err = googleapi: got HTTP response code 400 with body: too many list requests
         after 3 list calls
FAIL
```

Patched (same commands, same stuck token, returns immediately after two list calls):

```console
$ go test ./internal/cmd -count=1 -timeout 30s -v -run "TestSearchMessageIDsRejectsRepeatedPageToken|TestSearchMessageIDsRejectsRepeatedEmptyPageToken|TestSearchMessageIDsFollowsDistinctPageTokens|TestGmailArchiveCmd_QueryRejectsRepeatedPageToken"
=== RUN   TestSearchMessageIDsRejectsRepeatedPageToken
    gmail_archive_test.go:351: err = pagination loop: repeated page token "stuck" after 2 list calls
--- PASS: TestSearchMessageIDsRejectsRepeatedPageToken (0.00s)
=== RUN   TestSearchMessageIDsRejectsRepeatedEmptyPageToken
    gmail_archive_test.go:379: err = pagination loop: repeated page token "stuck" after 2 list calls
--- PASS: TestSearchMessageIDsRejectsRepeatedEmptyPageToken (0.00s)
=== RUN   TestSearchMessageIDsFollowsDistinctPageTokens
--- PASS: TestSearchMessageIDsFollowsDistinctPageTokens (0.00s)
=== RUN   TestGmailArchiveCmd_QueryRejectsRepeatedPageToken
    gmail_archive_test.go:434: err = pagination loop: repeated page token "stuck" after 2 list calls
--- PASS: TestGmailArchiveCmd_QueryRejectsRepeatedPageToken (0.00s)
PASS
ok  github.com/openclaw/gogcli/internal/cmd  2.704s
```

Live CLI still exposes the public query path:

```console
$ .\bin\gog.exe gmail archive --help
Usage: gog gmail (mail,email) archive [<messageId> ...] [flags]
  -q, --query=STRING            Archive all messages matching this Gmail search
                                query
      --max=100                 Max messages to archive (with --query)
```

`gofmt` is clean. `golangci-lint run ./internal/cmd/` reported 0 issues. `go build ./internal/cmd/` succeeded.

## Real behavior proof

- **Behavior or issue addressed:** Repeated Google `nextPageToken` values could hang `gog gmail archive --query` and `gog gmail autoreply` while `searchMessageIDs` paged `users.messages.list` and `remaining` stayed above zero.
- **Real environment tested:** Windows NT 10.0.26200.0 amd64, Go go1.27.1, worktree `C:\Users\sebta\.grok\tmp\pr-gate-batch\gogcli-f022` on `fix/gmail-archive-page-token` from `origin/main` at `25703c78`.
- **Exact steps or command run after this patch:** From that worktree, ran `go test ./internal/cmd -count=1 -timeout 30s -v -run TestSearchMessageIDsRejectsRepeatedEmptyPageToken` against a Gmail list peer that always returns `nextPageToken=stuck` and no messages (so `remaining` never shrinks), then ran `.\bin\gog.exe gmail archive --help` on the binary built from this branch.
- **Evidence after fix:** terminal output above. The search now returns `pagination loop: repeated page token "stuck"` after 2 list calls (0.00s). The unpatched loop made a third list call and only stopped when the hang guard returned HTTP 400.
- **Observed result after fix:** The stuck token no longer pages while `remaining > 0`. `searchMessageIDs` and `gog gmail archive --query in:inbox --max 50` return the repeated-token error on the next page instead of hanging. Two distinct tokens still return `m1,m2`.
- **What was not tested:** A live `users.messages.list` response that actually repeats a token. That requires a faulty Google page, which we cannot force from a healthy account.

## Related

- Same-repo guard already used by Gmail backup `ListMessageIDs` in [#1004](https://github.com/openclaw/gogcli/pull/1004) and by `collectAllPages` in `internal/cmd/paging.go`.
- `gog gmail search --from-contact` fallback uses the same error in [#1045](https://github.com/openclaw/gogcli/pull/1045).
- Unguarded archive query paging dates to [`74d8089a`](https://github.com/openclaw/gogcli/commit/74d8089a) (landed in [#385](https://github.com/openclaw/gogcli/pull/385), 2026-03-02, 187 days ago).
