### PR TITLE
feat(sheets): duplicate tabs within a spreadsheet

### DIFF
--- a/.agents/skills/gog-sheets/SKILL.md
+++ b/.agents/skills/gog-sheets/SKILL.md
@@ -41,6 +41,7 @@ gog --readonly --account user@example.com sheets get SHEET_ID 'Sheet1!A1:D20' --
 | `datasource` | Manage Connected Sheets data sources and extracts |
 | `delete-dimension` | Delete rows or columns while preserving intersecting tables |
 | `delete-tab` | Delete a tab/sheet from a spreadsheet (use --force to skip confirmation) |
+| `duplicate-tab` | Duplicate a tab within a spreadsheet |
 | `export` | Export a Google Sheet (pdf\|xlsx\|csv) via Drive |
 | `filter` | Manage basic filters |
 | `find-replace` | Find and replace text across a spreadsheet |

--- a/docs/commands.generated.md
+++ b/docs/commands.generated.md
@@ -621,6 +621,7 @@ Generated from `gog schema --json`.
       - [`gog sheets (sheet) datasource (data-source,data-sources,connected-sheets) update <spreadsheetId> <dataSourceId> [flags]`](commands/gog-sheets-datasource-update.md) - Update one BigQuery Connected Sheets data source
     - [`gog sheets (sheet) delete-dimension (delete-dim) --dimension=STRING <spreadsheetId> <rangeOrSheet> [flags]`](commands/gog-sheets-delete-dimension.md) - Delete rows or columns while preserving intersecting tables
     - [`gog sheets (sheet) delete-tab (delete-sheet) <spreadsheetId> <tabName>`](commands/gog-sheets-delete-tab.md) - Delete a tab/sheet from a spreadsheet (use --force to skip confirmation)
+    - [`gog sheets (sheet) duplicate-tab <spreadsheetId> <sourceTab> <newName> [flags]`](commands/gog-sheets-duplicate-tab.md) - Duplicate a tab within a spreadsheet
     - [`gog sheets (sheet) export (download,dl) <spreadsheetId> [flags]`](commands/gog-sheets-export.md) - Export a Google Sheet (pdf|xlsx|csv) via Drive
     - [`gog sheets (sheet) filter (filters,basic-filter,basic-filters) <command>`](commands/gog-sheets-filter.md) - Manage basic filters
       - [`gog sheets (sheet) filter (filters,basic-filter,basic-filters) set (create,add) <spreadsheetId> <range>`](commands/gog-sheets-filter-set.md) - Set a basic filter on a range; replacing an existing filter requires confirmation (or --force)

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -2,7 +2,7 @@
 
 Every `gog` command has a generated docs page. The source of truth is the live CLI schema; run `make docs-commands` after changing command names, flags, help text, aliases, or arguments.
 
-Generated pages: 766.
+Generated pages: 767.
 
 ## Top-level Commands
 
@@ -675,6 +675,7 @@ Generated pages: 766.
       - [gog sheets datasource update](gog-sheets-datasource-update.md) - Update one BigQuery Connected Sheets data source
     - [gog sheets delete-dimension](gog-sheets-delete-dimension.md) - Delete rows or columns while preserving intersecting tables
     - [gog sheets delete-tab](gog-sheets-delete-tab.md) - Delete a tab/sheet from a spreadsheet (use --force to skip confirmation)
+    - [gog sheets duplicate-tab](gog-sheets-duplicate-tab.md) - Duplicate a tab within a spreadsheet
     - [gog sheets export](gog-sheets-export.md) - Export a Google Sheet (pdf|xlsx|csv) via Drive
     - [gog sheets filter](gog-sheets-filter.md) - Manage basic filters
       - [gog sheets filter set](gog-sheets-filter-set.md) - Set a basic filter on a range; replacing an existing filter requires confirmation (or --force)

--- a/docs/commands/gog-sheets-duplicate-tab.md
+++ b/docs/commands/gog-sheets-duplicate-tab.md
@@ -1,0 +1,48 @@
+# `gog sheets duplicate-tab`
+
+> Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
+
+Duplicate a tab within a spreadsheet
+
+## Usage
+
+```bash
+gog sheets (sheet) duplicate-tab <spreadsheetId> <sourceTab> <newName> [flags]
+```
+
+## Parent
+
+- [gog sheets](gog-sheets.md)
+
+## Flags
+
+| Flag | Type | Default | Help |
+| --- | --- | --- | --- |
+| `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
+| `-a`<br>`--account`<br>`--acct` | `string` |  | Account email, alias, or auto for authenticated Google API commands |
+| `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
+| `--color` | `string` | auto | Color output: auto\|always\|never |
+| `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
+| `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
+| `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
+| `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
+| `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
+| `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
+| `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
+| `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `--index` | `*int64` |  | Zero-based insertion index (default: directly after the source tab) |
+| `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
+| `--quota-project` | `string` |  | Google Cloud project to bill for API usage (sent as X-Goog-User-Project; some APIs require it with --access-token or ADC) |
+| `--readonly` | `bool` | false | Block mutating API requests at runtime; auth add also requests read-only OAuth scopes |
+| `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
+| `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
+| `--version` | `kong.VersionFlag` |  | Print version and exit |
+| `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
+
+## See Also
+
+- [gog sheets](gog-sheets.md)
+- [Command index](README.md)

