### PR TITLE
fix(sheets): preserve zero indices when inserting dimensions

### DIFF
--- a/internal/cmd/sheets_insert.go
+++ b/internal/cmd/sheets_insert.go
@@ -98,16 +98,18 @@ func (c *SheetsInsertCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return usagef("unknown sheet %q", sheetName)
 	}
 
+	dimRange := &sheets.DimensionRange{
+		SheetId:    sheetID,
+		Dimension:  apiDimension,
+		StartIndex: startIndex,
+		EndIndex:   endIndex,
+	}
+	forceSendDimensionRangeZeroes(dimRange)
 	req := &sheets.BatchUpdateSpreadsheetRequest{
 		Requests: []*sheets.Request{
 			{
 				InsertDimension: &sheets.InsertDimensionRequest{
-					Range: &sheets.DimensionRange{
-						SheetId:    sheetID,
-						Dimension:  apiDimension,
-						StartIndex: startIndex,
-						EndIndex:   endIndex,
-					},
+					Range:             dimRange,
 					InheritFromBefore: inheritFromBefore,
 				},
 			},

--- a/internal/cmd/sheets_insert_test.go
+++ b/internal/cmd/sheets_insert_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -10,6 +11,31 @@ import (
 
 	"google.golang.org/api/sheets/v4"
 )
+
+func TestSheetsInsertCmd_FirstPositionSendsZeroes(t *testing.T) {
+	for _, sheetID := range []int64{0, 7} {
+		for _, dimension := range []string{"rows", "cols"} {
+			t.Run(fmt.Sprintf("%s/sheet%d", dimension, sheetID), func(t *testing.T) {
+				capture := &sheetsBatchUpdateCapture{}
+				svc := newSheetsBatchUpdateTestService(t, map[string]any{
+					"sheets": []map[string]any{{"properties": map[string]any{"sheetId": sheetID, "title": "Data"}}},
+				}, capture)
+				ctx := withSheetsTestService(newCmdRuntimeOutputContext(t, io.Discard, io.Discard), svc)
+				if err := runKong(t, &SheetsInsertCmd{}, []string{"s1", "Data", dimension, "1"}, ctx, &RootFlags{Account: "a@b.com"}); err != nil {
+					t.Fatal(err)
+				}
+				requests := capture.Body["requests"].([]any)
+				insert := requests[0].(map[string]any)["insertDimension"].(map[string]any)
+				rng := insert["range"].(map[string]any)
+				for key, want := range map[string]float64{"sheetId": float64(sheetID), "startIndex": 0, "endIndex": 1} {
+					if got, ok := rng[key]; !ok || got != want {
+						t.Errorf("expected %s=%v in serialized range, got %#v", key, want, rng)
+					}
+				}
+			})
+		}
+	}
+}
 
 func TestSheetsInsertCmd(t *testing.T) {
 	var gotInsert *sheets.InsertDimensionRequest


### PR DESCRIPTION
Inserting before row 1 or column A failed because the Google client omitted `startIndex: 0` from the request. Reuse the dimension-range serialization helper already used by resize and delete, including explicit zero sheet IDs.

Regression coverage checks raw request field presence for both dimensions and sheet IDs 0 and 7. The tests fail on main and pass with the fix. The real built CLI reproduced Google's 400 response before the fix; afterward both insertions succeeded and a synthetic sentinel moved from A1 to B2 in a disposable spreadsheet.

Closes #1107. Thanks @gurgeous for the report. The changelog entry is reserved for the final notes/dependency PR to avoid conflicts between independent branches.
