### PR TITLE
chore(deps): refresh tracking worker types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 **Highlights:** The quickstart now explains how to save a default account and how shell overrides affect it.
 
 - Docs: replace the reserved `default` alias command with the account manager's **Set default** action and explain account-selection precedence. (#1092, #1093) — thanks @gianpaj and @goutamadwant.
-- Dependencies: refresh Cloudflare Workers types while retaining the existing runtime, package manager, and 24-hour release-age policy.
+- Dependencies: refresh Cloudflare Workers types to 5.20260907.1 while retaining the existing runtime, package manager, and 24-hour release-age policy.
 
 ## 0.39.1 - 2026-09-05
 

--- a/internal/tracking/worker/package.json
+++ b/internal/tracking/worker/package.json
@@ -13,7 +13,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^5.20260906.1",
+    "@cloudflare/workers-types": "^5.20260907.1",
     "@typescript/native": "npm:typescript@^7.0.2",
     "oxfmt": "^0.66.0",
     "oxlint": "^1.81.0",

--- a/internal/tracking/worker/pnpm-lock.yaml
+++ b/internal/tracking/worker/pnpm-lock.yaml
@@ -17,8 +17,8 @@ importers:
   .:
     devDependencies:
       '@cloudflare/workers-types':
-        specifier: ^5.20260906.1
-        version: 5.20260906.1
+        specifier: ^5.20260907.1
+        version: 5.20260907.1
       '@typescript/native':
         specifier: npm:typescript@^7.0.2
         version: typescript@7.0.2
@@ -39,7 +39,7 @@ importers:
         version: 5.0.0(vite@8.2.2(esbuild@0.28.2))
       wrangler:
         specifier: ^4.129.0
-        version: 4.129.0(@cloudflare/workers-types@5.20260906.1)
+        version: 4.129.0(@cloudflare/workers-types@5.20260907.1)
 
 packages:
 
@@ -86,8 +86,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@cloudflare/workers-types@5.20260906.1':
-    resolution: {integrity: sha512-mRKC5n+9OP7tZiOu7vMv2MZ+Arh3tX4b9gVAt43WFns83LNzWchhfRs9o2IkFCnYKovHo4m4Af1P4zPQWdLx0g==}
+  '@cloudflare/workers-types@5.20260907.1':
+    resolution: {integrity: sha512-HYI7eFb/MOcNzvbUW7ZwHVZL5YFXb4r6yHN3vx8gJCqde7yhn3bhuPKiQPw90UtGWWp7uOI+Que3kf8Svjn5cw==}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -1372,7 +1372,7 @@ snapshots:
   '@cloudflare/workerd-windows-64@1.20260903.1':
     optional: true
 
-  '@cloudflare/workers-types@5.20260906.1': {}
+  '@cloudflare/workers-types@5.20260907.1': {}
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -2212,7 +2212,7 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20260903.1
       '@cloudflare/workerd-windows-64': 1.20260903.1
 
-  wrangler@4.129.0(@cloudflare/workers-types@5.20260906.1):
+  wrangler@4.129.0(@cloudflare/workers-types@5.20260907.1):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.5.0
       '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260903.1)
@@ -2223,7 +2223,7 @@ snapshots:
       unenv: 2.0.0-rc.24
       workerd: 1.20260903.1
     optionalDependencies:
-      '@cloudflare/workers-types': 5.20260906.1
+      '@cloudflare/workers-types': 5.20260907.1
       fsevents: 2.3.3
     transitivePeerDependencies:
       - bufferutil


### PR DESCRIPTION
Updates the tracking worker's Cloudflare type declarations from 5.20260906.1 to 5.20260907.1 and records the exact version in the existing 0.39.2 Unreleased notes. The lockfile retains Wrangler 4.129.0, pnpm 11.25.0, and the 24-hour release-age policy.

The selected types release is older than 24 hours. Newer Workers types 5.20260908.1, Wrangler 4.129.1, oxfmt 0.67.0, and oxlint 1.82.0 remain held until they meet that policy. All declared Go requirements are current.

Validation:
- Frozen install using pnpm 11.25.0; worker formatting/lint, typecheck, all 15 tests, and Wrangler dry-run bundle pass.
- Real local workerd requests return HTTP 200 with `ok` for `/health`, HTTP 200 with a valid 43-byte GIF for `/p/not-a-real-token.gif`, and HTTP 404 for an unknown route.
- Full local gate, built-CLI smoke, and independent autoreview results are recorded in the proof comment before landing.

No release is proposed for this development-only maintenance update.
