### PR TITLE
feat(drive): add opt-in file listing sort controls

### DIFF
--- a/docs/commands/gog-drive-ls.md
+++ b/docs/commands/gog-drive-ls.md
@@ -36,6 +36,7 @@ gog drive (drv) ls [flags]
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
 | `--max`<br>`--limit` | `int64` | 20 | Max results |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `--order` | `string` | desc | Sort direction |
 | `--page`<br>`--cursor` | `string` |  | Page token |
 | `--parent` | `string` |  | Folder ID to list (default: root) |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
@@ -44,6 +45,7 @@ gog drive (drv) ls [flags]
 | `--readonly` | `bool` | false | Block mutating API requests at runtime; auth add also requests read-only OAuth scopes |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `--sort` | `string` | modifiedTime | Drive API sort key |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |
 | `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |

--- a/docs/commands/gog-ls.md
+++ b/docs/commands/gog-ls.md
@@ -36,6 +36,7 @@ gog ls (list) [flags]
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
 | `--max`<br>`--limit` | `int64` | 20 | Max results |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `--order` | `string` | desc | Sort direction |
 | `--page`<br>`--cursor` | `string` |  | Page token |
 | `--parent` | `string` |  | Folder ID to list (default: root) |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
@@ -44,6 +45,7 @@ gog ls (list) [flags]
 | `--readonly` | `bool` | false | Block mutating API requests at runtime; auth add also requests read-only OAuth scopes |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `--sort` | `string` | modifiedTime | Drive API sort key |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |
 | `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -66,6 +66,8 @@ See [Drive audits](drive-audits.md), [polling](polling.md), and
 
 ```bash
 # Read-only folder audits.
+gog drive ls --sort modifiedByMeTime --order desc
+gog drive ls --sort name_natural --order asc
 gog drive tree --parent <folderId> --depth 2
 gog drive du --parent <folderId> --max 20 --json
 gog drive inventory --parent <folderId> --json

--- a/internal/cmd/drive.go
+++ b/internal/cmd/drive.go
@@ -93,6 +93,8 @@ type DriveLsCmd struct {
 	All       bool   `name:"all" aliases:"global" help:"List all accessible files (mutually exclusive with --parent)"`
 	AllDrives bool   `name:"all-drives" help:"Include shared drives (default: true; use --no-all-drives for My Drive only)" default:"true" negatable:"_"`
 	Fields    string `name:"fields" help:"Drive API field mask (overrides the default set; e.g. 'files(id,name,thumbnailLink),nextPageToken')"`
+	Sort      string `name:"sort" default:"modifiedTime" enum:"createdTime,folder,modifiedByMeTime,modifiedTime,name,name_natural,quotaBytesUsed,recency,sharedWithMeTime,starred,viewedByMeTime" help:"Drive API sort key"`
+	Order     string `name:"order" default:"desc" enum:"asc,desc" help:"Sort direction"`
 }
 
 type DriveSearchCmd struct {

--- a/internal/cmd/drive_listing.go
+++ b/internal/cmd/drive_listing.go
@@ -19,6 +19,7 @@ type driveFileListOptions struct {
 	allDrives bool
 	driveID   string
 	fields    string // optional field mask override
+	orderBy   string
 }
 
 func (c *DriveLsCmd) Run(ctx context.Context, flags *RootFlags) error {
@@ -43,6 +44,10 @@ func (c *DriveLsCmd) Run(ctx context.Context, flags *RootFlags) error {
 	if c.All {
 		query = buildDriveAllListQuery(c.Query)
 	}
+	orderBy := c.Sort
+	if c.Order == "desc" {
+		orderBy += " desc"
+	}
 
 	resp, err := listDriveFiles(ctx, svc, driveFileListOptions{
 		query:     query,
@@ -50,6 +55,7 @@ func (c *DriveLsCmd) Run(ctx context.Context, flags *RootFlags) error {
 		page:      c.Page,
 		allDrives: c.AllDrives,
 		fields:    c.Fields,
+		orderBy:   orderBy,
 	})
 	if err != nil {
 		return err
@@ -101,11 +107,15 @@ func (c *DriveSearchCmd) Run(ctx context.Context, flags *RootFlags) error {
 }
 
 func listDriveFiles(ctx context.Context, svc *drive.Service, opts driveFileListOptions) (*drive.FileList, error) {
+	orderBy := strings.TrimSpace(opts.orderBy)
+	if orderBy == "" {
+		orderBy = "modifiedTime desc"
+	}
 	call := svc.Files.List().
 		Q(opts.query).
 		PageSize(opts.max).
 		PageToken(opts.page).
-		OrderBy("modifiedTime desc")
+		OrderBy(orderBy)
 	call = driveFilesListCallWithDriveSupport(call, opts.allDrives, opts.driveID)
 	mask := driveFileListFields
 	if strings.TrimSpace(opts.fields) != "" {

--- a/internal/cmd/drive_ls_cmd_test.go
+++ b/internal/cmd/drive_ls_cmd_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"testing"
 
@@ -20,6 +21,9 @@ func TestDriveLsCmd_TextAndJSON(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodGet && (r.URL.Path == "/drive/v3/files" || r.URL.Path == "/files"):
+			if got := r.URL.Query().Get("orderBy"); got != "modifiedTime desc" {
+				t.Errorf("default orderBy = %q", got)
+			}
 			if errMsg := driveAllDrivesQueryError(r, true); errMsg != "" {
 				http.Error(w, errMsg, http.StatusBadRequest)
 				return
@@ -184,5 +188,48 @@ func TestDriveLsCmd_NoAllDrives(t *testing.T) {
 	cmd := &DriveLsCmd{}
 	if execErr := runKong(t, cmd, []string{"--no-all-drives"}, ctx, flags); execErr != nil {
 		t.Fatalf("execute: %v", execErr)
+	}
+}
+
+func TestDriveLsCmd_Sort(t *testing.T) {
+	for _, tc := range []struct {
+		args []string
+		want string
+	}{
+		{[]string{"--sort", "modifiedByMeTime"}, "modifiedByMeTime desc"},
+		{[]string{"--sort", "name_natural", "--order", "asc"}, "name_natural"},
+		{[]string{"--order", "asc"}, "modifiedTime"},
+	} {
+		t.Run(tc.want, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if got := r.URL.Query().Get("orderBy"); got != tc.want {
+					t.Errorf("orderBy = %q, want %q", got, tc.want)
+				}
+				if got := r.URL.Query().Get("pageToken"); got != "next-page" {
+					t.Errorf("pageToken = %q", got)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, `{"files":[]}`)
+			}))
+			defer srv.Close()
+			svc, err := drive.NewService(context.Background(), option.WithoutAuthentication(), option.WithHTTPClient(srv.Client()), option.WithEndpoint(srv.URL+"/"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			ctx := withDriveTestService(newCmdRuntimeOutputContext(t, io.Discard, io.Discard), svc)
+			args := slices.Clone(tc.args)
+			args = append(args, "--page", "next-page")
+			if err := runKong(t, &DriveLsCmd{}, args, ctx, &RootFlags{Account: "a@b.com"}); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestDriveLsCmd_InvalidSort(t *testing.T) {
+	for _, args := range [][]string{{"--sort", "unknown"}, {"--order", "sideways"}} {
+		if err := runKong(t, &DriveLsCmd{}, args, context.Background(), &RootFlags{}); err == nil {
+			t.Fatalf("expected invalid sort options to fail: %v", args)
+		}
 	}
 }


### PR DESCRIPTION
Add opt-in `drive ls --sort` and `--order` controls, including `modifiedByMeTime`. Sorting is performed by Google before pagination; the existing `modifiedTime desc` default, shared search behavior and output shape are preserved. Ascending order uses the documented bare-key syntax.

The built CLI passed live Google checks on disposable fixtures: personal-modification sorting, ascending and descending name sorting, and one-item pagination agreeing with the full sorted result. Request tests cover defaults, direction overrides, page-token propagation and invalid flags. Codex autoreview is clean through P2 after adopting the documented ascending syntax.

Closes #1105. Thanks @gurgeous for the request. The changelog line is reserved for the final notes/dependency PR.
