### PR TITLE
feat(api): cache Discovery documents with bounded TTL

### DIFF
--- a/docs/automation.md
+++ b/docs/automation.md
@@ -187,6 +187,20 @@ fi
 
 New classifications may be added. Keep a generic non-zero fallback.
 
+## Discovery document cache
+
+`gog api call` and `gog api describe` share a 24-hour on-disk cache of
+Discovery documents under the configured cache directory's `discovery`
+subdirectory. It keeps at most 32 documents and 64 MiB, evicting the oldest
+documents; individual documents are limited to 16 MiB. API versions, endpoint
+overrides and service-hosted fallback behavior use separate cache keys.
+
+Pass `--no-cache` to either command to fetch without reading or writing this
+cache. Missing, expired or corrupt entries are fetched again. Cache failures
+do not prevent network access, and failed fetches are not cached. `api list`
+and actual API responses remain uncached; authorization and command-policy
+checks still run on every call.
+
 ## MCP discovery
 
 MCP uses its standard `tools/list` request for client-side tool discovery. To

--- a/docs/commands.generated.md
+++ b/docs/commands.generated.md
@@ -64,7 +64,7 @@ Generated from `gog schema --json`.
     - [`gog analytics (ga) report <property> [flags]`](commands/gog-analytics-report.md) - Run a GA4 report (Analytics Data API)
   - [`gog api <command> [flags]`](commands/gog-api.md) - Google Discovery APIs and generic method calls
     - [`gog api call <api> <version> <method> [flags]`](commands/gog-api-call.md) - Call a Discovery-described API method
-    - [`gog api describe <api> <version> [<method>]`](commands/gog-api-describe.md) - Describe a Discovery API or method
+    - [`gog api describe <api> <version> [<method>] [flags]`](commands/gog-api-describe.md) - Describe a Discovery API or method
     - [`gog api list [flags]`](commands/gog-api-list.md) - List Google Discovery APIs
   - [`gog appscript (script,apps-script) <command> [flags]`](commands/gog-appscript.md) - Google Apps Script
     - [`gog appscript (script,apps-script) content (cat) <scriptId>`](commands/gog-appscript-content.md) - Get Apps Script project content

--- a/docs/commands/gog-api-call.md
+++ b/docs/commands/gog-api-call.md
@@ -33,6 +33,7 @@ gog api call <api> <version> <method> [flags]
 | `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--no-cache` | `bool` |  | Fetch the Discovery document without reading or writing the 24-hour disk cache |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
 | `--params` | `string` | {} | JSON object of path and query parameters |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |

--- a/docs/commands/gog-api-describe.md
+++ b/docs/commands/gog-api-describe.md
@@ -7,7 +7,7 @@ Describe a Discovery API or method
 ## Usage
 
 ```bash
-gog api describe <api> <version> [<method>]
+gog api describe <api> <version> [<method>] [flags]
 ```
 
 ## Parent
@@ -31,6 +31,7 @@ gog api describe <api> <version> [<method>]
 | `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--no-cache` | `bool` |  | Fetch the Discovery document without reading or writing the 24-hour disk cache |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
 | `--quota-project` | `string` |  | Google Cloud project to bill for API usage (sent as X-Goog-User-Project; some APIs require it with --access-token or ADC) |

--- a/internal/cmd/api.go
+++ b/internal/cmd/api.go
@@ -9,9 +9,11 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"unicode/utf8"
 
+	"github.com/openclaw/gogcli/internal/config"
 	"github.com/openclaw/gogcli/internal/discoveryapi"
 	"github.com/openclaw/gogcli/internal/googleapi"
 	"github.com/openclaw/gogcli/internal/outfmt"
