### PR TITLE
feat(slides): delete multiple elements in one batch

### DIFF
--- a/docs/commands.generated.md
+++ b/docs/commands.generated.md
@@ -680,7 +680,7 @@ Generated from `gog schema --json`.
       - [`gog slides (slide) element alt-text <presentationId> <objectId> [flags]`](commands/gog-slides-element-alt-text.md) - Set or clear element accessibility text
       - [`gog slides (slide) element create-line <presentationId> <slideId> [flags]`](commands/gog-slides-element-create-line.md) - Create a native line on a slide
       - [`gog slides (slide) element create-shape <presentationId> <slideId> [flags]`](commands/gog-slides-element-create-shape.md) - Create a native shape on a slide
-      - [`gog slides (slide) element delete (rm) <presentationId> <objectId>`](commands/gog-slides-element-delete.md) - Delete one page element
+      - [`gog slides (slide) element delete (rm) <presentationId> <objectId> ...`](commands/gog-slides-element-delete.md) - Delete one or more page elements
       - [`gog slides (slide) element group <presentationId> <objectId> ... [flags]`](commands/gog-slides-element-group.md) - Group two or more elements
       - [`gog slides (slide) element style <presentationId> <objectId> [flags]`](commands/gog-slides-element-style.md) - Style a shape fill/outline or a line
       - [`gog slides (slide) element transform (move,resize,rotate) <presentationId> <objectId> [flags]`](commands/gog-slides-element-transform.md) - Move, resize, rotate, or replace an element transform

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -734,7 +734,7 @@ Generated pages: 766.
       - [gog slides element alt-text](gog-slides-element-alt-text.md) - Set or clear element accessibility text
       - [gog slides element create-line](gog-slides-element-create-line.md) - Create a native line on a slide
       - [gog slides element create-shape](gog-slides-element-create-shape.md) - Create a native shape on a slide
-      - [gog slides element delete](gog-slides-element-delete.md) - Delete one page element
+      - [gog slides element delete](gog-slides-element-delete.md) - Delete one or more page elements
       - [gog slides element group](gog-slides-element-group.md) - Group two or more elements
       - [gog slides element style](gog-slides-element-style.md) - Style a shape fill/outline or a line
       - [gog slides element transform](gog-slides-element-transform.md) - Move, resize, rotate, or replace an element transform

--- a/docs/commands/gog-slides-element-delete.md
+++ b/docs/commands/gog-slides-element-delete.md
@@ -2,12 +2,12 @@
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Delete one page element
+Delete one or more page elements
 
 ## Usage
 
 ```bash
-gog slides (slide) element delete (rm) <presentationId> <objectId>
+gog slides (slide) element delete (rm) <presentationId> <objectId> ...
 ```
 
 ## Parent

--- a/docs/commands/gog-slides-element.md
+++ b/docs/commands/gog-slides-element.md
@@ -19,7 +19,7 @@ gog slides (slide) element <command>
 - [gog slides element alt-text](gog-slides-element-alt-text.md) - Set or clear element accessibility text
 - [gog slides element create-line](gog-slides-element-create-line.md) - Create a native line on a slide
 - [gog slides element create-shape](gog-slides-element-create-shape.md) - Create a native shape on a slide
-- [gog slides element delete](gog-slides-element-delete.md) - Delete one page element
+- [gog slides element delete](gog-slides-element-delete.md) - Delete one or more page elements
 - [gog slides element group](gog-slides-element-group.md) - Group two or more elements
 - [gog slides element style](gog-slides-element-style.md) - Style a shape fill/outline or a line
 - [gog slides element transform](gog-slides-element-transform.md) - Move, resize, rotate, or replace an element transform

--- a/docs/slides-structure.md
+++ b/docs/slides-structure.md
@@ -108,6 +108,7 @@ gog slides element ungroup <presentationId> <groupId>...
 gog slides element alt-text <presentationId> <objectId> \
   --title "Chart" --description "Quarterly revenue by region"
 gog slides element delete <presentationId> <objectId> --force
