### PR TITLE
fix(appscript): keep content filenames in one output field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.40.1 - Unreleased
 
+- Apps Script: keep file names within one TSV field in `appscript content`, escaping line breaks instead of splitting output rows. (#1091) — thanks @haosdent.
 - Search Console: add `searchconsole inspect` for per-URL index status via the URL Inspection API (coverage state, indexing/page-fetch/robots.txt state, canonical, sitemaps, last crawl time), using the existing `webmasters` OAuth scope. (#1094) — thanks @laihenyi.
 - Search Console: preserve permission-denied exit codes when adding API setup or scope guidance. (#1094)
 - Dependencies and CI: refresh Google protocol modules and tracking-worker tooling within release-age limits; test the Go 1.26 minimum, check worker types and generated skills, and avoid duplicate pull-request test runs. (#1131)

--- a/internal/cmd/appscript.go
+++ b/internal/cmd/appscript.go
@@ -106,7 +106,7 @@ func (c *AppScriptContentCmd) Run(ctx context.Context, flags *RootFlags) error {
 		if file == nil {
 			continue
 		}
-		u.Out().Linef("file\t%s\t%s", file.Name, file.Type)
+		u.Out().Linef("file\t%s\t%s", oneLine(file.Name), oneLine(file.Type))
 	}
 	return nil
 }

--- a/internal/cmd/appscript_content_output_test.go
+++ b/internal/cmd/appscript_content_output_test.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestAppScriptContentFileNamesStayInOneField(t *testing.T) {
+	const name = "Name\tWith\r\nBreaks"
+	for _, mode := range []string{"text", "plain", "json"} {
+		t.Run(mode, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"scriptId": "script123", "files": []map[string]any{{"name": name, "type": "SERVER_JS"}},
+				})
+			}))
+			defer srv.Close()
+			args := []string{"--account", "a@b.com", "appscript", "content", "script123"}
+			if mode != "text" {
+				args = append([]string{"--" + mode}, args...)
+			}
+			result := executeWithAppScriptTestService(t, args, newAppScriptTestService(t, srv))
+			if result.err != nil {
+				t.Fatal(result.err)
+			}
+			if mode == "json" {
+				var output struct {
+					Content struct {
+						Files []struct{ Name string } `json:"files"`
+					} `json:"content"`
+				}
+				if err := json.Unmarshal([]byte(result.stdout), &output); err != nil {
+					t.Fatal(err)
+				}
+				if len(output.Content.Files) != 1 || output.Content.Files[0].Name != name {
+					t.Fatalf("JSON changed the file name: %s", result.stdout)
+				}
+			} else if !strings.Contains(result.stdout, "file\tName With\\nBreaks\tSERVER_JS\n") {
+				t.Fatalf("unsafe file row: %q", result.stdout)
+			}
+		})
+	}
+}

--- a/internal/cmd/comment_ops.go
+++ b/internal/cmd/comment_ops.go
@@ -525,11 +525,7 @@ func filterOpenComments(comments []*drive.Comment) []*drive.Comment {
 }
 
 func oneLineTSV(s string) string {
-	s = strings.ReplaceAll(s, "\r\n", "\n")
-	s = strings.ReplaceAll(s, "\r", "\n")
-	s = strings.ReplaceAll(s, "\t", " ")
-	s = strings.ReplaceAll(s, "\n", "\\n")
-	return strings.TrimSpace(s)
+	return strings.TrimSpace(oneLine(s))
 }
 
 func truncateString(s string, maxLen int) string {

--- a/internal/cmd/output_helpers.go
+++ b/internal/cmd/output_helpers.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"io"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/openclaw/gogcli/internal/outfmt"
@@ -61,4 +62,13 @@ func printNextPageHintWithAll(u *ui.UI, nextPageToken string, allFlag string) {
 		return
 	}
 	u.Err().Linef("# More results: use %s to fetch every page, or --page %s for the next page", allFlag, nextPageToken)
+}
+
+func oneLine(s string) string {
+	s = strings.ReplaceAll(s, "\r\n", "\n")
+	s = strings.ReplaceAll(s, "\r", "\n")
+	// Keep output parseable in tables/TSV.
+	s = strings.ReplaceAll(s, "\t", " ")
+	s = strings.ReplaceAll(s, "\n", "\\n")
+	return s
 }

--- a/internal/cmd/sheets_notes.go
+++ b/internal/cmd/sheets_notes.go
@@ -97,12 +97,3 @@ func (c *SheetsNotesCmd) Run(ctx context.Context, flags *RootFlags) error {
 
 	return outfmt.WriteTable(ctx, stdoutWriter(ctx), notes, sheetsNoteColumns())
 }
-
-func oneLine(s string) string {
-	s = strings.ReplaceAll(s, "\r\n", "\n")
-	s = strings.ReplaceAll(s, "\r", "\n")
-	// Keep output parseable in tables/TSV.
-	s = strings.ReplaceAll(s, "\t", " ")
-	s = strings.ReplaceAll(s, "\n", "\\n")
-	return s
-}


### PR DESCRIPTION
`appscript content` printed API filenames directly into TSV rows, so a valid filename containing tabs or line breaks could create extra fields or rows. Escape those characters in text/plain output while preserving the exact filename in JSON. Move the existing single-line formatter into shared output helpers and preserve the trimmed comment variant's behavior. Thanks @haosdent for the original output-sanitization change.

The proposed `appscript push` command is deferred and is not part of this revision. Google's `projects.updateContent` replaces the whole project. A live disposable-project probe found no `GetContent` ETag and confirmed that `UpdateContent` accepted a deliberately stale `If-Match` header. A read/merge/write sequence can therefore overwrite concurrent remote edits or delete files absent from its preview. A second read only narrows that race; an explicit write-ownership/overwrite contract needs a maintainer decision before this mutation command is added.

Validation:

- Text, plain, and JSON regression cases pass; shared notes/comment formatting remains equivalent.
- Isolated Codex review is scoped clean through P2 with full helper context.
- Real Google API proof: created a disposable project containing a filename with tabs/newlines, observed the released CLI split its TSV row, and verified the final compiled CLI emits a single field while JSON retains the original name. The project was trashed.
- A separate live conditional-write probe confirmed the API limitation described above; its disposable project was also trashed.
- The final binary does not expose the deferred push command. Full local and exact-head CI gates are required before merge.
