### PR TITLE
fix(paging): reject token cycles across CLI scans and backups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## 0.39.1 - Unreleased
 
+### Highlights
+
+- Backups: stop repeated page tokens across Drive, Calendar, Contacts, Tasks, Groups, Admin, Keep, Workspace, and Apps Script without adding new page limits; retain earlier ACL and membership rows on ordinary API failures. (#1078, #1079, #1080, #1081, #1082, #1087) — thanks @SebTardif.
+- Calendar: stop cyclic recurring-instance lookups while preserving success as soon as the requested occurrence is found. (#1084, #1087) — thanks @SebTardif.
+- Gmail: stop cyclic query scans before bulk message changes or automatic replies, including empty result pages. (#1086, #1087) — thanks @SebTardif.
+- Drive and Contacts: stop tree, inventory, disk-usage, and contact-dedupe scans on repeated page tokens before emitting a partial report or applying contact changes. (#1083, #1085, #1087) — thanks @SebTardif.
+- Docs: stop open-comment scans when Drive repeats a page token, preserving first-open-page results. (#1087) — thanks @SebTardif.
 - Dependencies: refresh Google API support modules, tracking worker tooling and Undici, pnpm, and the Pages deployment action while retaining Go 1.26 compatibility.
 
 ## 0.39.0 - 2026-09-03

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -148,6 +148,14 @@ Best-effort optional services record encrypted `errors` shards and let the rest
 of the backup finish. The Gmail cache is only a local acceleration/resume cache;
 encrypted backup shards remain the source of truth once a push completes.
 
+Backup listings reject repeated page tokens without imposing new limits on
+distinct pages. Drive, Calendar, Contacts, and Tasks collection errors stop the
+final snapshot; optional service errors follow `--best-effort`. Per-file Drive
+collaboration errors and per-form response errors remain embedded error rows.
+Calendar ACL and Groups membership listings retain fetched rows on an ordinary
+later API error, but discard the affected resource's rows when pagination cycles;
+both cases record an error and continue with the next calendar or group.
+
 ## Files
 
 Local config:

--- a/docs/contacts-dedupe.md
+++ b/docs/contacts-dedupe.md
@@ -7,6 +7,9 @@ read_when:
 `gog contacts dedupe` finds likely duplicate personal contacts and prints a
 merge plan. Preview is the default; `--apply` performs the reviewed plan.
 
+Repeated page tokens stop the scan before a plan or contact update. `--max 0`
+still scans every distinct page; a positive `--max` stops at that contact count.
+
 ## Command Page
 
 - [`gog contacts dedupe`](commands/gog-contacts-dedupe.md)

--- a/docs/docs-editing.md
+++ b/docs/docs-editing.md
@@ -135,6 +135,10 @@ Use `--occurrence N` when an anchor is ambiguous and `--match-case` when case
 must be exact. `docs comments locate` applies the same matching rules to a
 comment's quoted text and reports its tab plus UTF-16 range.
 
+By default, `docs comments list` skips resolved-only pages until it finds open
+comments or reaches the end. A repeated page token stops the scan with a
+pagination error instead of hanging or reporting an incomplete result.
+
 `docs comments list --locate` does the same for every listed comment from a
 single document fetch, adding a `location` object (`matches`, `orphaned`) and a
 `TAB` column. `--tab` implies `--locate`, adds the resolved tab to JSON output

--- a/docs/drive-audits.md
+++ b/docs/drive-audits.md
@@ -48,6 +48,9 @@ aggregates those placements independently and sorts by `size`, `path`, or
 `files`. Shortcuts count as file placements with zero content bytes; scans do
 not follow shortcut targets.
 
+These reports reject repeated folder-list page tokens before emitting output.
+Successful scans retain their existing size and depth limits.
+
 ## Inventory Export
 
 Export a read-only item inventory:

--- a/docs/gmail-workflows.md
+++ b/docs/gmail-workflows.md
@@ -21,6 +21,10 @@ page by page and retains only exact name or email matches. Multiple matching
 contacts require a more specific selector; a repeated page token stops with a
 pagination error instead of leaving the command stuck.
 
+Query-based bulk message commands and autoreply also reject repeated page
+tokens, including empty pages, before modifying messages or sending replies.
+Their existing `--max` limit still stops the scan as soon as it is reached.
+
 For agents, logs, or issue reports, prefer sanitized content:
 
 ```bash

--- a/internal/cmd/backup_directory_keep.go
+++ b/internal/cmd/backup_directory_keep.go
@@ -136,7 +136,11 @@ func buildKeepBackupSnapshot(ctx context.Context, flags *RootFlags, shardMaxRows
 func fetchBackupCloudIdentityGroups(ctx context.Context, svc *cloudidentity.Service, account string) ([]*cloudidentity.GroupRelation, error) {
 	var out []*cloudidentity.GroupRelation
 	pageToken := ""
+	var guard pageTokenGuard
 	for {
+		if err := guard.check(pageToken); err != nil {
+			return nil, err
+		}
 		call := svc.Groups.Memberships.SearchTransitiveGroups("groups/-").
 			Query(searchTransitiveGroupsQuery(account)).
 			PageSize(1000).
@@ -171,7 +175,13 @@ func fetchBackupCloudIdentityGroupMembers(ctx context.Context, svc *cloudidentit
 			continue
 		}
 		pageToken := ""
+		var guard pageTokenGuard
+		groupStart := len(out)
 		for {
+			if err := guard.check(pageToken); err != nil {
+				out = append(out[:groupStart], groupsBackupMember{GroupEmail: groupEmail, Error: err.Error()})
+				break
+			}
 			call := svc.Groups.Memberships.List(groupName).PageSize(1000).Context(ctx)
 			if pageToken != "" {
 				call = call.PageToken(pageToken)
@@ -199,48 +209,47 @@ func fetchBackupCloudIdentityGroupMembers(ctx context.Context, svc *cloudidentit
 	return out
 }
 
-func fetchBackupAdminUsers(ctx context.Context, svc *admin.Service, domain string) ([]*admin.User, error) {
-	var out []*admin.User
-	pageToken := ""
-	for {
-		call := svc.Users.List().Domain(domain).MaxResults(500).Context(ctx)
-		if pageToken != "" {
-			call = call.PageToken(pageToken)
-		}
-		resp, err := call.Do()
-		if err != nil {
-			return nil, err
-		}
-		out = append(out, resp.Users...)
-		if resp.NextPageToken == "" {
-			break
-		}
-		pageToken = resp.NextPageToken
+func fetchSortedBackupPages[T any](fetch func(string) ([]T, string, error), less func(T, T) bool) ([]T, error) {
+	rows, err := collectUnboundedPages("", fetch)
+	if err != nil {
+		return nil, err
 	}
-	sort.Slice(out, func(i, j int) bool { return out[i].PrimaryEmail < out[j].PrimaryEmail })
-	return out, nil
+	sort.Slice(rows, func(i, j int) bool { return less(rows[i], rows[j]) })
+	return rows, nil
+}
+
+func fetchBackupAdminUsers(ctx context.Context, svc *admin.Service, domain string) ([]*admin.User, error) {
+	return fetchSortedBackupPages(
+		func(pageToken string) ([]*admin.User, string, error) {
+			call := svc.Users.List().Domain(domain).MaxResults(500).Context(ctx)
+			if pageToken != "" {
+				call = call.PageToken(pageToken)
+			}
+			resp, err := call.Do()
+			if err != nil {
+				return nil, "", err
+			}
+			return resp.Users, resp.NextPageToken, nil
+		},
+		func(a, b *admin.User) bool { return a.PrimaryEmail < b.PrimaryEmail },
+	)
 }
 
 func fetchBackupAdminGroups(ctx context.Context, svc *admin.Service, domain string) ([]*admin.Group, error) {
-	var out []*admin.Group
-	pageToken := ""
-	for {
-		call := svc.Groups.List().Domain(domain).MaxResults(200).Context(ctx)
-		if pageToken != "" {
-			call = call.PageToken(pageToken)
-		}
-		resp, err := call.Do()
-		if err != nil {
-			return nil, err
-		}
-		out = append(out, resp.Groups...)
-		if resp.NextPageToken == "" {
-			break
-		}
-		pageToken = resp.NextPageToken
-	}
-	sort.Slice(out, func(i, j int) bool { return out[i].Email < out[j].Email })
-	return out, nil
+	return fetchSortedBackupPages(
+		func(pageToken string) ([]*admin.Group, string, error) {
+			call := svc.Groups.List().Domain(domain).MaxResults(200).Context(ctx)
+			if pageToken != "" {
+				call = call.PageToken(pageToken)
+			}
+			resp, err := call.Do()
+			if err != nil {
+				return nil, "", err
+			}
+			return resp.Groups, resp.NextPageToken, nil
+		},
+		func(a, b *admin.Group) bool { return a.Email < b.Email },
+	)
 }
 
 func fetchBackupAdminGroupMembers(ctx context.Context, svc *admin.Service, groups []*admin.Group) []adminBackupMember {
@@ -286,25 +295,20 @@ func fetchAllBackupAdminGroupMembers(ctx context.Context, svc *admin.Service, gr
 }
 
 func fetchBackupKeepNotes(ctx context.Context, svc *keepapi.Service) ([]*keepapi.Note, error) {
-	var out []*keepapi.Note
-	pageToken := ""
-	for {
-		call := svc.Notes.List().PageSize(1000).Context(ctx)
-		if pageToken != "" {
-			call = call.PageToken(pageToken)
-		}
-		resp, err := call.Do()
-		if err != nil {
-			return nil, err
-		}
-		out = append(out, resp.Notes...)
-		if resp.NextPageToken == "" {
-			break
-		}
-		pageToken = resp.NextPageToken
-	}
-	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
-	return out, nil
+	return fetchSortedBackupPages(
+		func(pageToken string) ([]*keepapi.Note, string, error) {
+			call := svc.Notes.List().PageSize(1000).Context(ctx)
+			if pageToken != "" {
+				call = call.PageToken(pageToken)
+			}
+			resp, err := call.Do()
+			if err != nil {
+				return nil, "", err
+			}
+			return resp.Notes, resp.NextPageToken, nil
+		},
+		func(a, b *keepapi.Note) bool { return a.Name < b.Name },
+	)
 }
 
 func domainFromAccount(account string) string {

--- a/internal/cmd/backup_directory_keep_test.go
+++ b/internal/cmd/backup_directory_keep_test.go
@@ -1,0 +1,298 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"google.golang.org/api/cloudidentity/v1"
+)
+
+func TestFetchBackupCloudIdentityGroupsRejectsRepeatedPageToken(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	svc := newCloudIdentityTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !strings.Contains(r.URL.Path, "groups/-/memberships:searchTransitiveGroups") {
+			http.NotFound(w, r)
+			return
+		}
+		n := calls.Add(1)
+		if n > 2 {
+			http.Error(w, "unexpected extra group page request", http.StatusBadRequest)
+			return
+		}
+		wantToken := ""
+		if n == 2 {
+			wantToken = "stuck"
+		}
+		requireQuery(t, r, "pageToken", wantToken)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"memberships":   []map[string]any{{"groupKey": map[string]any{"id": "eng@example.com"}}},
+			"nextPageToken": "stuck",
+		})
+	}))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	got, err := fetchBackupCloudIdentityGroups(ctx, svc, "admin@example.com")
+	if err == nil || !strings.Contains(err.Error(), "repeated page token") {
+		t.Fatalf("err = %v after %d list calls", err, calls.Load())
+	}
+	if got != nil {
+		t.Fatalf("groups = %#v, want no partial result", got)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("list calls = %d, want 2", got)
+	}
+	t.Logf("err = %v after %d list calls", err, calls.Load())
+}
+
+func TestFetchBackupCloudIdentityGroupMembersRejectsRepeatedPageToken(t *testing.T) {
+	t.Parallel()
+
+	var listCalls atomic.Int32
+	svc := newCloudIdentityTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "groups:lookup"):
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"name": "groups/abc123"})
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "groups/abc123/memberships"):
+			n := listCalls.Add(1)
+			if n > 2 {
+				http.Error(w, "unexpected extra membership page request", http.StatusBadRequest)
+				return
+			}
+			wantToken := ""
+			if n == 2 {
+				wantToken = "stuck"
+			}
+			requireQuery(t, r, "pageToken", wantToken)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"memberships":   []map[string]any{{"preferredMemberKey": map[string]any{"id": "alice@example.com"}}},
+				"nextPageToken": "stuck",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	got := fetchBackupCloudIdentityGroupMembers(ctx, svc, []*cloudidentity.GroupRelation{
+		{GroupKey: &cloudidentity.EntityKey{Id: "eng@example.com"}},
+	})
+	if len(got) != 1 || !strings.Contains(got[0].Error, "repeated page token") {
+		t.Fatalf("members = %#v after %d list calls", got, listCalls.Load())
+	}
+	if got := listCalls.Load(); got != 2 {
+		t.Fatalf("list calls = %d, want 2", got)
+	}
+	t.Logf("member error = %s after %d list calls", got[0].Error, listCalls.Load())
+}
+
+func newStuckAdminBackupHandler(t *testing.T, calls *atomic.Int32, suffix, extra, key string, item map[string]any) http.Handler {
+	t.Helper()
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !strings.HasSuffix(r.URL.Path, suffix) {
+			http.NotFound(w, r)
+			return
+		}
+		n := calls.Add(1)
+		if n > 2 {
+			http.Error(w, extra, http.StatusBadRequest)
+			return
+		}
+		wantToken := ""
+		if n == 2 {
+			wantToken = "stuck"
+		}
+		requireQuery(t, r, "pageToken", wantToken)
+		requireQuery(t, r, "domain", "example.com")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			key:             []map[string]any{item},
+			"nextPageToken": "stuck",
+		})
+	})
+}
+
+func TestFetchBackupAdminUsersRejectsRepeatedPageToken(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	svc := newAdminTestService(t, newStuckAdminBackupHandler(t, &calls, "/users", "unexpected extra user page request", "users", map[string]any{"primaryEmail": "ada@example.com"}))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	got, err := fetchBackupAdminUsers(ctx, svc, "example.com")
+	if err == nil || !strings.Contains(err.Error(), "repeated page token") {
+		t.Fatalf("err = %v after %d list calls", err, calls.Load())
+	}
+	if got != nil {
+		t.Fatalf("users = %#v, want no partial result", got)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("list calls = %d, want 2", got)
+	}
+	t.Logf("err = %v after %d list calls", err, calls.Load())
+}
+
+func TestFetchBackupAdminGroupsRejectsRepeatedPageToken(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	svc := newAdminTestService(t, newStuckAdminBackupHandler(t, &calls, "/groups", "unexpected extra admin group page request", "groups", map[string]any{"email": "eng@example.com"}))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	got, err := fetchBackupAdminGroups(ctx, svc, "example.com")
+	if err == nil || !strings.Contains(err.Error(), "repeated page token") {
+		t.Fatalf("err = %v after %d list calls", err, calls.Load())
+	}
+	if got != nil {
+		t.Fatalf("groups = %#v, want no partial result", got)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("list calls = %d, want 2", got)
+	}
+	t.Logf("err = %v after %d list calls", err, calls.Load())
+}
+
+func TestFetchBackupKeepNotesRejectsRepeatedPageToken(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/v1/notes" {
+			http.NotFound(w, r)
+			return
+		}
+		n := calls.Add(1)
+		if n > 2 {
+			http.Error(w, "unexpected extra keep note page request", http.StatusBadRequest)
+			return
+		}
+		wantToken := ""
+		if n == 2 {
+			wantToken = "stuck"
+		}
+		requireQuery(t, r, "pageToken", wantToken)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"notes":         []map[string]any{{"name": "notes/abc"}},
+			"nextPageToken": "stuck",
+		})
+	}))
+	t.Cleanup(srv.Close)
+	svc := newKeepTestServiceFromServer(t, srv)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	got, err := fetchBackupKeepNotes(ctx, svc)
+	if err == nil || !strings.Contains(err.Error(), "repeated page token") {
+		t.Fatalf("err = %v after %d list calls", err, calls.Load())
+	}
+	if got != nil {
+		t.Fatalf("notes = %#v, want no partial result", got)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("list calls = %d, want 2", got)
+	}
+	t.Logf("err = %v after %d list calls", err, calls.Load())
+}
+
+func TestFetchBackupAdminUsersTwoDistinctPagesSucceed(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	svc := newAdminTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !strings.HasSuffix(r.URL.Path, "/users") {
+			http.NotFound(w, r)
+			return
+		}
+		n := calls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		if n == 1 {
+			requireQuery(t, r, "pageToken", "")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"users":         []map[string]any{{"primaryEmail": "zoe@example.com"}},
+				"nextPageToken": "page-2",
+			})
+			return
+		}
+		if n == 2 {
+			requireQuery(t, r, "pageToken", "page-2")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"users": []map[string]any{{"primaryEmail": "ada@example.com"}},
+			})
+			return
+		}
+		http.Error(w, "unexpected extra user page request", http.StatusBadRequest)
+	}))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	got, err := fetchBackupAdminUsers(ctx, svc, "example.com")
+	if err != nil {
+		t.Fatalf("err = %v after %d list calls", err, calls.Load())
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("list calls = %d, want 2", calls.Load())
+	}
+	if len(got) != 2 || got[0].PrimaryEmail != "ada@example.com" || got[1].PrimaryEmail != "zoe@example.com" {
+		t.Fatalf("users = %#v, want sorted ada then zoe", got)
+	}
+}
+
+func TestFetchBackupKeepNotesTwoDistinctPagesSucceed(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/v1/notes" {
+			http.NotFound(w, r)
+			return
+		}
+		n := calls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		if n == 1 {
+			requireQuery(t, r, "pageToken", "")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"notes":         []map[string]any{{"name": "notes/zzz"}},
+				"nextPageToken": "page-2",
+			})
+			return
+		}
+		if n == 2 {
+			requireQuery(t, r, "pageToken", "page-2")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"notes": []map[string]any{{"name": "notes/aaa"}},
+			})
+			return
+		}
+		http.Error(w, "unexpected extra keep note page request", http.StatusBadRequest)
+	}))
+	t.Cleanup(srv.Close)
+	svc := newKeepTestServiceFromServer(t, srv)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	got, err := fetchBackupKeepNotes(ctx, svc)
+	if err != nil {
+		t.Fatalf("err = %v after %d list calls", err, calls.Load())
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("list calls = %d, want 2", calls.Load())
+	}
+	if len(got) != 2 || got[0].Name != "notes/aaa" || got[1].Name != "notes/zzz" {
+		t.Fatalf("notes = %#v, want sorted aaa then zzz", got)
+	}
+}

--- a/internal/cmd/backup_drive.go
+++ b/internal/cmd/backup_drive.go
@@ -99,9 +99,7 @@ func buildDriveBackupSnapshot(ctx context.Context, flags *RootFlags, opts driveB
 }
 
 func fetchBackupSharedDrives(ctx context.Context, svc *drive.Service) ([]*drive.Drive, error) {
-	var out []*drive.Drive
-	pageToken := ""
-	for {
+	out, err := collectUnboundedPages("", func(pageToken string) ([]*drive.Drive, string, error) {
 		call := svc.Drives.List().
 			PageSize(100).
 			Fields("nextPageToken, drives(id, name, createdTime, hidden, restrictions)").
@@ -111,22 +109,19 @@ func fetchBackupSharedDrives(ctx context.Context, svc *drive.Service) ([]*drive.
 		}
 		resp, err := call.Do()
 		if err != nil {
-			return nil, err
+			return nil, "", err
 		}
-		out = append(out, resp.Drives...)
-		if resp.NextPageToken == "" {
-			break
-		}
-		pageToken = resp.NextPageToken
+		return resp.Drives, resp.NextPageToken, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Id < out[j].Id })
 	return out, nil
 }
 
 func fetchBackupDriveFiles(ctx context.Context, svc *drive.Service) ([]driveBackupFile, error) {
-	var out []driveBackupFile
-	pageToken := ""
-	for {
+	files, err := collectUnboundedPages("", func(pageToken string) ([]*drive.File, string, error) {
 		call := svc.Files.List().
 			Q("trashed = false").
 			PageSize(1000).
@@ -139,15 +134,16 @@ func fetchBackupDriveFiles(ctx context.Context, svc *drive.Service) ([]driveBack
 		}
 		resp, err := call.Do()
 		if err != nil {
-			return nil, err
+			return nil, "", err
 		}
-		for _, file := range resp.Files {
-			out = append(out, driveBackupFile{File: file})
-		}
-		if resp.NextPageToken == "" {
-			break
-		}
-		pageToken = resp.NextPageToken
+		return resp.Files, resp.NextPageToken, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	var out []driveBackupFile
+	for _, file := range files {
+		out = append(out, driveBackupFile{File: file})
 	}
 	return out, nil
 }

--- a/internal/cmd/backup_drive_collaboration.go
+++ b/internal/cmd/backup_drive_collaboration.go
@@ -149,7 +149,11 @@ func fetchBackupDriveFileCollaboration(ctx context.Context, svc *drive.Service, 
 func fetchBackupDrivePermissions(ctx context.Context, svc *drive.Service, fileID string) ([]*drive.Permission, error) {
 	var out []*drive.Permission
 	pageToken := ""
+	var guard pageTokenGuard
 	for {
+		if err := guard.check(pageToken); err != nil {
+			return nil, fmt.Errorf("drive file %s permissions: %w", fileID, err)
+		}
 		call := svc.Permissions.List(fileID).
 			PageSize(100).
 			SupportsAllDrives(true).
@@ -174,7 +178,11 @@ func fetchBackupDrivePermissions(ctx context.Context, svc *drive.Service, fileID
 func fetchBackupDriveComments(ctx context.Context, svc *drive.Service, fileID string) ([]*drive.Comment, error) {
 	var out []*drive.Comment
 	pageToken := ""
+	var guard pageTokenGuard
 	for {
+		if err := guard.check(pageToken); err != nil {
+			return nil, fmt.Errorf("drive file %s comments: %w", fileID, err)
+		}
 		comments, nextPageToken, err := listDriveComments(ctx, svc, fileID, driveCommentListOptions{
 			includeResolved: true,
 			includeQuoted:   true,
@@ -197,7 +205,11 @@ func fetchBackupDriveComments(ctx context.Context, svc *drive.Service, fileID st
 func fetchBackupDriveRevisions(ctx context.Context, svc *drive.Service, fileID string) ([]*drive.Revision, error) {
 	var out []*drive.Revision
 	pageToken := ""
+	var guard pageTokenGuard
 	for {
+		if err := guard.check(pageToken); err != nil {
+			return nil, fmt.Errorf("drive file %s revisions: %w", fileID, err)
+		}
 		call := svc.Revisions.List(fileID).
 			PageSize(200).
 			Fields(gapi.Field(driveRevisionListFields)).

--- a/internal/cmd/backup_drive_collaboration_test.go
+++ b/internal/cmd/backup_drive_collaboration_test.go
@@ -1,0 +1,247 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"google.golang.org/api/drive/v3"
+)
+
+type backupCollabPageCase struct {
+	name     string
+	path     string
+	pageSize string
+	key      string
+	item1    map[string]any
+	item2    map[string]any
+	extra    func(*testing.T, *http.Request)
+	ids      func(t *testing.T, ctx context.Context, svc *drive.Service) ([]string, error)
+}
+
+func backupCollabPageCases() []backupCollabPageCase {
+	return []backupCollabPageCase{
+		{
+			name:     "permissions",
+			path:     "/files/file-1/permissions",
+			pageSize: "100",
+			key:      "permissions",
+			item1:    map[string]any{"id": "perm-1", "type": "user", "role": "reader"},
+			item2:    map[string]any{"id": "perm-2", "type": "user", "role": "writer"},
+			extra:    requireSupportsAllDrives,
+			ids: func(t *testing.T, ctx context.Context, svc *drive.Service) ([]string, error) {
+				t.Helper()
+				got, err := fetchBackupDrivePermissions(ctx, svc, "file-1")
+				if err != nil {
+					return nil, err
+				}
+				out := make([]string, len(got))
+				for i, item := range got {
+					out[i] = item.Id
+				}
+				return out, nil
+			},
+		},
+		{
+			name:     "comments",
+			path:     "/files/file-1/comments",
+			pageSize: "100",
+			key:      "comments",
+			item1:    map[string]any{"id": "comment-1", "content": "hello"},
+			item2:    map[string]any{"id": "comment-2", "content": "second"},
+			ids: func(t *testing.T, ctx context.Context, svc *drive.Service) ([]string, error) {
+				t.Helper()
+				got, err := fetchBackupDriveComments(ctx, svc, "file-1")
+				if err != nil {
+					return nil, err
+				}
+				out := make([]string, len(got))
+				for i, item := range got {
+					out[i] = item.Id
+				}
+				return out, nil
+			},
+		},
+		{
+			name:     "revisions",
+			path:     "/files/file-1/revisions",
+			pageSize: "200",
+			key:      "revisions",
+			item1:    map[string]any{"id": "rev-1", "modifiedTime": "2026-04-01T10:00:00Z"},
+			item2:    map[string]any{"id": "rev-2", "modifiedTime": "2026-04-02T10:00:00Z"},
+			ids: func(t *testing.T, ctx context.Context, svc *drive.Service) ([]string, error) {
+				t.Helper()
+				got, err := fetchBackupDriveRevisions(ctx, svc, "file-1")
+				if err != nil {
+					return nil, err
+				}
+				out := make([]string, len(got))
+				for i, item := range got {
+					out[i] = item.Id
+				}
+				return out, nil
+			},
+		},
+	}
+}
+
+func TestFetchBackupDriveCollaborationRejectsRepeatedPageToken(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range backupCollabPageCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var calls atomic.Int32
+			svc, closeSvc := newDriveTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodGet || !strings.HasSuffix(r.URL.Path, tc.path) {
+					http.NotFound(w, r)
+					return
+				}
+				n := calls.Add(1)
+				if n > 2 {
+					http.Error(w, "unexpected extra "+tc.name+" page request", http.StatusBadRequest)
+					return
+				}
+				wantToken := ""
+				if n == 2 {
+					wantToken = "stuck"
+				}
+				requireQuery(t, r, "pageToken", wantToken)
+				requireQuery(t, r, "pageSize", tc.pageSize)
+				if tc.extra != nil {
+					tc.extra(t, r)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					tc.key:          []map[string]any{tc.item1},
+					"nextPageToken": "stuck",
+				})
+			}))
+			defer closeSvc()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			got, err := tc.ids(t, ctx, svc)
+			if err == nil || !strings.Contains(err.Error(), "repeated page token") {
+				t.Fatalf("err = %v after %d list calls", err, calls.Load())
+			}
+			if got != nil {
+				t.Fatalf("%s = %#v, want no partial result", tc.name, got)
+			}
+			if n := calls.Load(); n != 2 {
+				t.Fatalf("list calls = %d, want 2", n)
+			}
+			t.Logf("err = %v after %d list calls", err, calls.Load())
+		})
+	}
+}
+
+func TestFetchBackupDriveCollaborationTwoDistinctPagesSucceed(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range backupCollabPageCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var calls atomic.Int32
+			svc, closeSvc := newDriveTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodGet || !strings.HasSuffix(r.URL.Path, tc.path) {
+					http.NotFound(w, r)
+					return
+				}
+				n := calls.Add(1)
+				if tc.extra != nil {
+					tc.extra(t, r)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				if n == 1 {
+					requireQuery(t, r, "pageToken", "")
+					_ = json.NewEncoder(w).Encode(map[string]any{
+						tc.key:          []map[string]any{tc.item1},
+						"nextPageToken": "page-2",
+					})
+					return
+				}
+				if n == 2 {
+					requireQuery(t, r, "pageToken", "page-2")
+					_ = json.NewEncoder(w).Encode(map[string]any{
+						tc.key: []map[string]any{tc.item2},
+					})
+					return
+				}
+				http.Error(w, "unexpected extra "+tc.name+" page request", http.StatusBadRequest)
+			}))
+			defer closeSvc()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			got, err := tc.ids(t, ctx, svc)
+			if err != nil {
+				t.Fatalf("err = %v after %d list calls", err, calls.Load())
+			}
+			if calls.Load() != 2 {
+				t.Fatalf("list calls = %d, want 2", calls.Load())
+			}
+			want1, _ := tc.item1["id"].(string)
+			want2, _ := tc.item2["id"].(string)
+			if len(got) != 2 || got[0] != want1 || got[1] != want2 {
+				t.Fatalf("%s = %#v, want both pages concatenated", tc.name, got)
+			}
+		})
+	}
+}
+
+func TestFetchBackupDriveCollaborationRecordsRepeatedPageToken(t *testing.T) {
+	t.Parallel()
+
+	var permCalls atomic.Int32
+	svc, closeSvc := newDriveTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/files/file-1/permissions"):
+			n := permCalls.Add(1)
+			if n > 2 {
+				http.Error(w, "unexpected extra permission page request", http.StatusBadRequest)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"permissions":   []map[string]any{{"id": "perm-1", "type": "user", "role": "reader"}},
+				"nextPageToken": "stuck",
+			})
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/files/file-1/comments"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"comments": []map[string]any{{"id": "comment-1", "content": "hello"}},
+			})
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/files/file-1/revisions"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"revisions": []map[string]any{{"id": "rev-1", "modifiedTime": "2026-04-02T10:00:00Z"}},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer closeSvc()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	got, counts := fetchBackupDriveCollaboration(ctx, svc, []driveBackupFile{
+		{File: &drive.File{Id: "file-1"}},
+	})
+	if permCalls.Load() != 2 {
+		t.Fatalf("permission list calls = %d, want 2", permCalls.Load())
+	}
+	if counts["drive.collab.errors"] != 1 || counts["drive.comments"] != 1 || counts["drive.revisions"] != 1 {
+		t.Fatalf("unexpected counts: %#v", counts)
+	}
+	if len(got.Permissions) != 1 || got.Permissions[0].FileID != "file-1" || !strings.Contains(got.Permissions[0].Error, "repeated page token") {
+		t.Fatalf("permission row = %#v, want repeated page token error", got.Permissions)
+	}
+	if len(got.Comments) != 1 || got.Comments[0].Comment == nil || got.Comments[0].Comment.Id != "comment-1" {
+		t.Fatalf("comments = %#v", got.Comments)
+	}
+}

--- a/internal/cmd/backup_drive_test.go
+++ b/internal/cmd/backup_drive_test.go
@@ -1,0 +1,172 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestFetchBackupSharedDrivesRejectsRepeatedPageToken(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	svc, closeSvc := newDriveTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !strings.HasSuffix(r.URL.Path, "/drives") {
+			http.NotFound(w, r)
+			return
+		}
+		n := calls.Add(1)
+		if n > 2 {
+			http.Error(w, "unexpected extra shared drive page request", http.StatusBadRequest)
+			return
+		}
+		wantToken := ""
+		if n == 2 {
+			wantToken = "stuck"
+		}
+		requireQuery(t, r, "pageToken", wantToken)
+		requireQuery(t, r, "pageSize", "100")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"drives":        []map[string]any{{"id": "drive-1", "name": "Team"}},
+			"nextPageToken": "stuck",
+		})
+	}))
+	defer closeSvc()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	got, err := fetchBackupSharedDrives(ctx, svc)
+	if err == nil || !strings.Contains(err.Error(), "repeated page token") {
+		t.Fatalf("err = %v after %d list calls", err, calls.Load())
+	}
+	if got != nil {
+		t.Fatalf("drives = %#v, want no partial result", got)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("list calls = %d, want 2", got)
+	}
+	t.Logf("err = %v after %d list calls", err, calls.Load())
+}
+
+func TestFetchBackupDriveFilesRejectsRepeatedPageToken(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	svc, closeSvc := newDriveTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !strings.HasSuffix(r.URL.Path, "/files") {
+			http.NotFound(w, r)
+			return
+		}
+		n := calls.Add(1)
+		if n > 2 {
+			http.Error(w, "unexpected extra drive file page request", http.StatusBadRequest)
+			return
+		}
+		wantToken := ""
+		if n == 2 {
+			wantToken = "stuck"
+		}
+		requireQuery(t, r, "pageToken", wantToken)
+		requireQuery(t, r, "pageSize", "1000")
+		requireQuery(t, r, "q", "trashed = false")
+		requireQuery(t, r, "orderBy", "modifiedTime desc")
+		requireSupportsAllDrives(t, r)
+		requireQuery(t, r, "includeItemsFromAllDrives", "true")
+		requireQuery(t, r, "corpora", "allDrives")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"files":         []map[string]any{{"id": "file-1", "name": "notes.txt"}},
+			"nextPageToken": "stuck",
+		})
+	}))
+	defer closeSvc()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	got, err := fetchBackupDriveFiles(ctx, svc)
+	if err == nil || !strings.Contains(err.Error(), "repeated page token") {
+		t.Fatalf("err = %v after %d list calls", err, calls.Load())
+	}
+	if got != nil {
+		t.Fatalf("files = %#v, want no partial result", got)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("list calls = %d, want 2", got)
+	}
+	t.Logf("err = %v after %d list calls", err, calls.Load())
+}
+
+func TestFetchBackupSharedDrivesTwoDistinctPagesSucceed(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	svc, closeSvc := newDriveTestService(t, backupPagingTestHandler(t, &calls, "/drives", []map[string]any{
+		{"drives": []map[string]any{{"id": "zzz", "name": "Late"}}, "nextPageToken": "page-2"},
+		{"drives": []map[string]any{{"id": "aaa", "name": "Early"}}},
+	}, nil))
+	defer closeSvc()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	got, err := fetchBackupSharedDrives(ctx, svc)
+	if err != nil {
+		t.Fatalf("err = %v after %d list calls", err, calls.Load())
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("list calls = %d, want 2", calls.Load())
+	}
+	if len(got) != 2 || got[0].Id != "aaa" || got[1].Id != "zzz" {
+		t.Fatalf("drives = %#v, want sorted ids aaa then zzz", got)
+	}
+}
+
+func TestFetchBackupDriveFilesTwoDistinctPagesSucceed(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	svc, closeSvc := newDriveTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !strings.HasSuffix(r.URL.Path, "/files") {
+			http.NotFound(w, r)
+			return
+		}
+		n := calls.Add(1)
+		requireSupportsAllDrives(t, r)
+		requireQuery(t, r, "corpora", "allDrives")
+		w.Header().Set("Content-Type", "application/json")
+		if n == 1 {
+			requireQuery(t, r, "pageToken", "")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"files":         []map[string]any{{"id": "file-1", "name": "a.txt"}},
+				"nextPageToken": "page-2",
+			})
+			return
+		}
+		if n == 2 {
+			requireQuery(t, r, "pageToken", "page-2")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"files": []map[string]any{{"id": "file-2", "name": "b.txt"}},
+			})
+			return
+		}
+		http.Error(w, "unexpected extra drive file page request", http.StatusBadRequest)
+	}))
+	defer closeSvc()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	got, err := fetchBackupDriveFiles(ctx, svc)
+	if err != nil {
+		t.Fatalf("err = %v after %d list calls", err, calls.Load())
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("list calls = %d, want 2", calls.Load())
+	}
+	if len(got) != 2 || got[0].File.Id != "file-1" || got[1].File.Id != "file-2" {
+		t.Fatalf("files = %#v, want both pages concatenated", got)
+	}
+}

--- a/internal/cmd/backup_services.go
+++ b/internal/cmd/backup_services.go
@@ -210,7 +210,13 @@ func fetchBackupCalendarACLRules(ctx context.Context, svc *calendar.Service, cal
 			continue
 		}
 		pageToken := ""
+		var guard pageTokenGuard
+		calendarStart := len(out)
 		for {
+			if err := guard.check(pageToken); err != nil {
+				out = append(out[:calendarStart], calendarBackupACLRule{CalendarID: cal.Id, Error: err.Error()})
+				break
+			}
 			call := svc.Acl.List(cal.Id).MaxResults(250).Context(ctx)
 			if pageToken != "" {
 				call = call.PageToken(pageToken)
@@ -239,22 +245,19 @@ func fetchBackupCalendarACLRules(ctx context.Context, svc *calendar.Service, cal
 }
 
 func fetchBackupCalendarSettings(ctx context.Context, svc *calendar.Service) ([]*calendar.Setting, error) {
-	var out []*calendar.Setting
-	pageToken := ""
-	for {
+	out, err := collectUnboundedPages("", func(pageToken string) ([]*calendar.Setting, string, error) {
 		call := svc.Settings.List().MaxResults(250).Context(ctx)
 		if pageToken != "" {
 			call = call.PageToken(pageToken)
 		}
 		resp, err := call.Do()
 		if err != nil {
-			return nil, err
+			return nil, "", err
 		}
-		out = append(out, resp.Items...)
-		if resp.NextPageToken == "" {
-			break
-		}
-		pageToken = resp.NextPageToken
+		return resp.Items, resp.NextPageToken, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Id < out[j].Id })
 	return out, nil
@@ -312,22 +315,19 @@ func buildTasksBackupSnapshot(ctx context.Context, flags *RootFlags, shardMaxRow
 }
 
 func fetchBackupCalendars(ctx context.Context, svc *calendar.Service) ([]*calendar.CalendarListEntry, error) {
-	var out []*calendar.CalendarListEntry
-	pageToken := ""
-	for {
+	out, err := collectUnboundedPages("", func(pageToken string) ([]*calendar.CalendarListEntry, string, error) {
 		call := svc.CalendarList.List().MaxResults(250).Context(ctx)
 		if pageToken != "" {
 			call = call.PageToken(pageToken)
 		}
 		resp, err := call.Do()
 		if err != nil {
-			return nil, err
+			return nil, "", err
 		}
-		out = append(out, resp.Items...)
-		if resp.NextPageToken == "" {
-			break
-		}
-		pageToken = resp.NextPageToken
+		return resp.Items, resp.NextPageToken, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Id < out[j].Id })
 	return out, nil
@@ -340,7 +340,11 @@ func fetchBackupCalendarEvents(ctx context.Context, svc *calendar.Service, calen
 			continue
 		}
 		pageToken := ""
+		var guard pageTokenGuard
 		for {
+			if err := guard.check(pageToken); err != nil {
+				return nil, fmt.Errorf("calendar %s events: %w", cal.Id, err)
+			}
 			call := svc.Events.List(cal.Id).
 				MaxResults(2500).
 				ShowDeleted(true).
@@ -374,7 +378,11 @@ func fetchBackupCalendarEvents(ctx context.Context, svc *calendar.Service, calen
 func fetchBackupConnections(ctx context.Context, svc *people.Service) ([]contactsBackupPerson, error) {
 	var out []contactsBackupPerson
 	pageToken := ""
+	var guard pageTokenGuard
 	for {
+		if err := guard.check(pageToken); err != nil {
+			return nil, err
+		}
 		call := svc.People.Connections.List(peopleMeResource).
 			PersonFields(contactsGetReadMask).
 			PageSize(1000).
@@ -402,7 +410,11 @@ func fetchBackupOtherContacts(ctx context.Context, svc *people.Service) ([]conta
 
 	var out []contactsBackupPerson
 	pageToken := ""
+	var guard pageTokenGuard
 	for {
+		if err := guard.check(pageToken); err != nil {
+			return nil, err
+		}
 		call := svc.OtherContacts.List().
 			ReadMask(otherContactsBackupReadMask).
 			PageSize(1000).
@@ -426,9 +438,7 @@ func fetchBackupOtherContacts(ctx context.Context, svc *people.Service) ([]conta
 }
 
 func fetchBackupContactGroups(ctx context.Context, svc *people.Service) ([]*people.ContactGroup, error) {
-	var out []*people.ContactGroup
-	pageToken := ""
-	for {
+	out, err := collectUnboundedPages("", func(pageToken string) ([]*people.ContactGroup, string, error) {
 		call := svc.ContactGroups.List().
 			PageSize(1000).
 			GroupFields("clientData,groupType,memberCount,metadata,name").
@@ -438,35 +448,31 @@ func fetchBackupContactGroups(ctx context.Context, svc *people.Service) ([]*peop
 		}
 		resp, err := call.Do()
 		if err != nil {
-			return nil, err
+			return nil, "", err
 		}
-		out = append(out, resp.ContactGroups...)
-		if resp.NextPageToken == "" {
-			break
-		}
-		pageToken = resp.NextPageToken
+		return resp.ContactGroups, resp.NextPageToken, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
 	return out, nil
 }
 
 func fetchBackupTaskLists(ctx context.Context, svc *tasks.Service) ([]*tasks.TaskList, error) {
-	var out []*tasks.TaskList
-	pageToken := ""
-	for {
+	out, err := collectUnboundedPages("", func(pageToken string) ([]*tasks.TaskList, string, error) {
 		call := svc.Tasklists.List().MaxResults(100).Context(ctx)
 		if pageToken != "" {
 			call = call.PageToken(pageToken)
 		}
 		resp, err := call.Do()
 		if err != nil {
-			return nil, err
+			return nil, "", err
 		}
-		out = append(out, resp.Items...)
-		if resp.NextPageToken == "" {
-			break
-		}
-		pageToken = resp.NextPageToken
+		return resp.Items, resp.NextPageToken, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Id < out[j].Id })
 	return out, nil
@@ -479,7 +485,11 @@ func fetchBackupTasks(ctx context.Context, svc *tasks.Service, lists []*tasks.Ta
 			continue
 		}
 		pageToken := ""
+		var guard pageTokenGuard
 		for {
+			if err := guard.check(pageToken); err != nil {
+				return nil, fmt.Errorf("task list %s tasks: %w", list.Id, err)
+			}
 			call := svc.Tasks.List(list.Id).
 				MaxResults(100).
 				ShowCompleted(true).

--- a/internal/cmd/backup_services_test.go
+++ b/internal/cmd/backup_services_test.go
@@ -1,0 +1,217 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"google.golang.org/api/calendar/v3"
+	"google.golang.org/api/people/v1"
+	"google.golang.org/api/tasks/v1"
+)
+
+func TestFetchBackupCalendarsRejectsRepeatedPageToken(t *testing.T) {
+	var calls atomic.Int32
+	svc, closeSvc := newCalendarServiceForTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !strings.Contains(r.URL.Path, "/calendarList") {
+			http.NotFound(w, r)
+			return
+		}
+		n := calls.Add(1)
+		if n > 2 {
+			http.Error(w, "unexpected extra calendar page request", http.StatusBadRequest)
+			return
+		}
+		wantToken := ""
+		if n == 2 {
+			wantToken = "stuck"
+		}
+		requireQuery(t, r, "pageToken", wantToken)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"items":         []map[string]any{{"id": "cal-1", "summary": "Work"}},
+			"nextPageToken": "stuck",
+		})
+	}))
+	defer closeSvc()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	got, err := fetchBackupCalendars(ctx, svc)
+	if err == nil || !strings.Contains(err.Error(), "repeated page token") {
+		t.Fatalf("err = %v after %d list calls", err, calls.Load())
+	}
+	if got != nil {
+		t.Fatalf("calendars = %#v, want no partial result", got)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("list calls = %d, want 2", got)
+	}
+	t.Logf("err = %v after %d list calls", err, calls.Load())
+}
+
+func TestFetchBackupConnectionsRejectsRepeatedPageToken(t *testing.T) {
+	var calls atomic.Int32
+	svc, closeSvc := newGoogleTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !strings.Contains(r.URL.Path, "people/me/connections") {
+			http.NotFound(w, r)
+			return
+		}
+		n := calls.Add(1)
+		if n > 2 {
+			http.Error(w, "unexpected extra connections page request", http.StatusBadRequest)
+			return
+		}
+		wantToken := ""
+		if n == 2 {
+			wantToken = "stuck"
+		}
+		requireQuery(t, r, "pageToken", wantToken)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"connections":   []map[string]any{{"resourceName": "people/c1"}},
+			"nextPageToken": "stuck",
+		})
+	}), people.NewService)
+	defer closeSvc()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	got, err := fetchBackupConnections(ctx, svc)
+	if err == nil || !strings.Contains(err.Error(), "repeated page token") {
+		t.Fatalf("err = %v after %d list calls", err, calls.Load())
+	}
+	if got != nil {
+		t.Fatalf("connections = %#v, want no partial result", got)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("list calls = %d, want 2", got)
+	}
+	t.Logf("err = %v after %d list calls", err, calls.Load())
+}
+
+func TestFetchBackupTaskListsRejectsRepeatedPageToken(t *testing.T) {
+	var calls atomic.Int32
+	svc, closeSvc := newGoogleTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !strings.HasSuffix(r.URL.Path, "/users/@me/lists") {
+			http.NotFound(w, r)
+			return
+		}
+		n := calls.Add(1)
+		if n > 2 {
+			http.Error(w, "unexpected extra task list page request", http.StatusBadRequest)
+			return
+		}
+		wantToken := ""
+		if n == 2 {
+			wantToken = "stuck"
+		}
+		requireQuery(t, r, "pageToken", wantToken)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"items":         []map[string]any{{"id": "list-1", "title": "Inbox"}},
+			"nextPageToken": "stuck",
+		})
+	}), tasks.NewService)
+	defer closeSvc()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	got, err := fetchBackupTaskLists(ctx, svc)
+	if err == nil || !strings.Contains(err.Error(), "repeated page token") {
+		t.Fatalf("err = %v after %d list calls", err, calls.Load())
+	}
+	if got != nil {
+		t.Fatalf("task lists = %#v, want no partial result", got)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("list calls = %d, want 2", got)
+	}
+	t.Logf("err = %v after %d list calls", err, calls.Load())
+}
+
+func TestFetchBackupCalendarsTwoDistinctPagesSucceed(t *testing.T) {
+	var calls atomic.Int32
+	svc, closeSvc := newCalendarServiceForTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !strings.Contains(r.URL.Path, "/calendarList") {
+			http.NotFound(w, r)
+			return
+		}
+		n := calls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		if n == 1 {
+			requireQuery(t, r, "pageToken", "")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"items":         []map[string]any{{"id": "zzz", "summary": "Late"}},
+				"nextPageToken": "page-2",
+			})
+			return
+		}
+		if n == 2 {
+			requireQuery(t, r, "pageToken", "page-2")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"items": []map[string]any{{"id": "aaa", "summary": "Early"}},
+			})
+			return
+		}
+		http.Error(w, "unexpected extra calendar page request", http.StatusBadRequest)
+	}))
+	defer closeSvc()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	got, err := fetchBackupCalendars(ctx, svc)
+	if err != nil {
+		t.Fatalf("err = %v after %d list calls", err, calls.Load())
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("list calls = %d, want 2", calls.Load())
+	}
+	if len(got) != 2 || got[0].Id != "aaa" || got[1].Id != "zzz" {
+		t.Fatalf("calendars = %#v, want sorted ids aaa then zzz", got)
+	}
+}
+
+func TestFetchBackupCalendarEventsRejectsRepeatedPageToken(t *testing.T) {
+	var calls atomic.Int32
+	svc, closeSvc := newCalendarServiceForTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !strings.Contains(r.URL.Path, "/calendars/cal-1/events") {
+			http.NotFound(w, r)
+			return
+		}
+		n := calls.Add(1)
+		if n > 2 {
+			http.Error(w, "unexpected extra event page request", http.StatusBadRequest)
+			return
+		}
+		wantToken := ""
+		if n == 2 {
+			wantToken = "stuck"
+		}
+		requireQuery(t, r, "pageToken", wantToken)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"items":         []map[string]any{{"id": "evt-1", "summary": "Standup"}},
+			"nextPageToken": "stuck",
+		})
+	}))
+	defer closeSvc()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	got, err := fetchBackupCalendarEvents(ctx, svc, []*calendar.CalendarListEntry{{Id: "cal-1"}})
+	if err == nil || !strings.Contains(err.Error(), "repeated page token") {
+		t.Fatalf("err = %v after %d list calls", err, calls.Load())
+	}
+	if got != nil {
+		t.Fatalf("events = %#v, want no partial result", got)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("list calls = %d, want 2", got)
+	}
+	t.Logf("err = %v after %d list calls", err, calls.Load())
+}

--- a/internal/cmd/backup_workspace.go
+++ b/internal/cmd/backup_workspace.go
@@ -259,30 +259,21 @@ func capDriveFiles(files []*drive.File, maxFiles int) []*drive.File {
 }
 
 func fetchBackupFormResponses(ctx context.Context, svc *formsapi.Service, formID string) ([]*formsapi.FormResponse, error) {
-	var out []*formsapi.FormResponse
-	pageToken := ""
-	for {
+	return collectUnboundedPages("", func(pageToken string) ([]*formsapi.FormResponse, string, error) {
 		call := svc.Forms.Responses.List(formID).PageSize(5000).Context(ctx)
 		if pageToken != "" {
 			call = call.PageToken(pageToken)
 		}
 		resp, err := call.Do()
 		if err != nil {
-			return nil, err
+			return nil, "", err
 		}
-		out = append(out, resp.Responses...)
-		if resp.NextPageToken == "" {
-			break
-		}
-		pageToken = resp.NextPageToken
-	}
-	return out, nil
+		return resp.Responses, resp.NextPageToken, nil
+	})
 }
 
 func fetchDriveFilesByMime(ctx context.Context, svc *drive.Service, mimeType string) ([]*drive.File, error) {
-	var out []*drive.File
-	pageToken := ""
-	for {
+	out, err := collectUnboundedPages("", func(pageToken string) ([]*drive.File, string, error) {
 		call := svc.Files.List().
 			Q(fmt.Sprintf("mimeType = '%s' and trashed = false", mimeType)).
 			PageSize(1000).
@@ -295,13 +286,12 @@ func fetchDriveFilesByMime(ctx context.Context, svc *drive.Service, mimeType str
 		}
 		resp, err := call.Do()
 		if err != nil {
-			return nil, err
+			return nil, "", err
 		}
-		out = append(out, resp.Files...)
-		if resp.NextPageToken == "" {
-			break
-		}
-		pageToken = resp.NextPageToken
+		return resp.Files, resp.NextPageToken, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Id < out[j].Id })
 	return out, nil

--- a/internal/cmd/backup_workspace_test.go
+++ b/internal/cmd/backup_workspace_test.go
@@ -1,0 +1,130 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestFetchBackupFormResponsesRejectsRepeatedPageToken(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !strings.Contains(r.URL.Path, "/forms/form-1/responses") {
+			http.NotFound(w, r)
+			return
+		}
+		n := calls.Add(1)
+		if n > 2 {
+			http.Error(w, "unexpected extra form response page request", http.StatusBadRequest)
+			return
+		}
+		wantToken := ""
+		if n == 2 {
+			wantToken = "stuck"
+		}
+		requireQuery(t, r, "pageToken", wantToken)
+		requireQuery(t, r, "pageSize", "5000")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"responses":     []map[string]any{{"responseId": "r1"}},
+			"nextPageToken": "stuck",
+		})
+	}))
+	defer srv.Close()
+
+	svc := newFormsTestService(t, t.Context(), srv)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	got, err := fetchBackupFormResponses(ctx, svc, "form-1")
+	if err == nil || !strings.Contains(err.Error(), "repeated page token") {
+		t.Fatalf("err = %v after %d list calls", err, calls.Load())
+	}
+	if got != nil {
+		t.Fatalf("responses = %#v, want no partial result", got)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("list calls = %d, want 2", got)
+	}
+	t.Logf("err = %v after %d list calls", err, calls.Load())
+}
+
+func TestFetchDriveFilesByMimeRejectsRepeatedPageToken(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	svc, closeSvc := newDriveTestService(t, backupPagingTestHandler(t, &calls, "/files", []map[string]any{
+		{"files": []map[string]any{{"id": "file-1", "name": "Survey"}}, "nextPageToken": "stuck"},
+		{"files": []map[string]any{{"id": "file-1", "name": "Survey"}}, "nextPageToken": "stuck"},
+	}, map[string]string{"pageSize": "1000", "q": "mimeType = 'application/vnd.google-apps.form' and trashed = false", "orderBy": "modifiedTime desc", "supportsAllDrives": "true", "includeItemsFromAllDrives": "true", "corpora": "allDrives"}))
+	defer closeSvc()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	got, err := fetchDriveFilesByMime(ctx, svc, driveMimeGoogleForm)
+	if err == nil || !strings.Contains(err.Error(), "repeated page token") {
+		t.Fatalf("err = %v after %d list calls", err, calls.Load())
+	}
+	if got != nil {
+		t.Fatalf("files = %#v, want no partial result", got)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("list calls = %d, want 2", got)
+	}
+	t.Logf("err = %v after %d list calls", err, calls.Load())
+}
+
+func TestFetchBackupFormResponsesTwoDistinctPagesSucceed(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	srv := httptest.NewServer(backupPagingTestHandler(t, &calls, "/forms/form-1/responses", []map[string]any{
+		{"responses": []map[string]any{{"responseId": "r1"}}, "nextPageToken": "page-2"},
+		{"responses": []map[string]any{{"responseId": "r2"}}},
+	}, nil))
+	defer srv.Close()
+
+	svc := newFormsTestService(t, t.Context(), srv)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	got, err := fetchBackupFormResponses(ctx, svc, "form-1")
+	if err != nil {
+		t.Fatalf("err = %v after %d list calls", err, calls.Load())
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("list calls = %d, want 2", calls.Load())
+	}
+	if len(got) != 2 || got[0].ResponseId != "r1" || got[1].ResponseId != "r2" {
+		t.Fatalf("responses = %#v, want both pages concatenated", got)
+	}
+}
+
+func TestFetchDriveFilesByMimeTwoDistinctPagesSucceed(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	svc, closeSvc := newDriveTestService(t, backupPagingTestHandler(t, &calls, "/files", []map[string]any{
+		{"files": []map[string]any{{"id": "zzz", "name": "Late"}}, "nextPageToken": "page-2"},
+		{"files": []map[string]any{{"id": "aaa", "name": "Early"}}},
+	}, map[string]string{"supportsAllDrives": "true", "corpora": "allDrives"}))
+	defer closeSvc()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	got, err := fetchDriveFilesByMime(ctx, svc, driveMimeGoogleDoc)
+	if err != nil {
+		t.Fatalf("err = %v after %d list calls", err, calls.Load())
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("list calls = %d, want 2", calls.Load())
+	}
+	if len(got) != 2 || got[0].Id != "aaa" || got[1].Id != "zzz" {
+		t.Fatalf("files = %#v, want sorted ids aaa then zzz", got)
+	}
+}

--- a/internal/cmd/calendar_delete_test.go
+++ b/internal/cmd/calendar_delete_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"google.golang.org/api/calendar/v3"
@@ -67,6 +68,70 @@ func TestCalendarDeleteCmd_ScopeSingle(t *testing.T) {
 	}
 	if !payload.Deleted || payload.EventID != "ev_1" {
 		t.Fatalf("unexpected output: %#v", payload)
+	}
+}
+
+func TestCalendarDeleteCmd_ScopeSingleRejectsRepeatedPageToken(t *testing.T) {
+	var instanceCalls atomic.Int32
+	var deleted bool
+	svc, closeSvc := newCalendarServiceForTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimPrefix(r.URL.Path, "/calendar/v3")
+		switch {
+		case r.Method == http.MethodGet && path == "/calendars/cal@example.com/events/ev":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":         "ev",
+				"recurrence": []string{"RRULE:FREQ=DAILY"},
+			})
+			return
+		case r.Method == http.MethodGet && strings.HasPrefix(path, "/calendars/cal@example.com/events/ev/instances"):
+			if instanceCalls.Add(1) > 2 {
+				http.Error(w, "unexpected extra page request", http.StatusBadRequest)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"items": []map[string]any{
+					{
+						"id": "ev_other",
+						"originalStartTime": map[string]any{
+							"dateTime": "2025-01-03T10:00:00Z",
+						},
+					},
+				},
+				"nextPageToken": "stuck",
+			})
+			return
+		case r.Method == http.MethodDelete:
+			deleted = true
+			w.WriteHeader(http.StatusNoContent)
+			return
+		default:
+			http.NotFound(w, r)
+			return
+		}
+	}))
+	defer closeSvc()
+	ctx, output := newCalendarTestJSONContext(t, svc)
+
+	cmd := CalendarDeleteCmd{
+		CalendarID:        "cal@example.com",
+		EventID:           "ev",
+		Scope:             scopeSingle,
+		OriginalStartTime: "2025-01-02T10:00:00Z",
+	}
+	err := cmd.Run(ctx, &RootFlags{Account: "a@b.com", Force: true})
+	if err == nil || !strings.Contains(err.Error(), "repeated page token") {
+		t.Fatalf("err = %v after %d instance calls", err, instanceCalls.Load())
+	}
+	if instanceCalls.Load() != 2 {
+		t.Fatalf("instance calls = %d, want 2", instanceCalls.Load())
+	}
+	if deleted {
+		t.Fatalf("delete must not run after a pagination loop")
+	}
+	if output.Len() != 0 {
+		t.Fatalf("unexpected output: %s", output.Bytes())
 	}
 }
 

--- a/internal/cmd/calendar_recurrence.go
+++ b/internal/cmd/calendar_recurrence.go
@@ -70,7 +70,12 @@ func resolveRecurringInstanceID(ctx context.Context, svc *calendar.Service, cale
 		TimeMin(timeMin).
 		TimeMax(timeMax)
 
+	var guard pageTokenGuard
+	pageToken := ""
 	for {
+		if err := guard.check(pageToken); err != nil {
+			return "", err
+		}
 		resp, err := call.Context(ctx).Do()
 		if err != nil {
 			return "", err
@@ -83,6 +88,7 @@ func resolveRecurringInstanceID(ctx context.Context, svc *calendar.Service, cale
 		if resp.NextPageToken == "" {
 			break
 		}
+		pageToken = resp.NextPageToken
 		call = svc.Events.Instances(calendarID, recurringEventID).
 			ShowDeleted(false).
 			TimeMin(timeMin).

--- a/internal/cmd/calendar_recurrence_test.go
+++ b/internal/cmd/calendar_recurrence_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -152,5 +153,112 @@ func TestResolveRecurringParentEvent_Instance(t *testing.T) {
 	}
 	if len(recurrence) != 1 || recurrence[0] != "RRULE:FREQ=WEEKLY" {
 		t.Fatalf("unexpected recurrence: %#v", recurrence)
+	}
+}
+
+func TestResolveRecurringInstanceIDRejectsRepeatedPageToken(t *testing.T) {
+	var listCalls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimPrefix(r.URL.Path, "/calendar/v3")
+		if !(r.Method == http.MethodGet && strings.HasPrefix(path, "/calendars/cal/events/ev_master/instances")) {
+			http.NotFound(w, r)
+			return
+		}
+		if listCalls.Add(1) > 2 {
+			http.Error(w, "unexpected extra page request", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"items": []map[string]any{
+				{
+					"id": "ev_other",
+					"originalStartTime": map[string]any{
+						"dateTime": "2025-01-03T10:00:00Z",
+					},
+				},
+			},
+			"nextPageToken": "stuck",
+		})
+	}))
+	defer srv.Close()
+
+	svc, err := calendar.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	got, err := resolveRecurringInstanceID(context.Background(), svc, "cal", "ev_master", "2025-01-02T10:00:00Z")
+	if err == nil || !strings.Contains(err.Error(), "repeated page token") {
+		t.Fatalf("err = %v after %d list calls, got = %q", err, listCalls.Load(), got)
+	}
+	if got := listCalls.Load(); got != 2 {
+		t.Fatalf("list calls = %d, want 2", got)
+	}
+}
+
+func TestResolveRecurringInstanceIDFindsMatchOnLaterPage(t *testing.T) {
+	originalStart := "2025-01-02T10:00:00Z"
+	var listCalls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimPrefix(r.URL.Path, "/calendar/v3")
+		if !(r.Method == http.MethodGet && strings.HasPrefix(path, "/calendars/cal/events/ev_master/instances")) {
+			http.NotFound(w, r)
+			return
+		}
+		listCalls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Query().Get("pageToken") {
+		case "":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"items": []map[string]any{
+					{
+						"id": "ev_other",
+						"originalStartTime": map[string]any{
+							"dateTime": "2025-01-03T10:00:00Z",
+						},
+					},
+				},
+				"nextPageToken": "page-2",
+			})
+		case "page-2":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"items": []map[string]any{
+					{
+						"id": "ev_1",
+						"originalStartTime": map[string]any{
+							"dateTime": originalStart,
+						},
+					},
+				},
+			})
+		default:
+			http.Error(w, "unexpected extra page request", http.StatusBadRequest)
+		}
+	}))
+	defer srv.Close()
+
+	svc, err := calendar.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	got, err := resolveRecurringInstanceID(context.Background(), svc, "cal", "ev_master", originalStart)
+	if err != nil {
+		t.Fatalf("resolveRecurringInstanceID: %v", err)
+	}
+	if got != "ev_1" {
+		t.Fatalf("unexpected instance id: %q", got)
+	}
+	if listCalls.Load() != 2 {
+		t.Fatalf("list calls = %d, want 2", listCalls.Load())
 	}
 }

--- a/internal/cmd/comment_ops.go
+++ b/internal/cmd/comment_ops.go
@@ -143,12 +143,11 @@ func listDriveComments(ctx context.Context, svc *drive.Service, fileID string, o
 	}
 
 	pageToken := strings.TrimSpace(opts.page)
-	seen := map[string]bool{}
+	var guard pageTokenGuard
 	for {
-		if seen[pageToken] {
-			return nil, "", fmt.Errorf("pagination loop: repeated page token %q", pageToken)
+		if err := guard.check(pageToken); err != nil {
+			return nil, "", err
 		}
-		seen[pageToken] = true
 
 		pageComments, nextPageToken, err := fetch(pageToken)
 		if err != nil {

--- a/internal/cmd/comment_ops.go
+++ b/internal/cmd/comment_ops.go
@@ -142,14 +142,21 @@ func listDriveComments(ctx context.Context, svc *drive.Service, fileID string, o
 		return comments, nextPageToken, nil
 	}
 
-	pageToken := opts.page
+	pageToken := strings.TrimSpace(opts.page)
+	seen := map[string]bool{}
 	for {
+		if seen[pageToken] {
+			return nil, "", fmt.Errorf("pagination loop: repeated page token %q", pageToken)
+		}
+		seen[pageToken] = true
+
 		pageComments, nextPageToken, err := fetch(pageToken)
 		if err != nil {
 			return nil, "", err
 		}
 		open := filterOpenComments(pageComments)
-		if len(open) > 0 || strings.TrimSpace(nextPageToken) == "" {
+		nextPageToken = strings.TrimSpace(nextPageToken)
+		if len(open) > 0 || nextPageToken == "" {
 			return open, nextPageToken, nil
 		}
 		pageToken = nextPageToken

--- a/internal/cmd/contacts_dedupe.go
+++ b/internal/cmd/contacts_dedupe.go
@@ -150,7 +150,11 @@ func contactsDedupeGetResources(ctx context.Context, svc *people.Service, resour
 func contactsDedupeList(ctx context.Context, svc *people.Service, maxResults int64) ([]*people.Person, error) {
 	var out []*people.Person
 	pageToken := ""
+	var guard pageTokenGuard
 	for {
+		if err := guard.check(pageToken); err != nil {
+			return nil, err
+		}
 		pageSize := int64(500)
 		if maxResults > 0 && maxResults-int64(len(out)) < pageSize {
 			pageSize = maxResults - int64(len(out))

--- a/internal/cmd/contacts_dedupe_test.go
+++ b/internal/cmd/contacts_dedupe_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"reflect"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"google.golang.org/api/people/v1"
@@ -163,6 +164,43 @@ func TestContactsDedupeExecuteJSON(t *testing.T) {
 	if !reflect.DeepEqual(parsed.Groups[0].MatchedOn, []string{"email:ada@example.com"}) {
 		t.Fatalf("matched_on = %#v", parsed.Groups[0].MatchedOn)
 	}
+}
+
+func TestContactsDedupeExecuteRejectsRepeatedPageToken(t *testing.T) {
+	var listCalls atomic.Int32
+	svc, closeSrv := newPeopleService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/v1/people/me/connections" {
+			http.NotFound(w, r)
+			return
+		}
+		if listCalls.Add(1) > 2 {
+			http.Error(w, "unexpected extra connections page request", http.StatusBadRequest)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"connections": []map[string]any{{
+				"resourceName":   "people/1",
+				"names":          []map[string]any{{"displayName": "Ada"}},
+				"emailAddresses": []map[string]any{{"value": "ada@example.com"}},
+			}},
+			"nextPageToken": "stuck",
+		})
+	}))
+	defer closeSrv()
+
+	result := executeWithPeopleTestServices(t, []string{"--json", "--account", "a@example.com", "contacts", "dedupe"}, peopleTestServices{
+		Contacts: fixedPeopleTestService(svc),
+	})
+	if result.err == nil || !strings.Contains(result.err.Error(), "repeated page token") {
+		t.Fatalf("err = %v after %d list calls", result.err, listCalls.Load())
+	}
+	if got := listCalls.Load(); got != 2 {
+		t.Fatalf("list calls = %d, want 2", got)
+	}
+	if result.stdout != "" {
+		t.Fatalf("unexpected partial output: %q", result.stdout)
+	}
+	t.Logf("err = %v after %d list calls", result.err, listCalls.Load())
 }
 
 func testDedupePerson(resource, name string, emails, phones []string) *people.Person {

--- a/internal/cmd/docs_comments_test.go
+++ b/internal/cmd/docs_comments_test.go
@@ -325,6 +325,53 @@ func TestDocsCommentsList_ScansPagesForOpenComments(t *testing.T) {
 	}
 }
 
+func TestDocsCommentsList_RejectsRepeatedScanPageToken(t *testing.T) {
+	var listCalls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimPrefix(r.URL.Path, "/drive/v3")
+		if r.Method != http.MethodGet || path != "/files/stuck/comments" {
+			http.NotFound(w, r)
+			return
+		}
+		listCalls++
+		if listCalls > 2 {
+			http.Error(w, "unexpected extra page request", http.StatusBadRequest)
+			return
+		}
+		if listCalls == 1 {
+			if got := r.URL.Query().Get("pageToken"); got != "" {
+				t.Errorf("first pageToken = %q, want empty", got)
+			}
+		} else if got := r.URL.Query().Get("pageToken"); got != "stuck" {
+			t.Errorf("later pageToken = %q, want stuck", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"comments": []map[string]any{
+				{
+					"id":          "c-res",
+					"author":      map[string]any{"displayName": "Eli"},
+					"content":     "Resolved only",
+					"createdTime": "2025-06-03T09:00:00Z",
+					"resolved":    true,
+				},
+			},
+			"nextPageToken": "stuck",
+		})
+	}))
+	defer srv.Close()
+	svc := driveServiceFromServer(t, srv)
+
+	result := executeWithDriveTestService(t, []string{"--json", "--account", "a@b.com", "docs", "comments", "list", "stuck"}, svc)
+	if result.err == nil || !strings.Contains(result.err.Error(), "repeated page token") {
+		t.Fatalf("err = %v after %d list calls", result.err, listCalls)
+	}
+	if listCalls != 2 {
+		t.Fatalf("list calls = %d, want 2", listCalls)
+	}
+	t.Logf("err = %v after %d list calls", result.err, listCalls)
+}
+
 func TestDocsCommentsList_Empty(t *testing.T) {
 	srv := newCommentsTestServer(t)
 	defer srv.Close()

--- a/internal/cmd/drive_reporting.go
+++ b/internal/cmd/drive_reporting.go
@@ -366,8 +366,12 @@ func listDriveChildren(ctx context.Context, svc *drive.Service, parentID string,
 	q := buildDriveListQuery(parentID, "")
 	out := make([]*drive.File, 0, 64)
 	var pageToken string
+	var guard pageTokenGuard
 
 	for {
+		if err := guard.check(pageToken); err != nil {
+			return nil, err
+		}
 		call := svc.Files.List().
 			Q(q).
 			PageSize(driveDefaultPageSize).

--- a/internal/cmd/drive_reporting_test.go
+++ b/internal/cmd/drive_reporting_test.go
@@ -1,10 +1,14 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func TestExecuteDriveTreeJSON(t *testing.T) {
@@ -322,5 +326,174 @@ func TestDriveTreeRejectsFolderCycle(t *testing.T) {
 	}
 	if !strings.Contains(result.err.Error(), `drive folder cycle detected at "A/Root again" (id root)`) {
 		t.Fatalf("cycle error = %q", result.err)
+	}
+}
+
+func TestListDriveChildrenRejectsRepeatedPageToken(t *testing.T) {
+	t.Parallel()
+
+	var listCalls atomic.Int32
+	svc, closeSvc := newDriveTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !strings.HasSuffix(r.URL.Path, "/files") {
+			http.NotFound(w, r)
+			return
+		}
+		n := listCalls.Add(1)
+		if n > 2 {
+			http.Error(w, "unexpected extra page request", http.StatusBadRequest)
+			return
+		}
+		wantToken := ""
+		if n == 2 {
+			wantToken = "stuck"
+		}
+		requireSupportsAllDrives(t, r)
+		requireQuery(t, r, "includeItemsFromAllDrives", "true")
+		requireQuery(t, r, "corpora", "allDrives")
+		requireQuery(t, r, "pageSize", "1000")
+		requireQuery(t, r, "orderBy", "folder,name")
+		requireQuery(t, r, "pageToken", wantToken)
+		if q := r.URL.Query().Get("q"); !strings.Contains(q, "'root' in parents") {
+			t.Fatalf("query = %q, want root parent", q)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"files": []any{
+				map[string]any{"id": "child-1", "name": "a.txt", "mimeType": "text/plain"},
+			},
+			"nextPageToken": "stuck",
+		})
+	}))
+	defer closeSvc()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	files, err := listDriveChildren(ctx, svc, "", driveTreeFields, true)
+	if err == nil || !strings.Contains(err.Error(), "repeated page token") {
+		t.Fatalf("err = %v after %d list calls", err, listCalls.Load())
+	}
+	if files != nil {
+		t.Fatalf("unexpected partial children: %#v", files)
+	}
+	if got := listCalls.Load(); got != 2 {
+		t.Fatalf("list calls = %d, want 2", got)
+	}
+	t.Logf("err = %v after %d list calls", err, listCalls.Load())
+}
+
+func TestListDriveChildrenLaterPages(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name           string
+		failSecondPage bool
+	}{
+		{name: "success preserves page order"},
+		{name: "later error discards partial children", failSecondPage: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var listCalls atomic.Int32
+			svc, closeSvc := newDriveTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodGet || !strings.HasSuffix(r.URL.Path, "/files") {
+					http.NotFound(w, r)
+					return
+				}
+				requireSupportsAllDrives(t, r)
+				requireQuery(t, r, "pageSize", "1000")
+				requireQuery(t, r, "orderBy", "folder,name")
+				if q := r.URL.Query().Get("q"); !strings.Contains(q, "'parent' in parents") {
+					t.Fatalf("query = %q, want parent folder", q)
+				}
+				n := listCalls.Add(1)
+				w.Header().Set("Content-Type", "application/json")
+				switch n {
+				case 1:
+					requireQuery(t, r, "pageToken", "")
+					_, _ = io.WriteString(w, `{"files":[{"id":"child-1","name":"1.txt","mimeType":"text/plain"}],"nextPageToken":"page-2"}`)
+				case 2:
+					requireQuery(t, r, "pageToken", "page-2")
+					if tc.failSecondPage {
+						http.Error(w, `{"error":{"code":403,"message":"page two denied"}}`, http.StatusForbidden)
+						return
+					}
+					_, _ = io.WriteString(w, `{"files":[{"id":"child-2","name":"2.txt","mimeType":"text/plain"}]}`)
+				default:
+					http.Error(w, "unexpected extra page request", http.StatusBadRequest)
+				}
+			}))
+			defer closeSvc()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			files, err := listDriveChildren(ctx, svc, "parent", driveTreeFields, true)
+			if tc.failSecondPage {
+				if err == nil || !strings.Contains(err.Error(), "page two denied") || files != nil {
+					t.Fatalf("files = %#v, err = %v; want nil children and provider error", files, err)
+				}
+			} else if err != nil || len(files) != 2 || files[0].Id != "child-1" || files[1].Id != "child-2" {
+				t.Fatalf("files = %#v, err = %v; want both pages in order", files, err)
+			}
+			if got := listCalls.Load(); got != 2 {
+				t.Fatalf("list calls = %d, want 2", got)
+			}
+		})
+	}
+}
+
+func TestExecuteDriveReportingRejectsRepeatedPageToken(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{name: "tree", args: []string{"drive", "tree", "--parent", "root", "--depth", "1"}},
+		{name: "inventory", args: []string{"drive", "inventory", "--parent", "root", "--depth", "1"}},
+		{name: "du", args: []string{"drive", "du", "--parent", "root", "--depth", "1"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var listCalls atomic.Int32
+			svc, closeSvc := newDriveTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodGet || !strings.HasSuffix(r.URL.Path, "/files") {
+					http.NotFound(w, r)
+					return
+				}
+				n := listCalls.Add(1)
+				if n > 2 {
+					http.Error(w, "unexpected extra page request", http.StatusBadRequest)
+					return
+				}
+				requireSupportsAllDrives(t, r)
+				if n == 1 {
+					requireQuery(t, r, "pageToken", "")
+				} else {
+					requireQuery(t, r, "pageToken", "stuck")
+				}
+				if q := r.URL.Query().Get("q"); !strings.Contains(q, "'root' in parents") {
+					t.Fatalf("query = %q, want root parent", q)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"files": []any{
+						map[string]any{"id": "loop", "name": "stuck.txt", "mimeType": "text/plain"},
+					},
+					"nextPageToken": "stuck",
+				})
+			}))
+			defer closeSvc()
+
+			args := append([]string{"--json", "--account", "owner@example.com", "--no-input"}, tc.args...)
+			result := executeWithDriveTestService(t, args, svc)
+			wantError := `list Drive folder root: pagination loop: repeated page token "stuck"`
+			if result.err == nil || !strings.Contains(result.err.Error(), wantError) || ExitCode(result.err) != 1 {
+				t.Fatalf("err = %v, exit = %d, stderr = %q; want folder list error", result.err, ExitCode(result.err), result.stderr)
+			}
+			if result.stdout != "" || !strings.Contains(result.stderr, wantError) {
+				t.Fatalf("stdout = %q, stderr = %q; want only the list error", result.stdout, result.stderr)
+			}
+			if got := listCalls.Load(); got != 2 {
+				t.Fatalf("list calls = %d, want 2", got)
+			}
+			t.Logf("%v; no success output", result.err)
+		})
 	}
 }

--- a/internal/cmd/gmail_archive.go
+++ b/internal/cmd/gmail_archive.go
@@ -256,8 +256,12 @@ func searchMessageIDs(ctx context.Context, svc *gmail.Service, query string, lim
 	var ids []string
 	pageToken := ""
 	remaining := limit
+	var guard pageTokenGuard
 
 	for {
+		if err := guard.check(pageToken); err != nil {
+			return nil, err
+		}
 		batchSize := remaining
 		if batchSize > 500 {
 			batchSize = 500

--- a/internal/cmd/gmail_archive_test.go
+++ b/internal/cmd/gmail_archive_test.go
@@ -8,7 +8,9 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"google.golang.org/api/gmail/v1"
 
@@ -310,4 +312,127 @@ func TestGmailBulkOps_QueryInvalidMaxFailsBeforeDryRun(t *testing.T) {
 			}
 		})
 	}
+}
+
+func stuckGmailSearchListHandler(t *testing.T, listCalls *atomic.Int32) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimPrefix(r.URL.Path, "/gmail/v1")
+		if r.Method != http.MethodGet || path != "/users/me/messages" {
+			http.NotFound(w, r)
+			return
+		}
+		if listCalls.Add(1) > 2 {
+			http.Error(w, "too many list requests", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"messages":      []map[string]any{{"id": "m1"}},
+			"nextPageToken": "stuck",
+		})
+	}
+}
+
+func TestSearchMessageIDsRejectsRepeatedPageToken(t *testing.T) {
+	var listCalls atomic.Int32
+	svc, cleanup := newGmailServiceForTest(t, stuckGmailSearchListHandler(t, &listCalls))
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	ids, err := searchMessageIDs(ctx, svc, "in:inbox", 50)
+	if err == nil || !strings.Contains(err.Error(), "repeated page token") {
+		t.Fatalf("err = %v after %d list calls, ids=%v", err, listCalls.Load(), ids)
+	}
+	if got := listCalls.Load(); got != 2 {
+		t.Fatalf("list calls = %d, want 2", got)
+	}
+	t.Logf("err = %v after %d list calls", err, listCalls.Load())
+}
+
+func TestSearchMessageIDsRejectsRepeatedEmptyPageToken(t *testing.T) {
+	var listCalls atomic.Int32
+	svc, cleanup := newGmailServiceForTest(t, func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimPrefix(r.URL.Path, "/gmail/v1")
+		if r.Method != http.MethodGet || path != "/users/me/messages" {
+			http.NotFound(w, r)
+			return
+		}
+		if listCalls.Add(1) > 2 {
+			http.Error(w, "unexpected extra page request", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"nextPageToken": "stuck",
+		})
+	})
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	ids, err := searchMessageIDs(ctx, svc, "in:inbox", 50)
+	if err == nil || !strings.Contains(err.Error(), "repeated page token") {
+		t.Fatalf("err = %v after %d list calls, ids=%v", err, listCalls.Load(), ids)
+	}
+	if got := listCalls.Load(); got != 2 {
+		t.Fatalf("list calls = %d, want 2", got)
+	}
+	t.Logf("err = %v after %d list calls", err, listCalls.Load())
+}
+
+func TestSearchMessageIDsFollowsDistinctPageTokens(t *testing.T) {
+	var listCalls atomic.Int32
+	svc, cleanup := newGmailServiceForTest(t, func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimPrefix(r.URL.Path, "/gmail/v1")
+		if r.Method != http.MethodGet || path != "/users/me/messages" {
+			http.NotFound(w, r)
+			return
+		}
+		n := listCalls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Query().Get("pageToken") == "" {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"messages":      []map[string]any{{"id": "m1"}},
+				"nextPageToken": "page-2",
+			})
+			return
+		}
+		if r.URL.Query().Get("pageToken") != "page-2" || n != 2 {
+			t.Fatalf("unexpected list call %d token=%q", n, r.URL.Query().Get("pageToken"))
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"messages": []map[string]any{{"id": "m2"}},
+		})
+	})
+	defer cleanup()
+
+	ids, err := searchMessageIDs(context.Background(), svc, "in:inbox", 50)
+	if err != nil {
+		t.Fatalf("searchMessageIDs: %v", err)
+	}
+	if strings.Join(ids, ",") != "m1,m2" {
+		t.Fatalf("ids = %v, want [m1 m2]", ids)
+	}
+	if got := listCalls.Load(); got != 2 {
+		t.Fatalf("list calls = %d, want 2", got)
+	}
+}
+
+func TestGmailArchiveCmd_QueryRejectsRepeatedPageToken(t *testing.T) {
+	var listCalls atomic.Int32
+	svc, cleanup := newGmailServiceForTest(t, stuckGmailSearchListHandler(t, &listCalls))
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(withGmailTestService(context.Background(), svc), 10*time.Second)
+	defer cancel()
+	err := runKong(t, &GmailArchiveCmd{}, []string{"--query", "in:inbox", "--max", "50"}, ctx, &RootFlags{Account: "a@b.com"})
+	if err == nil || !strings.Contains(err.Error(), "repeated page token") {
+		t.Fatalf("err = %v after %d list calls", err, listCalls.Load())
+	}
+	if got := listCalls.Load(); got != 2 {
+		t.Fatalf("list calls = %d, want 2", got)
+	}
+	t.Logf("err = %v after %d list calls", err, listCalls.Load())
 }

--- a/internal/cmd/paging.go
+++ b/internal/cmd/paging.go
@@ -17,15 +17,23 @@ func failEmptyExit(failEmpty bool) error {
 // collectAllPages keeps calling fetch until it returns an empty next page token.
 // It guards against pagination loops by tracking seen page tokens.
 func collectAllPages[T any](startPageToken string, fetch func(pageToken string) ([]T, string, error)) ([]T, error) {
+	return collectPages(startPageToken, 10_000, fetch)
+}
+
+// collectUnboundedPages preserves the capacity of existing unbounded listings.
+func collectUnboundedPages[T any](startPageToken string, fetch func(pageToken string) ([]T, string, error)) ([]T, error) {
+	return collectPages(startPageToken, 0, fetch)
+}
+
+func collectPages[T any](startPageToken string, maxPages int, fetch func(pageToken string) ([]T, string, error)) ([]T, error) {
 	pageToken := strings.TrimSpace(startPageToken)
-	seen := map[string]bool{}
+	var guard pageTokenGuard
 
 	var out []T
-	for i := 0; i < 10_000; i++ {
-		if seen[pageToken] {
-			return nil, fmt.Errorf("pagination loop: repeated page token %q", pageToken)
+	for i := 0; maxPages == 0 || i < maxPages; i++ {
+		if err := guard.check(pageToken); err != nil {
+			return nil, err
 		}
-		seen[pageToken] = true
 
 		items, next, err := fetch(pageToken)
 		if err != nil {

--- a/internal/cmd/paging_contract_test.go
+++ b/internal/cmd/paging_contract_test.go
@@ -1,0 +1,141 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/calendar/v3"
+	"google.golang.org/api/cloudidentity/v1"
+)
+
+func TestBackupACLPagingPreservesOrdinaryErrors(t *testing.T) {
+	for _, cycle := range []bool{false, true} {
+		t.Run(map[bool]string{false: "provider-error", true: "cycle"}[cycle], func(t *testing.T) {
+			calls := 0
+			svc, cleanup := newCalendarServiceForTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				if strings.Contains(r.URL.Path, "/calendars/second/acl") {
+					_ = json.NewEncoder(w).Encode(map[string]any{"items": []map[string]any{{"id": "second-rule"}}})
+					return
+				}
+				calls++
+				if calls > 2 || (!cycle && calls == 2) {
+					http.Error(w, "permission denied", http.StatusForbidden)
+					return
+				}
+				_ = json.NewEncoder(w).Encode(map[string]any{"items": []map[string]any{{"id": "first-rule"}}, "nextPageToken": "again"})
+			}))
+			defer cleanup()
+			rows := fetchBackupCalendarACLRules(context.Background(), svc, []*calendar.CalendarListEntry{{Id: "first"}, {Id: "second"}})
+			firstRules, secondRules, errors := 0, 0, 0
+			for _, row := range rows {
+				if row.Rule != nil && row.Rule.Id == "first-rule" {
+					firstRules++
+				}
+				if row.Rule != nil && row.Rule.Id == "second-rule" {
+					secondRules++
+				}
+				if row.Error != "" {
+					errors++
+					if cycle && !strings.Contains(row.Error, "repeated page token") {
+						t.Fatalf("expected cycle error, got %q", row.Error)
+					}
+				}
+			}
+			wantFirst := 1
+			if cycle {
+				wantFirst = 0
+			}
+			if calls != 2 || firstRules != wantFirst || secondRules != 1 || errors != 1 {
+				t.Fatalf("calls=%d first=%d second=%d errors=%d", calls, firstRules, secondRules, errors)
+			}
+		})
+	}
+}
+
+func TestBackupMembershipPagingPreservesOrdinaryErrors(t *testing.T) {
+	calls := 0
+	svc := newCloudIdentityTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(r.URL.Path, "groups:lookup") {
+			name := "groups/first"
+			if r.URL.Query().Get("groupKey.id") == "second@example.com" {
+				name = "groups/second"
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"name": name})
+			return
+		}
+		if strings.Contains(r.URL.Path, "groups/second/memberships") {
+			_ = json.NewEncoder(w).Encode(map[string]any{"memberships": []map[string]any{{"name": "second-member"}}})
+			return
+		}
+		calls++
+		if calls > 1 {
+			http.Error(w, "permission denied", http.StatusForbidden)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"memberships": []map[string]any{{"name": "first-member"}}, "nextPageToken": "next"})
+	}))
+	rows := fetchBackupCloudIdentityGroupMembers(context.Background(), svc, []*cloudidentity.GroupRelation{
+		{GroupKey: &cloudidentity.EntityKey{Id: "first@example.com"}},
+		{GroupKey: &cloudidentity.EntityKey{Id: "second@example.com"}},
+	})
+	first, second, errors := false, false, 0
+	for _, row := range rows {
+		if row.Member != nil {
+			first = first || row.Member.Name == "first-member"
+			second = second || row.Member.Name == "second-member"
+		}
+		if row.Error != "" {
+			errors++
+		}
+	}
+	if calls != 2 || !first || !second || errors != 1 {
+		t.Fatalf("calls=%d first=%v second=%v errors=%d", calls, first, second, errors)
+	}
+}
+
+func TestRecurringInstancePagingStopsAtMatch(t *testing.T) {
+	calls := 0
+	svc, cleanup := newCalendarServiceForTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls > 1 {
+			http.Error(w, "must not fetch after matching", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"items":         []map[string]any{{"id": "found", "originalStartTime": map[string]any{"dateTime": "2026-09-05T10:00:00Z"}}},
+			"nextPageToken": "unnecessary",
+		})
+	}))
+	defer cleanup()
+	id, err := resolveRecurringInstanceID(context.Background(), svc, "cal", "series", "2026-09-05T10:00:00Z")
+	if err != nil || id != "found" || calls != 1 {
+		t.Fatalf("id=%q calls=%d err=%v", id, calls, err)
+	}
+}
+
+func TestContactsDedupePagingStopsAtLimit(t *testing.T) {
+	calls := 0
+	svc, cleanup := newPeopleService(t, func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls > 1 {
+			http.Error(w, "must not fetch after limit", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"connections":   []map[string]any{{"resourceName": "people/one"}},
+			"nextPageToken": "unnecessary",
+		})
+	})
+	defer cleanup()
+	rows, err := contactsDedupeList(context.Background(), svc, 1)
+	if err != nil || len(rows) != 1 || calls != 1 {
+		t.Fatalf("rows=%v calls=%d err=%v", rows, calls, err)
+	}
+}

--- a/internal/cmd/paging_guard.go
+++ b/internal/cmd/paging_guard.go
@@ -1,0 +1,20 @@
+package cmd
+
+import "fmt"
+
+// pageTokenGuard detects cycles without changing a caller's page limit or
+// partial-result and early-return behavior. Tokens remain opaque.
+type pageTokenGuard struct {
+	seen map[string]struct{}
+}
+
+func (g *pageTokenGuard) check(token string) error {
+	if _, exists := g.seen[token]; exists {
+		return fmt.Errorf("pagination loop: repeated page token %q", token)
+	}
+	if g.seen == nil {
+		g.seen = make(map[string]struct{})
+	}
+	g.seen[token] = struct{}{}
+	return nil
+}

--- a/internal/cmd/paging_guard_test.go
+++ b/internal/cmd/paging_guard_test.go
@@ -1,0 +1,52 @@
+package cmd
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestPageTokenGuard(t *testing.T) {
+	for _, tokens := range [][]string{{"", ""}, {"start", "start"}, {"a", "b", "c", "a"}} {
+		var guard pageTokenGuard
+		for i, token := range tokens {
+			err := guard.check(token)
+			if i < len(tokens)-1 {
+				if err != nil {
+					t.Fatal(err)
+				}
+			} else if err == nil || !strings.Contains(err.Error(), "repeated page token") {
+				t.Fatalf("tokens %q: expected cycle error, got %v", tokens, err)
+			}
+		}
+	}
+}
+
+func TestPageTokenGuardPreservesUnboundedOpaqueTokens(t *testing.T) {
+	var guard pageTokenGuard
+	for i := range 10_001 {
+		if err := guard.check(strconv.Itoa(i)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, token := range []string{"", " ", "0 "} {
+		if err := guard.check(token); err != nil {
+			t.Fatalf("distinct opaque token %q: %v", token, err)
+		}
+	}
+}
+
+func TestCollectUnboundedPagesHasNoPageCeiling(t *testing.T) {
+	calls := 0
+	rows, err := collectUnboundedPages("", func(token string) ([]int, string, error) {
+		calls++
+		next := strconv.Itoa(calls)
+		if calls == 10_001 {
+			next = ""
+		}
+		return []int{calls}, next, nil
+	})
+	if err != nil || len(rows) != 10_001 {
+		t.Fatalf("got %d rows after %d calls: %v", len(rows), calls, err)
+	}
+}

--- a/internal/cmd/paging_testutil_test.go
+++ b/internal/cmd/paging_testutil_test.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func backupPagingTestHandler(t *testing.T, calls *atomic.Int32, pathSuffix string, pages []map[string]any, query map[string]string) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !strings.HasSuffix(r.URL.Path, pathSuffix) {
+			http.NotFound(w, r)
+			return
+		}
+		n := int(calls.Add(1))
+		if n > len(pages) {
+			http.Error(w, "unexpected extra page request", http.StatusBadRequest)
+			return
+		}
+		previousToken := ""
+		if n > 1 {
+			previousToken, _ = pages[n-2]["nextPageToken"].(string)
+		}
+		requireQuery(t, r, "pageToken", previousToken)
+		for name, value := range query {
+			requireQuery(t, r, name, value)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(pages[n-1])
+	}
+}


### PR DESCRIPTION
Repeated Google page tokens could leave backups, Drive reports, contact dedupe, Gmail bulk queries, recurring Calendar lookups, and open-comment scans running indefinitely. This consolidates #1078–#1086 into this existing contributor PR and gives those paths one shared cycle guard.

The repair preserves each caller's behavior: existing unlimited scans stay unlimited, bounded scans and occurrence lookup stop as soon as satisfied, and ordinary later-page ACL/membership errors retain previously fetched rows. Cycles discard the affected incomplete collection and follow the existing command or backup error path. The existing bounded all-pages collector keeps its 10,000-page limit.

Validation includes generated-client regressions, the local CI gate, and 33 real built-CLI runs against a local HTTPS fault-injection peer. Those runs cover repeated-token errors, zero downstream writes after failed scans, early-result success, unchanged existing backup manifests/Git HEAD after fatal collection errors, and decryption of embedded error rows and retained ACL/membership records. All inputs, credentials, and resources in the fault fixture are synthetic; this does not claim that a healthy Google endpoint was forced to emit a bad cursor.

Credited Unreleased entries and command/backup documentation are included. The nine sibling PRs remain open for maintainer closeout after this consolidated repair lands. This does not resolve #1059's Cloud Identity query validation or change Gmail-web MIME behavior or download defaults.

Co-authored contribution: Sebastien Tardif (@SebTardif); preserved in the commit credit.

Captured examples from the stock-binary run (synthetic HTTPS peer):

```text
{"case": "docs", "exit": 1, "target_requests": 2, "mutations": 0, "result": "cycle rejected; empty stdout"}
{"case": "dedupe-limit", "exit": 0, "target_requests": 1, "mutations": 0, "result": "stopped at existing result/limit"}
{"case": "calendar-match", "exit": 0, "target_requests": 1, "mutations": 1, "result": "stopped at existing result/limit"}
{"case": "drive-files", "exit": 1, "target_requests": 2, "mutations": 0, "result": "aborted; existing snapshot and Git HEAD unchanged"}
{"case": "acl-ordinary", "exit": 0, "target_requests": 2, "mutations": 0, "result": "verified encrypted error row; earlier row retained"}
{"case": "members-ordinary", "exit": 0, "target_requests": 2, "mutations": 0, "result": "verified encrypted error row; earlier row retained"}
PASS 33 stock CLI cases
```

[Full request-count and backup-result trace](https://github.com/openclaw/gogcli/pull/1087#issuecomment-5554761691).
