### PR TITLE
chore(tools): update goimports and deadcode to x/tools v0.50.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ GOIMPORTS := $(TOOLS_DIR)/goimports
 GOLANGCI_LINT := $(TOOLS_DIR)/golangci-lint
 DEADCODE := $(TOOLS_DIR)/deadcode
 TOOLS_STAMP := $(TOOLS_DIR)/.versions
-TOOLS_VERSION := gofumpt=v0.11.0;goimports=v0.49.0;golangci-lint=v2.13.2;deadcode=v0.49.0
+TOOLS_VERSION := gofumpt=v0.11.0;goimports=v0.50.0;golangci-lint=v2.13.2;deadcode=v0.50.0
 
 # Allow passing CLI args as extra "targets":
 #   make gogcli -- --help
@@ -91,9 +91,9 @@ tools:
 	else \
 		set -e; \
 		GOBIN=$(TOOLS_DIR) go install mvdan.cc/gofumpt@v0.11.0; \
-		GOBIN=$(TOOLS_DIR) go install golang.org/x/tools/cmd/goimports@v0.49.0; \
+		GOBIN=$(TOOLS_DIR) go install golang.org/x/tools/cmd/goimports@v0.50.0; \
 		GOBIN=$(TOOLS_DIR) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.13.2; \
-		GOBIN=$(TOOLS_DIR) go install golang.org/x/tools/cmd/deadcode@v0.49.0; \
+		GOBIN=$(TOOLS_DIR) go install golang.org/x/tools/cmd/deadcode@v0.50.0; \
 		printf '%s\n' "$(TOOLS_VERSION)" > "$(TOOLS_STAMP)"; \
 	fi
 


### PR DESCRIPTION
Refresh the pinned goimports and deadcode commands from golang.org/x/tools v0.49.0 to v0.50.0, including the shared tool-version stamp. The new version supports the repository's Go 1.26 minimum and Go 1.27.1 build toolchain.

The tools are installed into an isolated task directory so concurrent work retains its own pinned baseline. Validation runs the repository formatting, lint, deadcode, tests and generated-document checks with the updated tools, plus a build and real CLI schema smoke. Codex autoreview is clean through P2; exact-head CI proof will be added before handoff.

Release-note context is reserved for the final batch notes PR.
