### PR TITLE
feat(sheets): select a tab in raw API reads

### DIFF
--- a/docs/commands/gog-sheets-raw.md
+++ b/docs/commands/gog-sheets-raw.md
@@ -39,6 +39,7 @@ gog sheets (sheet) raw <spreadsheetId> [flags]
 | `--readonly` | `bool` | false | Block mutating API requests at runtime; auth add also requests read-only OAuth scopes |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `--sheet` | `string` |  | Return only this sheet (exact tab title); spreadsheet-level metadata remains included |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |
 | `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |

--- a/docs/raw-api.md
+++ b/docs/raw-api.md
@@ -32,7 +32,14 @@ gog docs raw <docId> --tab "Notes" --pretty
 gog docs raw <docId> --all-tabs --json > doc-tabs-api.json
 gog gmail raw <messageId> --format metadata --json
 gog sheets raw <spreadsheetId> --include-grid-data --json
+gog sheets raw <spreadsheetId> --sheet "Quarterly Data" --include-grid-data --json
 ```
+
+`gog sheets raw --sheet` selects one exact tab title on the server, reducing
+the response before it is downloaded. Titles such as `A1` and titles containing
+apostrophes are treated as tab names. Spreadsheet-level metadata remains in
+the raw response; grid data still requires `--include-grid-data`. Omitting
+`--sheet` returns every tab as before.
 
 `gog docs raw --tab` resolves a tab title or ID and projects that tab into the
 legacy top-level `Document` fields such as `body`, `lists`, and

--- a/internal/cmd/sheets.go
+++ b/internal/cmd/sheets.go
@@ -687,6 +687,7 @@ func (c *SheetsClearCmd) Run(ctx context.Context, flags *RootFlags) error {
 // Go type: https://pkg.go.dev/google.golang.org/api/sheets/v4#Spreadsheet
 type SheetsRawCmd struct {
 	SpreadsheetID   string `arg:"" name:"spreadsheetId" help:"Spreadsheet ID"`
+	Sheet           string `name:"sheet" help:"Return only this sheet (exact tab title); spreadsheet-level metadata remains included"`
 	IncludeGridData bool   `name:"include-grid-data" help:"Include cell-level grid data in the response (off by default; payloads can be large and may contain secrets in formulas)"`
 	Pretty          bool   `name:"pretty" help:"Pretty-print JSON (default: compact single-line)"`
 }
@@ -704,6 +705,10 @@ func (c *SheetsRawCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	call := svc.Spreadsheets.Get(spreadsheetID).Context(ctx)
+	if c.Sheet != "" {
+		// Always quote the title so A1-like names cannot resolve to cell ranges.
+		call = call.Ranges("'" + strings.ReplaceAll(c.Sheet, "'", "''") + "'")
+	}
 	if c.IncludeGridData {
 		call = call.IncludeGridData(true)
 		u.Err().Println("warning: --include-grid-data may expose cell-level formulas that contain API keys or hardcoded secrets")

--- a/internal/cmd/sheets_raw_test.go
+++ b/internal/cmd/sheets_raw_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -97,6 +98,49 @@ func TestSheetsRaw_HappyPath_NoGridDataByDefault(t *testing.T) {
 	}
 	if _, ok := got["sheets"]; !ok {
 		t.Fatalf("expected sheets in raw output")
+	}
+}
+
+func TestSheetsRaw_SheetSelection(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		want string
+	}{
+		{"Data", "'Data'"},
+		{"A1", "'A1'"},
+		{"O'Brien! Data", "'O''Brien! Data'"},
+		{" Data ", "' Data '"},
+	} {
+		for _, grid := range []bool{false, true} {
+			t.Run(tc.name+"/grid="+strconv.FormatBool(grid), func(t *testing.T) {
+				srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if got := r.URL.Query().Get("ranges"); got != tc.want {
+						t.Errorf("ranges = %q, want %q", got, tc.want)
+					}
+					if got := r.URL.Query().Get("includeGridData") == "true"; got != grid {
+						t.Errorf("includeGridData = %v, want %v", got, grid)
+					}
+					_ = json.NewEncoder(w).Encode(fullSheetResponse("s1"))
+				}))
+				defer srv.Close()
+				var output bytes.Buffer
+				ctx := newSheetsRawTestContext(t, srv, &output, io.Discard)
+				args := []string{"s1", "--sheet", tc.name}
+				if grid {
+					args = append(args, "--include-grid-data")
+				}
+				if err := runKong(t, &SheetsRawCmd{}, args, ctx, &RootFlags{Account: "a@b.com"}); err != nil {
+					t.Fatal(err)
+				}
+				var got map[string]any
+				if err := json.Unmarshal(output.Bytes(), &got); err != nil {
+					t.Fatal(err)
+				}
+				if got["spreadsheetId"] != "s1" || got["properties"] == nil {
+					t.Fatalf("raw response metadata lost: %v", got)
+				}
+			})
+		}
 	}
 }
 


### PR DESCRIPTION
Add `sheets raw --sheet <title>` so large spreadsheets can be inspected one tab at a time. The Sheets API filters the response before download; spreadsheet-level metadata and the existing grid-data opt-in remain intact. Quoting the exact title also handles apostrophes, whitespace and A1-like names without interpreting them as ranges.

Validated the built binary against a disposable two-tab Google spreadsheet: unfiltered reads returned both tabs and selected reads returned only Data, both with and without grid data. Selected grid readback retained the expected synthetic cell. Request-level tests cover title escaping and grid selection.

Closes #1104. Thanks @gurgeous for the request. The changelog line is reserved for the final notes/dependency PR.
