### PR TITLE
docs: correct persistent default account setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.39.2 - Unreleased
 
+### Fixes and maintenance
+
+- Docs: use the account manager, rather than the reserved `default` alias, to persist a default account. (#1092) — thanks @gianpaj.
+
 ## 0.39.1 - 2026-09-05
 
 ### Highlights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## 0.39.2 - Unreleased
 
-### Fixes and maintenance
-
-- Docs: use the account manager, rather than the reserved `default` alias, to persist a default account. (#1092) — thanks @gianpaj.
-
 ## 0.39.1 - 2026-09-05
 
 ### Highlights

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -109,8 +109,8 @@ gog auth doctor --check
 
 ```bash
 export GOG_ACCOUNT=you@gmail.com
-# or persist a default with gog auth alias
-gog auth alias set default you@gmail.com
+# or choose a persistent default in the interactive account manager
+gog auth manage
 ```
 
 Now you can drop `--account` from every command.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -107,13 +107,26 @@ gog auth doctor --check
 
 ## 5. Set a default account
 
+For a persistent default, open the account manager and click **Set default**
+beside the account you want to use:
+
 ```bash
-export GOG_ACCOUNT=you@gmail.com
-# or choose a persistent default in the interactive account manager
 gog auth manage
 ```
 
-Now you can drop `--account` from every command.
+The stored default applies when neither `--account` nor `GOG_ACCOUNT` is set.
+If you previously exported `GOG_ACCOUNT`, run `unset GOG_ACCOUNT` to use the
+stored default.
+
+Alternatively, select an account for your shell with:
+
+```bash
+export GOG_ACCOUNT=you@gmail.com
+```
+
+Either approach lets you omit `--account` from commands. Account aliases such
+as `work` are shortcuts for explicit selection; `default` and `auto` are
+reserved names, not aliases you can create.
 
 ## 6. Run real commands
 


### PR DESCRIPTION
The quickstart recommended `gog auth alias set default`, but `default` is reserved. Use `gog auth manage` and its **Set default** action for persistent selection, with explicit guidance that `--account` and `GOG_ACCOUNT` override the stored default. Existing aliases and account-selection behavior are unchanged.

Closes #1092.

Validation: focused account/alias tests pass. The real built CLI reproduced the reserved-alias error, then launched the real account manager against an isolated file keyring with two synthetic accounts. Its local **Set default** action persisted the second account; a new CLI process selected that account after the manager exited. Explicit flag and environment overrides were also verified. No existing credentials or account defaults were changed, and this did not require Google OAuth or an API call.

Local and committed-branch autoreview are clean at P0–P2. Release notes and contributor credit are consolidated in the final notes/dependency PR to keep this branch independent.