@@ -35,6 +37,7 @@ type APIDescribeCmd struct {
 	API     string `arg:"" name:"api" help:"Discovery API name (for example gmail)"`
 	Version string `arg:"" name:"version" help:"Discovery API version (for example v1)"`
 	Method  string `arg:"" optional:"" name:"method" help:"Optional Discovery method ID"`
+	NoCache bool   `name:"no-cache" help:"Fetch the Discovery document without reading or writing the 24-hour disk cache"`
 }
 
 type APICallCmd struct {
@@ -45,10 +48,21 @@ type APICallCmd struct {
 	BodyJSON   string `name:"body" help:"JSON request body or @file"`
 	Scope      string `name:"scope" help:"OAuth scope override (default: narrowest Discovery-listed scope)"`
 	AllowWrite bool   `name:"allow-write" help:"Allow non-read HTTP methods (also requires confirmation or --force)"`
+	NoCache    bool   `name:"no-cache" help:"Fetch the Discovery document without reading or writing the 24-hour disk cache"`
 }
 
 func discoveryClient() discoveryapi.Client {
 	return discoveryapi.Client{BaseURL: os.Getenv("GOG_DISCOVERY_BASE_URL")}
+}
+
+func discoveryDescriptionClient(ctx context.Context, noCache bool) discoveryapi.Client {
+	client := discoveryClient()
+	if !noCache {
+		if layout, err := commandLayout(ctx, config.PathKindCache); err == nil && layout.CacheDir != "" {
+			client.CacheDir = filepath.Join(layout.CacheDir, "discovery")
+		}
+	}
+	return client
 }
 
 func (c *APIListCmd) Run(ctx context.Context) error {
@@ -61,7 +75,7 @@ func (c *APIListCmd) Run(ctx context.Context) error {
 }
 
 func (c *APIDescribeCmd) Run(ctx context.Context) error {
-	description, err := discoveryClient().Description(ctx, c.API, c.Version)
+	description, err := discoveryDescriptionClient(ctx, c.NoCache).Description(ctx, c.API, c.Version)
 	if err != nil {
 		return err
 	}
@@ -81,7 +95,7 @@ func (c *APIDescribeCmd) Run(ctx context.Context) error {
 }
 
 func (c *APICallCmd) Run(ctx context.Context, flags *RootFlags) error {
-	description, err := discoveryClient().Description(ctx, c.API, c.Version)
+	description, err := discoveryDescriptionClient(ctx, c.NoCache).Description(ctx, c.API, c.Version)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/api_test.go
+++ b/internal/cmd/api_test.go
@@ -6,9 +6,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/openclaw/gogcli/internal/app"
@@ -48,6 +50,7 @@ func TestAPICallReadOnlyBlocksWriteBeforeAuth(t *testing.T) {
 }
 
 func TestAPICallReadOnlyAllowsQueryPOSTDryRun(t *testing.T) {
+	t.Setenv("GOG_CACHE_DIR", t.TempDir())
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = fmt.Fprint(w, `{"rootUrl":"https://www.googleapis.com/","servicePath":"calendar/v3/","resources":{"freebusy":{"methods":{"query":{"id":"calendar.freebusy.query","httpMethod":"POST","path":"freeBusy","scopes":["scope"]}}}}}`)
@@ -244,5 +247,47 @@ func TestDiscoveryScopesSelectsNarrowestAlternative(t *testing.T) {
 	}
 	if _, err := discoveryScopes(available, "invalid"); err == nil {
 		t.Fatal("expected invalid override error")
+	}
+}
+
+func TestDiscoveryCommandCacheAndBypass(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		_, _ = fmt.Fprint(w, `{"name":"drive","version":"v3","rootUrl":"https://www.googleapis.com/","servicePath":"drive/v3/","methods":{"list":{"id":"drive.files.list","httpMethod":"GET","path":"files","scopes":["https://www.googleapis.com/auth/drive.readonly"]}}}`)
+	}))
+	defer server.Close()
+	t.Setenv("GOG_DISCOVERY_BASE_URL", server.URL)
+	cache := t.TempDir()
+	ctx := withTestRuntime(newCmdRuntimeJSONOutputContext(t, io.Discard, io.Discard), func(r *app.Runtime) { r.Layout.CacheDir = cache })
+	for range 2 {
+		if err := runKong(t, &APIDescribeCmd{}, []string{"drive", "v3"}, ctx, &RootFlags{}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if calls.Load() != 1 {
+		t.Fatal("describe missed warm cache")
+	}
+	call := &APICallCmd{API: "drive", Version: "v3", Method: "drive.files.list"}
+	if err := call.Run(ctx, &RootFlags{DryRun: true}); err != nil && ExitCode(err) != 0 {
+		t.Fatal(err)
+	}
+	if calls.Load() != 1 {
+		t.Fatal("call did not share description cache")
+	}
+	if err := call.Run(ctx, &RootFlags{DryRun: true, DisableCommands: "api.drive.files.list"}); err == nil || !strings.Contains(err.Error(), "disabled") {
+		t.Fatalf("cached command bypassed policy: %v", err)
+	}
+	for range 2 {
+		if err := runKong(t, &APIDescribeCmd{}, []string{"drive", "v3", "--no-cache"}, ctx, &RootFlags{}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	call.NoCache = true
+	if err := call.Run(ctx, &RootFlags{DryRun: true}); err != nil && ExitCode(err) != 0 {
+		t.Fatal(err)
+	}
+	if calls.Load() != 4 {
+		t.Fatalf("bypass fetch count=%d, want 4", calls.Load())
 	}
 }

--- a/internal/discoveryapi/cache.go
+++ b/internal/discoveryapi/cache.go
@@ -1,0 +1,164 @@
+package discoveryapi
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	discovery "google.golang.org/api/discovery/v1"
+
+	"github.com/openclaw/gogcli/internal/filelock"
+)
+
+const (
+	descriptionCacheTTL           = 24 * time.Hour
+	descriptionCacheMaxEntries    = 32
+	descriptionCacheMaxBytes      = 64 << 20
+	descriptionCacheMaxEntryBytes = 16 << 20
+	descriptionCacheTempPrefix    = ".discovery-"
+)
+
+func (c Client) descriptionCacheKey(requestURL string) string {
+	// Explicit base URLs must not reuse service-hosted fallback results.
+	if strings.TrimSpace(c.BaseURL) == "" {
+		requestURL += "\x00service-hosted-fallback"
+	}
+	sum := sha256.Sum256([]byte(requestURL))
+
+	return hex.EncodeToString(sum[:]) + ".json"
+}
+
+func (c Client) cachedDescription(key string) *discovery.RestDescription {
+	path := filepath.Join(c.CacheDir, key)
+
+	info, err := os.Lstat(path)
+	if err != nil || !info.Mode().IsRegular() || info.Size() > descriptionCacheMaxEntryBytes {
+		return nil
+	}
+
+	age := time.Since(info.ModTime())
+	if age < 0 || age >= descriptionCacheTTL {
+		return nil
+	}
+
+	f, err := os.Open(path) // #nosec G304 -- key is a generated SHA-256 filename in the configured cache directory.
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+
+	raw, err := io.ReadAll(io.LimitReader(f, descriptionCacheMaxEntryBytes+1))
+	if err != nil || len(raw) > descriptionCacheMaxEntryBytes {
+		return nil
+	}
+
+	var description discovery.RestDescription
+	if json.Unmarshal(raw, &description) != nil {
+		return nil
+	}
+
+	return &description
+}
+
+func (c Client) cacheDescription(key string, raw []byte) {
+	if c.CacheDir == "" || len(raw) > descriptionCacheMaxEntryBytes {
+		return
+	}
+
+	if os.MkdirAll(c.CacheDir, 0o700) != nil {
+		return
+	}
+	// Serialize pruning and replacement across CLI processes; never hold a lock
+	// over the network, and treat contention or filesystem errors as cache misses.
+	_ = filelock.Shared(filepath.Join(c.CacheDir, ".lock"), 100*time.Millisecond).WithExclusive(func() error {
+		if !pruneDescriptionCache(c.CacheDir, key, int64(len(raw))) {
+			return nil
+		}
+
+		f, err := os.CreateTemp(c.CacheDir, descriptionCacheTempPrefix)
+		if err != nil {
+			return nil
+		}
+		defer os.Remove(f.Name())
+
+		if _, err := f.Write(raw); err != nil {
+			_ = f.Close()
+			return nil
+		}
+
+		if err := f.Close(); err != nil {
+			return nil
+		}
+		_ = os.Rename(f.Name(), filepath.Join(c.CacheDir, key))
+
+		return nil
+	})
+}
+
+func pruneDescriptionCache(dir, replacing string, incoming int64) bool {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false
+	}
+	type record struct {
+		name string
+		info os.FileInfo
+	}
+	var records []record
+	total := incoming
+
+	for _, entry := range entries {
+		name := entry.Name()
+		if strings.HasPrefix(name, descriptionCacheTempPrefix) && entry.Type().IsRegular() {
+			if err := os.Remove(filepath.Join(dir, name)); err != nil {
+				return false
+			}
+
+			continue
+		}
+
+		if name == replacing || !isDescriptionCacheName(name) || !entry.Type().IsRegular() {
+			continue
+		}
+
+		info, err := entry.Info()
+		if err != nil {
+			return false
+		}
+		total += info.Size()
+		records = append(records, record{name: name, info: info})
+	}
+
+	sort.Slice(records, func(i, j int) bool { return records[i].info.ModTime().Before(records[j].info.ModTime()) })
+
+	count := len(records) + 1
+	for _, record := range records {
+		age := time.Since(record.info.ModTime())
+		if age >= 0 && age < descriptionCacheTTL && count <= descriptionCacheMaxEntries && total <= descriptionCacheMaxBytes {
+			continue
+		}
+
+		if err := os.Remove(filepath.Join(dir, record.name)); err != nil {
+			return false
+		}
+		total -= record.info.Size()
+		count--
+	}
+
+	return true
+}
+
+func isDescriptionCacheName(name string) bool {
+	if len(name) != sha256.Size*2+len(".json") || !strings.HasSuffix(name, ".json") {
+		return false
+	}
+	_, err := hex.DecodeString(strings.TrimSuffix(name, ".json"))
+
+	return err == nil
+}

--- a/internal/discoveryapi/cache_test.go
+++ b/internal/discoveryapi/cache_test.go
@@ -1,0 +1,289 @@
+package discoveryapi
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestDescriptionCacheLifecycle(t *testing.T) {
+	var requests atomic.Int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		_, _ = fmt.Fprint(w, `{"name":"demo","version":"v1"}`)
+	}))
+	defer server.Close()
+	client := Client{BaseURL: server.URL, CacheDir: t.TempDir()}
+	load := func() {
+		t.Helper()
+
+		d, err := client.Description(context.Background(), "demo", "v1")
+		if err != nil || d.Name != "demo" {
+			t.Fatalf("description=%v err=%v", d, err)
+		}
+	}
+	load()
+	load()
+
+	if requests.Load() != 1 {
+		t.Fatalf("warm cache fetched %d times", requests.Load())
+	}
+	file := filepath.Join(client.CacheDir, client.descriptionCacheKey(server.URL+"/apis/demo/v1/rest"))
+
+	for _, mode := range []string{"expired", "future", "corrupt"} {
+		t.Run(mode, func(t *testing.T) {
+			switch mode {
+			case "expired":
+				old := time.Now().Add(-descriptionCacheTTL - time.Hour)
+				if err := os.Chtimes(file, old, old); err != nil {
+					t.Fatal(err)
+				}
+			case "future":
+				future := time.Now().Add(time.Hour)
+				if err := os.Chtimes(file, future, future); err != nil {
+					t.Fatal(err)
+				}
+			case "corrupt":
+				if err := os.WriteFile(file, []byte("not JSON"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			before := requests.Load()
+
+			load()
+			load()
+
+			if requests.Load() != before+1 {
+				t.Fatal("expected one refresh")
+			}
+		})
+	}
+	uncached := client
+	uncached.CacheDir = ""
+	before := requests.Load()
+
+	for range 2 {
+		if _, err := uncached.Description(context.Background(), "demo", "v1"); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if requests.Load() != before+2 {
+		t.Fatal("uncached path did not fetch each request")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if _, err := client.Description(ctx, "demo", "v1"); !errors.Is(err, context.Canceled) {
+		t.Fatalf("cancelled cache lookup=%v", err)
+	}
+}
+
+func TestDescriptionCacheDoesNotStoreFailures(t *testing.T) {
+	for _, tc := range []struct {
+		status int
+		body   string
+	}{{500, `{"error":"fail"}`}, {200, "invalid"}} {
+		t.Run(fmt.Sprint(tc.status), func(t *testing.T) {
+			var count atomic.Int32
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				count.Add(1)
+				w.WriteHeader(tc.status)
+				_, _ = fmt.Fprint(w, tc.body)
+			}))
+			defer server.Close()
+
+			client := Client{BaseURL: server.URL, CacheDir: t.TempDir()}
+			for range 2 {
+				if _, err := client.Description(context.Background(), "demo", "v1"); err == nil {
+					t.Fatal("expected failure")
+				}
+			}
+
+			if count.Load() != 2 {
+				t.Fatal("cached failure")
+			}
+
+			entries, _ := os.ReadDir(client.CacheDir)
+			if len(entries) != 0 {
+				t.Fatalf("cached failure: %v", entries)
+			}
+		})
+	}
+}
+
+func TestDescriptionCacheUnavailable(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { _, _ = fmt.Fprint(w, `{"name":"demo"}`) }))
+	defer server.Close()
+
+	path := filepath.Join(t.TempDir(), "not-a-directory")
+	if err := os.WriteFile(path, []byte("keep"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	client := Client{BaseURL: server.URL, CacheDir: path}
+	if d, err := client.Description(context.Background(), "demo", "v1"); err != nil || d.Name != "demo" {
+		t.Fatalf("cache error blocked network: %v", err)
+	}
+}
+
+func TestDescriptionCacheKeyIsolation(t *testing.T) {
+	a := Client{}
+	b := Client{BaseURL: DefaultBaseURL}
+	c := Client{BaseURL: "https://example.test"}
+
+	url := DefaultBaseURL + "/apis/meet/v2/rest"
+	if a.descriptionCacheKey(url) == b.descriptionCacheKey(url) {
+		t.Fatal("fallback policy not isolated")
+	}
+
+	if b.descriptionCacheKey(url) == c.descriptionCacheKey(c.BaseURL+"/apis/meet/v2/rest") {
+		t.Fatal("endpoints not isolated")
+	}
+
+	if b.descriptionCacheKey(url) == b.descriptionCacheKey(DefaultBaseURL+"/apis/meet/v1/rest") {
+		t.Fatal("versions not isolated")
+	}
+}
+
+func TestDescriptionCacheBoundsAndConcurrentWrites(t *testing.T) {
+	client := Client{CacheDir: t.TempDir()}
+
+	unrelated := filepath.Join(client.CacheDir, "keep.txt")
+	if err := os.WriteFile(unrelated, []byte("keep"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	staleTemp := filepath.Join(client.CacheDir, descriptionCacheTempPrefix+"abandoned")
+	if err := os.WriteFile(staleTemp, []byte("partial"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var wg sync.WaitGroup
+	for i := range descriptionCacheMaxEntries + 8 {
+		wg.Go(func() { client.cacheDescription(client.descriptionCacheKey(fmt.Sprint(i)), []byte(`{"name":"demo"}`)) })
+	}
+
+	wg.Wait()
+
+	entries, readDirErr := os.ReadDir(client.CacheDir)
+	if readDirErr != nil {
+		t.Fatal(readDirErr)
+	}
+	count := 0
+
+	for _, e := range entries {
+		if isDescriptionCacheName(e.Name()) {
+			count++
+
+			b, err := os.ReadFile(filepath.Join(client.CacheDir, e.Name()))
+			if err != nil || !json.Valid(b) {
+				t.Fatalf("partial record: %v", err)
+			}
+		}
+	}
+
+	if count > descriptionCacheMaxEntries {
+		t.Fatalf("cached %d entries", count)
+	}
+
+	if _, err := os.Stat(unrelated); err != nil {
+		t.Fatal("removed unrelated file")
+	}
+
+	if _, err := os.Stat(staleTemp); !os.IsNotExist(err) {
+		t.Fatal("abandoned temp not removed")
+	}
+	// Sparse files prove byte eviction without allocating a large test buffer.
+	for i := range 5 {
+		path := filepath.Join(client.CacheDir, client.descriptionCacheKey(fmt.Sprint("large", i)))
+
+		f, err := os.Create(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = f.Truncate(descriptionCacheMaxEntryBytes)
+		_ = f.Close()
+
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	client.cacheDescription(client.descriptionCacheKey("last"), []byte(`{"name":"last"}`))
+
+	entries, readDirErr = os.ReadDir(client.CacheDir)
+	if readDirErr != nil {
+		t.Fatal(readDirErr)
+	}
+	var total int64
+
+	for _, e := range entries {
+		if isDescriptionCacheName(e.Name()) {
+			info, err := e.Info()
+			if err != nil {
+				t.Fatal(err)
+			}
+			total += info.Size()
+		}
+	}
+
+	if total > descriptionCacheMaxBytes {
+		t.Fatalf("cached %d bytes", total)
+	}
+}
+
+func TestDescriptionCacheFallbackAndDirectoryRemainIndependent(t *testing.T) {
+	var calls atomic.Int32
+
+	client := Client{CacheDir: t.TempDir(), HTTP: &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		calls.Add(1)
+		code := 200
+		body := `{"name":"meet","version":"v2"}`
+
+		if strings.Contains(r.URL.Path, "/apis/meet/") {
+			code = 404
+			body = `{}`
+		}
+
+		return &http.Response{StatusCode: code, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(body))}, nil
+	})}}
+	for range 2 {
+		if _, err := client.Description(context.Background(), "meet", "v2"); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if calls.Load() != 2 {
+		t.Fatalf("fallback cache requests=%d", calls.Load())
+	}
+
+	for range 2 {
+		if _, err := client.List(context.Background(), true); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if calls.Load() != 4 {
+		t.Fatal("directory listing was cached")
+	}
+	explicit := client
+
+	explicit.BaseURL = DefaultBaseURL
+	if _, err := explicit.Description(context.Background(), "meet", "v2"); err == nil {
+		t.Fatal("explicit endpoint reused fallback entry")
+	}
+}

--- a/internal/discoveryapi/discovery.go
+++ b/internal/discoveryapi/discovery.go
@@ -28,8 +28,9 @@ var (
 )
 
 type Client struct {
-	BaseURL string
-	HTTP    *http.Client
+	BaseURL  string
+	HTTP     *http.Client
+	CacheDir string
 }
 
 type responseError struct {
@@ -85,6 +86,17 @@ func (c Client) Description(ctx context.Context, api, version string) (*discover
 
 	u := c.baseURL() + "/apis/" + url.PathEscape(api) + "/" + url.PathEscape(version) + "/rest"
 
+	cacheKey := c.descriptionCacheKey(u)
+	if c.CacheDir != "" {
+		if err := ctx.Err(); err != nil {
+			return nil, fmt.Errorf("load Discovery document: %w", err)
+		}
+
+		if description := c.cachedDescription(cacheKey); description != nil {
+			return description, nil
+		}
+	}
+
 	raw, err := c.get(ctx, u)
 
 	var responseErr *responseError
@@ -101,6 +113,10 @@ func (c Client) Description(ctx context.Context, api, version string) (*discover
 	var description discovery.RestDescription
 	if err := json.Unmarshal(raw, &description); err != nil {
 		return nil, fmt.Errorf("decode Discovery document: %w", err)
+	}
+
+	if ctx.Err() == nil {
+		c.cacheDescription(cacheKey, raw)
 	}
 
 	return &description, nil


### PR DESCRIPTION
Cache successful Discovery documents for `api call` and `api describe` for 24 hours, retaining at most 32 documents/64 MiB under gog's configured cache root. Endpoint/version/fallback keys are isolated; private atomic writes and serialized eviction keep the cache bounded. Expired or corrupt entries and unavailable cache storage fall back to the network. `--no-cache` bypasses both reads and writes.

API responses and `api list` remain uncached. Account authorization, method policy and read-only/send guards still run for every API call.

Built-CLI proof across separate processes verified cold/warm request counts, bypass without cache changes, expiry and corruption recovery. Actual Google Discovery outputs matched cold/warm/bypass, and two authenticated Drive API calls agreed. One schema-only run measured 250/68/483 ms respectively. Tests cover fallback isolation, failures, cancellation, concurrent writes and disk limits; Codex autoreview is clean through P2.

Closes #1106. Thanks @gurgeous. Changelog context is reserved for the final notes PR; exact-head CI proof will be posted before handoff.