+gog slides element delete <presentationId> <objectId1> <objectId2> --force
 ```
 
 `z-order` targets must share one slide and must not be grouped. `group` needs at
@@ -115,3 +116,9 @@ least two ungrouped elements on one slide; Slides does not permit every element
 kind to be grouped. Passing an empty `--title=` or `--description=` clears that
 alt-text field. Element deletion is destructive and requires confirmation or
 `--force` in non-interactive use. Every mutation supports `--dry-run --json`.
+
+Multiple deletion targets are submitted together in one atomic API batch;
+duplicate IDs are rejected before submission. A single target retains the
+existing `objectId` JSON field; multiple targets return `objectIds` instead.
+Text replacement does not edit WordArt text. To replace a WordArt heading,
+delete its element and create a text box with the desired text.

--- a/internal/cmd/slides_element.go
+++ b/internal/cmd/slides_element.go
@@ -22,7 +22,7 @@ type SlidesElementCmd struct {
 	Group       SlidesElementGroupCmd       `cmd:"" name:"group" help:"Group two or more elements"`
 	Ungroup     SlidesElementUngroupCmd     `cmd:"" name:"ungroup" help:"Ungroup one or more element groups"`
 	AltText     SlidesElementAltTextCmd     `cmd:"" name:"alt-text" help:"Set or clear element accessibility text"`
-	Delete      SlidesElementDeleteCmd      `cmd:"" name:"delete" aliases:"rm" help:"Delete one page element"`
+	Delete      SlidesElementDeleteCmd      `cmd:"" name:"delete" aliases:"rm" help:"Delete one or more page elements"`
 }
 
 const (
@@ -395,26 +395,37 @@ func (c *SlidesElementAltTextCmd) Run(ctx context.Context, flags *RootFlags) err
 }
 
 type SlidesElementDeleteCmd struct {
-	PresentationID string `arg:"" name:"presentationId" help:"Presentation ID"`
-	ObjectID       string `arg:"" name:"objectId" help:"Page element object ID"`
+	PresentationID string   `arg:"" name:"presentationId" help:"Presentation ID"`
+	ObjectIDs      []string `arg:"" name:"objectId" help:"One or more page element object IDs"`
 }
 
 func (c *SlidesElementDeleteCmd) Run(ctx context.Context, flags *RootFlags) error {
-	presentationID, objectID, err := slidesElementTarget(c.PresentationID, c.ObjectID)
+	presentationID, objectIDs, err := slidesElementTargets(c.PresentationID, c.ObjectIDs, 1)
 	if err != nil {
 		return err
 	}
-	request := &slides.Request{DeleteObject: &slides.DeleteObjectRequest{ObjectId: objectID}}
-	return runSlidesElementMutation(ctx, flags, slidesElementMutation{
+	requests := make([]*slides.Request, 0, len(objectIDs))
+	for _, objectID := range objectIDs {
+		requests = append(requests, &slides.Request{DeleteObject: &slides.DeleteObjectRequest{ObjectId: objectID}})
+	}
+	mutation := slidesElementMutation{
 		Op:             "slides.element.delete",
-		Action:         "delete element",
+		Action:         "delete elements",
 		PresentationID: presentationID,
-		Request:        request,
-		Payload:        map[string]any{"object_id": objectID},
-		Output:         map[string]any{"presentationId": presentationID, "objectId": objectID, "deleted": true},
-		Text:           fmt.Sprintf("Deleted element %s", objectID),
-		Destructive:    fmt.Sprintf("delete element %s from presentation %s", objectID, presentationID),
-	})
+		Payload:        map[string]any{"object_ids": objectIDs},
+		Output:         map[string]any{"presentationId": presentationID, "objectIds": objectIDs, "deleted": true},
+		Text:           fmt.Sprintf("Deleted %d elements", len(objectIDs)),
+		Destructive:    fmt.Sprintf("delete elements %s from presentation %s", strings.Join(objectIDs, ", "), presentationID),
+	}
+	if len(objectIDs) == 1 {
+		objectID := objectIDs[0]
+		mutation.Action = "delete element"
+		mutation.Payload = map[string]any{"object_id": objectID}
+		mutation.Output = map[string]any{"presentationId": presentationID, "objectId": objectID, "deleted": true}
+		mutation.Text = fmt.Sprintf("Deleted element %s", objectID)
+		mutation.Destructive = fmt.Sprintf("delete element %s from presentation %s", objectID, presentationID)
+	}
+	return runSlidesElementBatchMutation(ctx, flags, mutation, &slides.BatchUpdatePresentationRequest{Requests: requests})
 }
 
 type slidesElementMutation struct {
@@ -430,6 +441,10 @@ type slidesElementMutation struct {
 
 func runSlidesElementMutation(ctx context.Context, flags *RootFlags, mutation slidesElementMutation) error {
 	body := &slides.BatchUpdatePresentationRequest{Requests: []*slides.Request{mutation.Request}}
+	return runSlidesElementBatchMutation(ctx, flags, mutation, body)
+}
+
+func runSlidesElementBatchMutation(ctx context.Context, flags *RootFlags, mutation slidesElementMutation, body *slides.BatchUpdatePresentationRequest) error {
 	payload := mutation.Payload
 	if payload == nil {
 		payload = make(map[string]any)

--- a/internal/cmd/slides_element_test.go
+++ b/internal/cmd/slides_element_test.go
@@ -204,7 +204,7 @@ func TestSlidesElementStructuralRequests(t *testing.T) {
 	t.Run("delete", func(t *testing.T) {
 		request := captureSlidesElementRequest(t, &SlidesElementDeleteCmd{
 			PresentationID: "pres1",
-			ObjectID:       "shape1",
+			ObjectIDs:      []string{"shape1"},
 		}, &RootFlags{Account: "a@b.com", Force: true})
 		if request.DeleteObject == nil || request.DeleteObject.ObjectId != "shape1" {
 			t.Fatalf("unexpected delete request: %+v", request)
@@ -270,5 +270,66 @@ func TestSlidesElementValidation(t *testing.T) {
 				t.Fatalf("ExitCode = %d, want 2", ExitCode(err))
 			}
 		})
+	}
+}
+
+func TestSlidesElementDeleteMultiple(t *testing.T) {
+	var captured []*slides.Request
+	srv := mockSlidesBatchUpdateServer(t, &captured, map[string]any{})
+	defer srv.Close()
+	var output bytes.Buffer
+	ctx := withSlidesTestService(newCmdRuntimeJSONOutputContext(t, &output, io.Discard), newSlidesServiceFromServer(t, srv))
+	if err := runKong(t, &SlidesElementDeleteCmd{}, []string{"pres1", "shape1", "wordart1"}, ctx, &RootFlags{Account: "a@b.com", Force: true}); err != nil {
+		t.Fatal(err)
+	}
+	if len(captured) != 2 || captured[0].DeleteObject.ObjectId != "shape1" || captured[1].DeleteObject.ObjectId != "wordart1" {
+		t.Fatalf("unexpected delete batch: %+v", captured)
+	}
+	var result struct {
+		ObjectIDs []string `json:"objectIds"`
+		Deleted   bool     `json:"deleted"`
+	}
+	if err := json.Unmarshal(output.Bytes(), &result); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Join(result.ObjectIDs, ",") != "shape1,wordart1" || !result.Deleted {
+		t.Fatalf("unexpected output: %s", output.String())
+	}
+}
+
+func TestSlidesElementDeleteSingleOutput(t *testing.T) {
+	var captured []*slides.Request
+	srv := mockSlidesBatchUpdateServer(t, &captured, map[string]any{})
+	defer srv.Close()
+	var output bytes.Buffer
+	ctx := withSlidesTestService(newCmdRuntimeJSONOutputContext(t, &output, io.Discard), newSlidesServiceFromServer(t, srv))
+	if err := runKong(t, &SlidesElementDeleteCmd{}, []string{"pres1", "shape1"}, ctx, &RootFlags{Account: "a@b.com", Force: true}); err != nil {
+		t.Fatal(err)
+	}
+	var result map[string]any
+	if err := json.Unmarshal(output.Bytes(), &result); err != nil {
+		t.Fatal(err)
+	}
+	if result["objectId"] != "shape1" || result["deleted"] != true || result["objectIds"] != nil {
+		t.Fatalf("single-ID contract changed: %s", output.String())
+	}
+}
+
+func TestSlidesElementDeleteGuards(t *testing.T) {
+	ctx := withSlidesTestServiceFactory(newCmdRuntimeOutputContext(t, io.Discard, io.Discard), func(context.Context, string) (*slides.Service, error) {
+		t.Fatal("service must not be created")
+		return nil, context.Canceled
+	})
+	for _, args := range [][]string{{"pres1", "shape1", "shape1"}, {"pres1", "shape1", ""}} {
+		if err := runKong(t, &SlidesElementDeleteCmd{}, args, ctx, &RootFlags{Force: true}); err == nil {
+			t.Fatalf("expected invalid IDs to fail: %v", args)
+		}
+	}
+	args := []string{"pres1", "shape1", "shape2"}
+	if err := runKong(t, &SlidesElementDeleteCmd{}, args, ctx, &RootFlags{NoInput: true}); err == nil {
+		t.Fatal("expected confirmation refusal")
+	}
+	if err := runKong(t, &SlidesElementDeleteCmd{}, args, ctx, &RootFlags{DryRun: true, NoInput: true}); err != nil && ExitCode(err) != 0 {
+		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
Extend `slides element delete` to accept several object IDs and submit their DeleteObject requests together in one atomic API batch. Existing single-ID JSON/text output, confirmation and dry-run behavior remain intact; multiple targets return `objectIds`. Reuse the existing target validation to reject duplicate or empty IDs before making a request.

Single-element deletion was already available. This completes the requested multi-target operation and documents the WordArt limitation and delete/recreate workflow; it does not add automatic WordArt warnings to text replacement.

Live built-CLI proof: created two synthetic elements in a disposable presentation, verified non-interactive refusal without force, inspected the two-request dry run, deleted with force, then read back both elements absent with the slide preserved. Tests cover request grouping, single-ID output compatibility, validation, confirmation and dry runs. Local Codex autoreview is clean through P2.

Closes #1109. Thanks @sebsnyk for the request. The changelog bullet is in #1118, which must merge after this and the other code PRs.
