### PR TITLE
chore: prepare 0.39.2 notes and refresh worker types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 0.39.2 - Unreleased
 
+**Highlights:** The quickstart now explains how to save a default account and how shell overrides affect it.
+
+- Docs: replace the reserved `default` alias command with the account manager's **Set default** action and explain account-selection precedence. (#1092, #1093) — thanks @gianpaj and @goutamadwant.
+- Dependencies: refresh Cloudflare Workers types while retaining the existing runtime, package manager, and 24-hour release-age policy.
+
 ## 0.39.1 - 2026-09-05
 
 ### Highlights

--- a/internal/tracking/worker/package.json
+++ b/internal/tracking/worker/package.json
@@ -13,7 +13,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^5.20260904.1",
+    "@cloudflare/workers-types": "^5.20260906.1",
     "@typescript/native": "npm:typescript@^7.0.2",
     "oxfmt": "^0.66.0",
     "oxlint": "^1.81.0",

--- a/internal/tracking/worker/pnpm-lock.yaml
+++ b/internal/tracking/worker/pnpm-lock.yaml
@@ -17,8 +17,8 @@ importers:
   .:
     devDependencies:
       '@cloudflare/workers-types':
-        specifier: ^5.20260904.1
-        version: 5.20260904.1
+        specifier: ^5.20260906.1
+        version: 5.20260906.1
       '@typescript/native':
         specifier: npm:typescript@^7.0.2
         version: typescript@7.0.2
@@ -39,7 +39,7 @@ importers:
         version: 5.0.0(vite@8.2.2(esbuild@0.28.2))
       wrangler:
         specifier: ^4.129.0
-        version: 4.129.0(@cloudflare/workers-types@5.20260904.1)
+        version: 4.129.0(@cloudflare/workers-types@5.20260906.1)
 
 packages:
 
@@ -86,8 +86,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@cloudflare/workers-types@5.20260904.1':
-    resolution: {integrity: sha512-SbulPvrdb4j5iISDr81Iw+YpNCG4Bb6xRqV3arkgn/Ib6STMaoG63lhPnuWqmZdakOn0qS1OUudBMdxtBFx0Jg==}
+  '@cloudflare/workers-types@5.20260906.1':
+    resolution: {integrity: sha512-mRKC5n+9OP7tZiOu7vMv2MZ+Arh3tX4b9gVAt43WFns83LNzWchhfRs9o2IkFCnYKovHo4m4Af1P4zPQWdLx0g==}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -1372,7 +1372,7 @@ snapshots:
   '@cloudflare/workerd-windows-64@1.20260903.1':
     optional: true
 
-  '@cloudflare/workers-types@5.20260904.1': {}
+  '@cloudflare/workers-types@5.20260906.1': {}
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -2212,7 +2212,7 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20260903.1
       '@cloudflare/workerd-windows-64': 1.20260903.1
 
-  wrangler@4.129.0(@cloudflare/workers-types@5.20260904.1):
+  wrangler@4.129.0(@cloudflare/workers-types@5.20260906.1):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.5.0
       '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260903.1)
@@ -2223,7 +2223,7 @@ snapshots:
       unenv: 2.0.0-rc.24
       workerd: 1.20260903.1
     optionalDependencies:
-      '@cloudflare/workers-types': 5.20260904.1
+      '@cloudflare/workers-types': 5.20260906.1
       fsevents: 2.3.3
     transitivePeerDependencies:
       - bufferutil


### PR DESCRIPTION
Consolidates the 0.39.2 Unreleased notes for the default-account quickstart correction and updates Cloudflare Workers type declarations from 5.20260904.1 to 5.20260906.1. The runtime, Go toolchain, pnpm version, and 24-hour dependency release-age policy remain unchanged. The newer September 7 type release is still within that age window.

Land after #1093. This branch starts independently from main and owns the complete Unreleased section so the documentation PR has no changelog conflict. It preserves credit for the report and contributor fix. No release version is finalized and no tag or publication is requested by this PR.

Validation: frozen pnpm installation; Worker formatting/lint, typecheck, deployment dry-run, and all 15 tests passed. The compiled Worker ran locally with real D1 storage: health, unauthorized admin access, invalid tracking IDs, encrypted pixel persistence, duplicate suppression, and query/admin results passed. The real built CLI also completed an authenticated read-only Drive request. Local and committed-branch autoreview are clean at P0–P2. The full local gate passed: formatting, lint, deadcode, all 42 Go packages, 19 script tests, docs coverage (766 command pages and 28 feature pages), and generated agent-skill freshness. The docs generator initially blocked in Homebrew Bash heredoc handling; the remaining checks passed with a fresh private temp directory and system Bash. Exact-head CI is linked in the proof comment before landing.

Dependency audit found no stale Go modules used by this repository or its tests, and all pinned GitHub Actions releases are current. Existing unused module-graph versions and the prior pnpm-major hold remain unchanged.