--- a/docs/commands/gog-sheets.md
+++ b/docs/commands/gog-sheets.md
@@ -29,6 +29,7 @@ gog sheets (sheet) <command> [flags]
 - [gog sheets datasource](gog-sheets-datasource.md) - Manage Connected Sheets data sources and extracts
 - [gog sheets delete-dimension](gog-sheets-delete-dimension.md) - Delete rows or columns while preserving intersecting tables
 - [gog sheets delete-tab](gog-sheets-delete-tab.md) - Delete a tab/sheet from a spreadsheet (use --force to skip confirmation)
+- [gog sheets duplicate-tab](gog-sheets-duplicate-tab.md) - Duplicate a tab within a spreadsheet
 - [gog sheets export](gog-sheets-export.md) - Export a Google Sheet (pdf|xlsx|csv) via Drive
 - [gog sheets filter](gog-sheets-filter.md) - Manage basic filters
 - [gog sheets find-replace](gog-sheets-find-replace.md) - Find and replace text across a spreadsheet

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -192,6 +192,7 @@ See [batch updates](sheets-batch-update.md), [tables](sheets-tables.md), and
 
 ```bash
 gog sheets get <spreadsheetId> 'Sheet1!A1:D20' --json
+gog sheets duplicate-tab <spreadsheetId> Sheet1 "Sheet1 backup" --json
 gog sheets update <spreadsheetId> 'Sheet1!B13' \
   --values-json @formula.json --fail-on-formula-error --json
 gog sheets batch-update <spreadsheetId> --data-json @updates.json --json

--- a/internal/cmd/sheets.go
+++ b/internal/cmd/sheets.go
@@ -65,6 +65,7 @@ type SheetsCmd struct {
 	Export        SheetsExportCmd          `cmd:"" name:"export" aliases:"download,dl" help:"Export a Google Sheet (pdf|xlsx|csv) via Drive"`
 	Chart         SheetsChartCmd           `cmd:"" name:"chart" aliases:"charts" help:"Manage spreadsheet charts"`
 	AddTab        SheetsAddTabCmd          `cmd:"" name:"add-tab" aliases:"add-sheet" help:"Add a new tab/sheet to a spreadsheet"`
+	DuplicateTab  SheetsDuplicateTabCmd    `cmd:"" name:"duplicate-tab" help:"Duplicate a tab within a spreadsheet"`
 	RenameTab     SheetsRenameTabCmd       `cmd:"" name:"rename-tab" aliases:"rename-sheet" help:"Rename a tab/sheet in a spreadsheet"`
 	DeleteTab     SheetsDeleteTabCmd       `cmd:"" name:"delete-tab" aliases:"delete-sheet" help:"Delete a tab/sheet from a spreadsheet (use --force to skip confirmation)"`
 	ReorderTab    SheetsReorderTabCmd      `cmd:"" name:"reorder-tab" aliases:"move-tab,reorder-sheet,move-sheet" help:"Move a tab/sheet to a specific 0-based position in the spreadsheet"`

--- a/internal/cmd/sheets_duplicate_tab.go
+++ b/internal/cmd/sheets_duplicate_tab.go
@@ -1,0 +1,84 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"google.golang.org/api/sheets/v4"
+
+	"github.com/openclaw/gogcli/internal/outfmt"
+	"github.com/openclaw/gogcli/internal/ui"
+)
+
+type SheetsDuplicateTabCmd struct {
+	SpreadsheetID string `arg:"" name:"spreadsheetId" help:"Spreadsheet ID"`
+	SourceTab     string `arg:"" name:"sourceTab" help:"Source tab title or numeric sheet ID"`
+	NewName       string `arg:"" name:"newName" help:"Name of the duplicated tab"`
+	Index         *int64 `name:"index" help:"Zero-based insertion index (default: directly after the source tab)"`
+}
+
+func (c *SheetsDuplicateTabCmd) Run(ctx context.Context, flags *RootFlags) error {
+	spreadsheetID := normalizeGoogleID(strings.TrimSpace(c.SpreadsheetID))
+	sourceTab := strings.TrimSpace(c.SourceTab)
+	newName := strings.TrimSpace(c.NewName)
+	if spreadsheetID == "" {
+		return usage("empty spreadsheetId")
+	}
+	if sourceTab == "" || newName == "" {
+		return usage("sourceTab and newName must not be empty")
+	}
+	if c.Index != nil && *c.Index < 0 {
+		return usage("--index must be >= 0")
+	}
+	if err := dryRunExit(ctx, flags, "sheets.duplicate-tab", map[string]any{
+		"spreadsheet_id": spreadsheetID,
+		"source_tab":     sourceTab,
+		"new_name":       newName,
+		"index":          c.Index,
+	}); err != nil {
+		return err
+	}
+	_, svc, err := requireSheetsService(ctx, flags)
+	if err != nil {
+		return err
+	}
+	target, err := resolveSheetTab(ctx, svc, spreadsheetID, sourceTab)
+	if err != nil {
+		return err
+	}
+	index := target.Index + 1
+	if c.Index != nil {
+		index = *c.Index
+	}
+	if index > int64(target.Count) {
+		return usagef("--index must be between 0 and %d", target.Count)
+	}
+	request := &sheets.DuplicateSheetRequest{
+		SourceSheetId:    target.ID,
+		NewSheetName:     newName,
+		InsertSheetIndex: index,
+		ForceSendFields:  []string{"SourceSheetId", "InsertSheetIndex"},
+	}
+	resp, err := svc.Spreadsheets.BatchUpdate(spreadsheetID, &sheets.BatchUpdateSpreadsheetRequest{
+		Requests: []*sheets.Request{{DuplicateSheet: request}},
+	}).Context(ctx).Do()
+	if err != nil {
+		return err
+	}
+	if resp == nil || len(resp.Replies) != 1 || resp.Replies[0] == nil || resp.Replies[0].DuplicateSheet == nil || resp.Replies[0].DuplicateSheet.Properties == nil {
+		return errors.New("duplicate-tab: Google returned no new tab properties; inspect the spreadsheet before retrying")
+	}
+	props := resp.Replies[0].DuplicateSheet.Properties
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(ctx, stdoutWriter(ctx), map[string]any{
+			"spreadsheetId": spreadsheetID,
+			"sourceSheetId": target.ID,
+			"sheetId":       props.SheetId,
+			"title":         props.Title,
+			"index":         props.Index,
+		})
+	}
+	ui.FromContext(ctx).Out().Linef("Duplicated tab %q as %q (sheetId %d, index %d)", target.Title, props.Title, props.SheetId, props.Index)
+	return nil
+}

--- a/internal/cmd/sheets_duplicate_tab_test.go
+++ b/internal/cmd/sheets_duplicate_tab_test.go
@@ -1,0 +1,111 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/openclaw/gogcli/internal/outfmt"
+)
+
+func TestSheetsDuplicateTab(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		args  []string
+		index float64
+	}{
+		{"default", nil, 1},
+		{"first", []string{"--index", "0"}, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				if r.Method == http.MethodGet {
+					_, _ = io.WriteString(w, `{"sheets":[{"properties":{"sheetId":0,"title":"Data","index":0}}]}`)
+					return
+				}
+				var body struct {
+					Requests []struct {
+						DuplicateSheet map[string]any `json:"duplicateSheet"`
+					} `json:"requests"`
+				}
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					t.Error(err)
+					return
+				}
+				if len(body.Requests) != 1 {
+					t.Errorf("requests = %v", body.Requests)
+					return
+				}
+				got := body.Requests[0].DuplicateSheet
+				if v, ok := got["sourceSheetId"]; !ok || v != float64(0) {
+					t.Errorf("sourceSheetId missing or wrong: %v", got)
+				}
+				if v, ok := got["insertSheetIndex"]; !ok || v != tc.index {
+					t.Errorf("insertSheetIndex missing or wrong: %v", got)
+				}
+				if got["newSheetName"] != "Backup" {
+					t.Errorf("name = %v", got)
+				}
+				_ = json.NewEncoder(w).Encode(map[string]any{"replies": []any{map[string]any{"duplicateSheet": map[string]any{"properties": map[string]any{"sheetId": 7, "title": "Backup", "index": tc.index}}}}})
+			}))
+			defer srv.Close()
+			var output bytes.Buffer
+			ctx := withSheetsTestService(newCmdRuntimeOutputContext(t, &output, io.Discard), newSheetsServiceFromServer(t, srv))
+			ctx = outfmt.WithMode(ctx, outfmt.Mode{JSON: true})
+			args := append([]string{"s1", "Data", "Backup"}, tc.args...)
+			if err := runKong(t, &SheetsDuplicateTabCmd{}, args, ctx, &RootFlags{Account: "a@b.com"}); err != nil {
+				t.Fatal(err)
+			}
+			var result map[string]any
+			if err := json.Unmarshal(output.Bytes(), &result); err != nil {
+				t.Fatal(err)
+			}
+			if result["sheetId"] != float64(7) || result["title"] != "Backup" || result["index"] != tc.index {
+				t.Fatalf("unexpected result: %v", result)
+			}
+		})
+	}
+}
+
+func TestSheetsDuplicateTab_RejectsBeforeMutation(t *testing.T) {
+	for _, args := range [][]string{{"s1", "missing", "Backup"}, {"s1", "Data", "Backup", "--index=2"}} {
+		capture := &sheetsBatchUpdateCapture{}
+		svc := newSheetsBatchUpdateTestService(t, map[string]any{"sheets": []any{map[string]any{"properties": map[string]any{"sheetId": 0, "title": "Data"}}}}, capture)
+		ctx := withSheetsTestService(newCmdRuntimeOutputContext(t, io.Discard, io.Discard), svc)
+		if err := runKong(t, &SheetsDuplicateTabCmd{}, args, ctx, &RootFlags{Account: "a@b.com"}); err == nil || capture.Body != nil {
+			t.Fatalf("expected rejection before mutation, err=%v body=%v", err, capture.Body)
+		}
+	}
+}
+
+func TestSheetsDuplicateTab_DryRunWithoutAuth(t *testing.T) {
+	ctx := newCmdRuntimeOutputContext(t, io.Discard, io.Discard)
+	err := runKong(t, &SheetsDuplicateTabCmd{}, []string{"s1", "Data", "Backup"}, ctx, &RootFlags{DryRun: true, NoInput: true})
+	if err != nil && ExitCode(err) != 0 {
+		t.Fatal(err)
+	}
+}
+
+func TestSheetsDuplicateTab_MissingReply(t *testing.T) {
+	capture := &sheetsBatchUpdateCapture{}
+	svc := newSheetsBatchUpdateTestService(t, map[string]any{"sheets": []any{map[string]any{"properties": map[string]any{"sheetId": 0, "title": "Data"}}}}, capture)
+	ctx := withSheetsTestService(newCmdRuntimeOutputContext(t, io.Discard, io.Discard), svc)
+	err := runKong(t, &SheetsDuplicateTabCmd{}, []string{"s1", "Data", "Backup"}, ctx, &RootFlags{Account: "a@b.com"})
+	if err == nil || !strings.Contains(err.Error(), "inspect the spreadsheet before retrying") {
+		t.Fatalf("expected incomplete-response guidance, got %v", err)
+	}
+}
+
+func TestSheetsDuplicateTab_Validation(t *testing.T) {
+	for _, args := range [][]string{{"", "Data", "Backup"}, {"s1", "", "Backup"}, {"s1", "Data", ""}, {"s1", "Data", "Backup", "--index=-1"}} {
+		if err := runKong(t, &SheetsDuplicateTabCmd{}, args, context.Background(), &RootFlags{}); err == nil {
+			t.Fatalf("expected validation error for %v", args)
+		}
+	}
+}

--- a/safety-profiles/agent-safe.yaml
+++ b/safety-profiles/agent-safe.yaml
@@ -212,6 +212,7 @@ sheets:
   create: false
   copy: false
   add-tab: true
+  duplicate-tab: false
   rename-tab: true
   delete-tab: false
   chart:

--- a/safety-profiles/readonly.yaml
+++ b/safety-profiles/readonly.yaml
@@ -217,6 +217,7 @@ sheets:
   create: false
   copy: false
   add-tab: false
+  duplicate-tab: false
   rename-tab: false
   delete-tab: false
   chart:


### PR DESCRIPTION
Add `sheets duplicate-tab <spreadsheetId> <sourceTab> <newName>` for making an in-spreadsheet backup before editing. The command resolves a title or numeric sheet ID, submits one DuplicateSheet request, and returns the new tab's ID, title and index. `--index` optionally chooses placement; the default is directly after the source.

Dry runs are auth-free, invalid targets/indexes stop before writes, zero sheet/index values are serialized explicitly, and an incomplete successful response advises inspection before retrying. The supplied baked profiles keep this copy operation disabled, matching their existing copy policy.

Live built-CLI proof on a disposable Google spreadsheet: duplicated Data at index zero, verified the sentinel at B2 in both original and copy, and verified Google's duplicate-name rejection. Request tests cover zero serialization, JSON output, validation, dry run and incomplete responses. Codex autoreview is clean through P2.

Closes #1102. Thanks @gurgeous for the request. The changelog entry is reserved for the final notes/dependency PR.
