### PR TITLE
feat(slides): add paragraph styling for shapes and cells

### DIFF
--- a/.agents/skills/gog-slides/SKILL.md
+++ b/.agents/skills/gog-slides/SKILL.md
@@ -46,6 +46,7 @@ gog --readonly --account user@example.com slides --help
 | `locate` | Locate text in shapes and table cells with object IDs and UTF-16 ranges |
 | `move-slide` | Move a slide to a zero-based insertion index |
 | `new-slide` | Create a native themed slide |
+| `paragraph-style` | Set paragraph alignment, spacing, indentation, or direction |
 | `raw` | Dump raw Google Slides API response as JSON (Presentations.Get; lossless; for scripting and LLM consumption) |
 | `read-slide` | Read slide content: speaker notes, text elements, and images |
 | `replace-slide` | Replace an existing slide image from a local file or public URL |

--- a/docs/commands.generated.md
+++ b/docs/commands.generated.md
@@ -696,6 +696,7 @@ Generated from `gog schema --json`.
     - [`gog slides (slide) locate (find-element) <presentationId> <text> [flags]`](commands/gog-slides-locate.md) - Locate text in shapes and table cells with object IDs and UTF-16 ranges
     - [`gog slides (slide) move-slide --to-index=TO-INDEX <presentationId> <slideId>`](commands/gog-slides-move-slide.md) - Move a slide to a zero-based insertion index
     - [`gog slides (slide) new-slide <presentationId> [flags]`](commands/gog-slides-new-slide.md) - Create a native themed slide
+    - [`gog slides (slide) paragraph-style <presentationId> <objectId> [flags]`](commands/gog-slides-paragraph-style.md) - Set paragraph alignment, spacing, indentation, or direction
     - [`gog slides (slide) raw <presentationId> [flags]`](commands/gog-slides-raw.md) - Dump raw Google Slides API response as JSON (Presentations.Get; lossless; for scripting and LLM consumption)
     - [`gog slides (slide) read-slide <presentationId> <slideId> [flags]`](commands/gog-slides-read-slide.md) - Read slide content: speaker notes, text elements, and images
     - [`gog slides (slide) replace-slide <presentationId> <slideId> [<image>] [flags]`](commands/gog-slides-replace-slide.md) - Replace an existing slide image from a local file or public URL

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -2,7 +2,7 @@
 
 Every `gog` command has a generated docs page. The source of truth is the live CLI schema; run `make docs-commands` after changing command names, flags, help text, aliases, or arguments.
 
-Generated pages: 767.
+Generated pages: 768.
 
 ## Top-level Commands
 
@@ -750,6 +750,7 @@ Generated pages: 767.
     - [gog slides locate](gog-slides-locate.md) - Locate text in shapes and table cells with object IDs and UTF-16 ranges
     - [gog slides move-slide](gog-slides-move-slide.md) - Move a slide to a zero-based insertion index
     - [gog slides new-slide](gog-slides-new-slide.md) - Create a native themed slide
+    - [gog slides paragraph-style](gog-slides-paragraph-style.md) - Set paragraph alignment, spacing, indentation, or direction
     - [gog slides raw](gog-slides-raw.md) - Dump raw Google Slides API response as JSON (Presentations.Get; lossless; for scripting and LLM consumption)
     - [gog slides read-slide](gog-slides-read-slide.md) - Read slide content: speaker notes, text elements, and images
     - [gog slides replace-slide](gog-slides-replace-slide.md) - Replace an existing slide image from a local file or public URL

--- a/docs/commands/gog-slides-paragraph-style.md
+++ b/docs/commands/gog-slides-paragraph-style.md
@@ -1,0 +1,58 @@
+# `gog slides paragraph-style`
+
+> Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
+
+Set paragraph alignment, spacing, indentation, or direction
+
+## Usage
+
+```bash
+gog slides (slide) paragraph-style <presentationId> <objectId> [flags]
+```
+
+## Parent
+
+- [gog slides](gog-slides.md)
+
+## Flags
+
+| Flag | Type | Default | Help |
+| --- | --- | --- | --- |
+| `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
+| `-a`<br>`--account`<br>`--acct` | `string` |  | Account email, alias, or auto for authenticated Google API commands |
+| `--align` | `string` |  | Paragraph alignment: START, CENTER, END, JUSTIFIED |
+| `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
+| `--col` | `*int64` |  | Zero-based table column; requires --row |
+| `--color` | `string` | auto | Color output: auto\|always\|never |
+| `--direction` | `string` |  | Text direction: LEFT_TO_RIGHT or RIGHT_TO_LEFT |
+| `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
+| `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
+| `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
+| `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
+| `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
+| `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
+| `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
+| `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `--indent-end` | `*float64` |  | Paragraph end indentation in points |
+| `--indent-first-line` | `*float64` |  | First-line indentation in points |
+| `--indent-start` | `*float64` |  | Paragraph start indentation in points |
+| `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--line-spacing` | `*float64` |  | Line spacing percent (100 is normal) |
+| `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
+| `--quota-project` | `string` |  | Google Cloud project to bill for API usage (sent as X-Goog-User-Project; some APIs require it with --access-token or ADC) |
+| `--range` | `string` |  | UTF-16 range as start:end (default: all text); styles every intersecting paragraph |
+| `--readonly` | `bool` | false | Block mutating API requests at runtime; auth add also requests read-only OAuth scopes |
+| `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
+| `--row` | `*int64` |  | Zero-based table row; requires --col |
+| `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `--space-above` | `*float64` |  | Space above each paragraph in points |
+| `--space-below` | `*float64` |  | Space below each paragraph in points |
+| `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
+| `--version` | `kong.VersionFlag` |  | Print version and exit |
+| `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
+
+## See Also
+
+- [gog slides](gog-slides.md)
+- [Command index](README.md)

--- a/docs/commands/gog-slides.md
+++ b/docs/commands/gog-slides.md
@@ -34,6 +34,7 @@ gog slides (slide) <command> [flags]
 - [gog slides locate](gog-slides-locate.md) - Locate text in shapes and table cells with object IDs and UTF-16 ranges
 - [gog slides move-slide](gog-slides-move-slide.md) - Move a slide to a zero-based insertion index
 - [gog slides new-slide](gog-slides-new-slide.md) - Create a native themed slide
+- [gog slides paragraph-style](gog-slides-paragraph-style.md) - Set paragraph alignment, spacing, indentation, or direction
 - [gog slides raw](gog-slides-raw.md) - Dump raw Google Slides API response as JSON (Presentations.Get; lossless; for scripting and LLM consumption)
 - [gog slides read-slide](gog-slides-read-slide.md) - Read slide content: speaker notes, text elements, and images
 - [gog slides replace-slide](gog-slides-replace-slide.md) - Replace an existing slide image from a local file or public URL

--- a/docs/slides-text-editing.md
+++ b/docs/slides-text-editing.md
@@ -29,6 +29,22 @@ auth or API access.
 
 ## Replace text safely
 
+`paragraph-style` formats all paragraphs in one shape, or the paragraphs
+intersecting an optional UTF-16 range. It also supports one table cell:
+
+```bash
+gog slides paragraph-style <presentationId> <objectId> --align START --line-spacing 120
+gog slides paragraph-style <presentationId> <objectId> --range 0:20 --space-above 0 --space-below 8
+gog slides paragraph-style <presentationId> <objectId> --indent-start 18 --indent-first-line 0
+gog slides paragraph-style <presentationId> <tableId> --row 0 --col 1 --align CENTER
+```
+
+Spacing and indentation are in points; line spacing is a percentage (100 is
+normal). Only supplied fields are changed, including explicit zero values.
+Use `--direction LEFT_TO_RIGHT` or `RIGHT_TO_LEFT` for paragraph direction.
+Table cells are validated against the current presentation and updated with
+revision protection. Dry runs require no authentication.
+
 `replace-text` requires an explicit scope:
 
 ```bash

--- a/internal/cmd/slides.go
+++ b/internal/cmd/slides.go
@@ -39,6 +39,7 @@ type SlidesCmd struct {
 	Table              SlidesTableCmd              `cmd:"" name:"table" help:"Create and update native tables"`
 	Element            SlidesElementCmd            `cmd:"" name:"element" help:"Create and manipulate native page elements"`
 	StyleText          SlidesStyleTextCmd          `cmd:"" name:"style-text" help:"Apply range-scoped text styling to one page element"`
+	ParagraphStyle     SlidesParagraphStyleCmd     `cmd:"" name:"paragraph-style" help:"Set paragraph alignment, spacing, indentation, or direction"`
 	Link               SlidesLinkCmd               `cmd:"" name:"link" help:"Apply a hyperlink to a text range in one page element"`
 	Bullets            SlidesBulletsCmd            `cmd:"" name:"bullets" help:"Turn paragraph bullets on or off in one page element"`
 	ReplaceText        SlidesReplaceTextCmd        `cmd:"" name:"replace-text" help:"Find-and-replace text in an explicit object, slide, or presentation scope"`

--- a/internal/cmd/slides_paragraph_style.go
+++ b/internal/cmd/slides_paragraph_style.go
@@ -1,0 +1,124 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"strings"
+
+	"google.golang.org/api/slides/v1"
+)
+
+type SlidesParagraphStyleCmd struct {
+	PresentationID  string   `arg:"" name:"presentationId" help:"Presentation ID"`
+	ObjectID        string   `arg:"" name:"objectId" help:"Shape or table object ID"`
+	Range           string   `name:"range" help:"UTF-16 range as start:end (default: all text); styles every intersecting paragraph"`
+	Row             *int64   `name:"row" help:"Zero-based table row; requires --col"`
+	Col             *int64   `name:"col" help:"Zero-based table column; requires --row"`
+	Align           string   `name:"align" help:"Paragraph alignment: START, CENTER, END, JUSTIFIED"`
+	Direction       string   `name:"direction" help:"Text direction: LEFT_TO_RIGHT or RIGHT_TO_LEFT"`
+	LineSpacing     *float64 `name:"line-spacing" help:"Line spacing percent (100 is normal)"`
+	SpaceAbove      *float64 `name:"space-above" help:"Space above each paragraph in points"`
+	SpaceBelow      *float64 `name:"space-below" help:"Space below each paragraph in points"`
+	IndentStart     *float64 `name:"indent-start" help:"Paragraph start indentation in points"`
+	IndentEnd       *float64 `name:"indent-end" help:"Paragraph end indentation in points"`
+	IndentFirstLine *float64 `name:"indent-first-line" help:"First-line indentation in points"`
+}
+
+func (c *SlidesParagraphStyleCmd) Run(ctx context.Context, flags *RootFlags) error {
+	presentationID, objectID, err := slidesElementTarget(c.PresentationID, c.ObjectID)
+	if err != nil {
+		return err
+	}
+	if (c.Row == nil) != (c.Col == nil) {
+		return usage("--row and --col must be provided together")
+	}
+	if c.Row != nil && (*c.Row < 0 || *c.Col < 0) {
+		return usage("--row and --col must be >= 0")
+	}
+	textRange := &slides.Range{Type: "ALL"}
+	if strings.TrimSpace(c.Range) != "" {
+		textRange, err = parseSlidesTextRange(c.Range)
+		if err != nil {
+			return err
+		}
+	}
+	style, fields, err := c.paragraphStyle()
+	if err != nil {
+		return err
+	}
+	request := &slides.Request{UpdateParagraphStyle: &slides.UpdateParagraphStyleRequest{
+		ObjectId: objectID, TextRange: textRange, Style: style, Fields: strings.Join(fields, ","),
+	}}
+	payload := map[string]any{"object_id": objectID, "fields": fields}
+	output := map[string]any{"presentationId": presentationID, "objectId": objectID, "fields": fields}
+	message := fmt.Sprintf("Styled paragraphs in %s", objectID)
+	if c.Row != nil {
+		request.UpdateParagraphStyle.CellLocation = slidesTableCellLocation(*c.Row, *c.Col)
+		payload["row"], payload["col"] = *c.Row, *c.Col
+		output["row"], output["col"] = *c.Row, *c.Col
+		return runSlidesTableMutation(ctx, flags, slidesTableMutation{
+			Op: "slides.paragraph-style", Action: "style paragraphs", PresentationID: presentationID,
+			TableObjectID: objectID, Request: request, Payload: payload, Output: output, Text: message,
+			Validate: func(table *slides.Table) error { return validateSlidesTableAnchor(table, *c.Row, *c.Col) },
+		})
+	}
+	return runSlidesElementMutation(ctx, flags, slidesElementMutation{
+		Op: "slides.paragraph-style", Action: "style paragraphs", PresentationID: presentationID,
+		Request: request, Payload: payload, Output: output, Text: message,
+	})
+}
+
+func (c *SlidesParagraphStyleCmd) paragraphStyle() (*slides.ParagraphStyle, []string, error) {
+	style := &slides.ParagraphStyle{}
+	var fields []string
+	if c.Align != "" {
+		align, err := slidesElementEnum(c.Align, "", "START", "CENTER", "END", "JUSTIFIED")
+		if err != nil {
+			return nil, nil, usage("--align must be START, CENTER, END, or JUSTIFIED")
+		}
+		style.Alignment = align
+		fields = append(fields, "alignment")
+	}
+	if c.Direction != "" {
+		direction, err := slidesElementEnum(c.Direction, "", "LEFT_TO_RIGHT", "RIGHT_TO_LEFT")
+		if err != nil {
+			return nil, nil, usage("--direction must be LEFT_TO_RIGHT or RIGHT_TO_LEFT")
+		}
+		style.Direction = direction
+		fields = append(fields, "direction")
+	}
+	if c.LineSpacing != nil {
+		if math.IsNaN(*c.LineSpacing) || math.IsInf(*c.LineSpacing, 0) || *c.LineSpacing <= 0 {
+			return nil, nil, usage("--line-spacing must be finite and > 0")
+		}
+		style.LineSpacing = *c.LineSpacing
+		fields = append(fields, "lineSpacing")
+	}
+	for _, dimension := range []struct {
+		value       *float64
+		target      **slides.Dimension
+		field       string
+		nonnegative bool
+	}{
+		{c.SpaceAbove, &style.SpaceAbove, "spaceAbove", true},
+		{c.SpaceBelow, &style.SpaceBelow, "spaceBelow", true},
+		{c.IndentStart, &style.IndentStart, "indentStart", false},
+		{c.IndentEnd, &style.IndentEnd, "indentEnd", false},
+		{c.IndentFirstLine, &style.IndentFirstLine, "indentFirstLine", false},
+	} {
+		if dimension.value == nil {
+			continue
+		}
+		value := *dimension.value
+		if math.IsNaN(value) || math.IsInf(value, 0) || (dimension.nonnegative && value < 0) {
+			return nil, nil, usagef("invalid %s value", dimension.field)
+		}
+		*dimension.target = &slides.Dimension{Magnitude: value, Unit: "PT", ForceSendFields: []string{"Magnitude"}}
+		fields = append(fields, dimension.field)
+	}
+	if len(fields) == 0 {
+		return nil, nil, usage("provide at least one paragraph style option")
+	}
+	return style, fields, nil
+}

--- a/internal/cmd/slides_paragraph_style_test.go
+++ b/internal/cmd/slides_paragraph_style_test.go
@@ -1,0 +1,151 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"math"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/slides/v1"
+)
+
+func TestSlidesParagraphStyleShape(t *testing.T) {
+	var captured []*slides.Request
+	server := mockSlidesBatchUpdateServer(t, &captured, map[string]any{})
+	defer server.Close()
+	var output bytes.Buffer
+	ctx := withSlidesTestService(newCmdRuntimeJSONOutputContext(t, &output, io.Discard), newSlidesServiceFromServer(t, server))
+	args := []string{"pres1", "shape1", "--align", "center", "--direction", "right-to-left", "--line-spacing", "125", "--space-above", "0", "--indent-start", "18", "--indent-first-line", "0", "--range", "0:8"}
+	if err := runKong(t, &SlidesParagraphStyleCmd{}, args, ctx, &RootFlags{Account: "a@b.com"}); err != nil {
+		t.Fatal(err)
+	}
+	if len(captured) != 1 || captured[0].UpdateParagraphStyle == nil {
+		t.Fatalf("requests=%+v", captured)
+	}
+	r := captured[0].UpdateParagraphStyle
+	if r.Style.Alignment != "CENTER" || r.Style.Direction != "RIGHT_TO_LEFT" || r.Style.LineSpacing != 125 {
+		t.Fatalf("style=%+v", r.Style)
+	}
+	if r.Fields != "alignment,direction,lineSpacing,spaceAbove,indentStart,indentFirstLine" {
+		t.Fatalf("fields=%s", r.Fields)
+	}
+	if r.TextRange.Type != "FIXED_RANGE" || r.TextRange.StartIndex == nil || *r.TextRange.StartIndex != 0 || r.TextRange.EndIndex == nil || *r.TextRange.EndIndex != 8 {
+		t.Fatalf("range=%+v", r.TextRange)
+	}
+	if !strings.Contains(output.String(), `"objectId": "shape1"`) {
+		t.Fatal(output.String())
+	}
+}
+
+func TestSlidesParagraphStyleZeroFields(t *testing.T) {
+	zero := float64(0)
+	c := SlidesParagraphStyleCmd{SpaceAbove: &zero, SpaceBelow: &zero, IndentStart: &zero, IndentEnd: &zero, IndentFirstLine: &zero}
+	style, fields, err := c.paragraphStyle()
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := json.Marshal(style)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var obj map[string]map[string]any
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		t.Fatal(err)
+	}
+	if len(fields) != 5 {
+		t.Fatal(fields)
+	}
+	for _, field := range fields {
+		if v, ok := obj[field]["magnitude"]; !ok || v != float64(0) {
+			t.Fatalf("explicit zero missing: %s", raw)
+		}
+	}
+}
+
+func TestSlidesParagraphStyleCell(t *testing.T) {
+	var captured slides.BatchUpdatePresentationRequest
+	pres := slidesPresentationWithTableCellText(0, 0, "cell\n")
+	server := mockSlidesPresentationBatchUpdateServer(t, &captured, pres, map[string]any{})
+	defer server.Close()
+	ctx := withSlidesTestService(newCmdRuntimeOutputContext(t, io.Discard, io.Discard), newSlidesServiceFromServer(t, server))
+	args := []string{"pres1", "table_1", "--row", "0", "--col", "0", "--align", "END"}
+	if err := runKong(t, &SlidesParagraphStyleCmd{}, args, ctx, &RootFlags{Account: "a@b.com"}); err != nil {
+		t.Fatal(err)
+	}
+	r := captured.Requests[0].UpdateParagraphStyle
+	if r.CellLocation == nil || r.CellLocation.RowIndex != 0 || r.CellLocation.ColumnIndex != 0 || r.TextRange.Type != "ALL" {
+		t.Fatalf("request=%+v", r)
+	}
+	if captured.WriteControl == nil || captured.WriteControl.RequiredRevisionId != "rev1" {
+		t.Fatal("missing revision protection")
+	}
+	captured = slides.BatchUpdatePresentationRequest{}
+	args = []string{"pres1", "table_1", "--row", "9", "--col", "0", "--align", "END"}
+	if err := runKong(t, &SlidesParagraphStyleCmd{}, args, ctx, &RootFlags{Account: "a@b.com"}); err == nil || len(captured.Requests) != 0 {
+		t.Fatalf("invalid cell changed table: err=%v", err)
+	}
+}
+
+func TestSlidesParagraphStyleValidationAndDryRun(t *testing.T) {
+	ctx := withSlidesTestServiceFactory(newCmdRuntimeOutputContext(t, io.Discard, io.Discard), func(context.Context, string) (*slides.Service, error) {
+		t.Fatal("service created")
+		return nil, context.Canceled
+	})
+	for _, opts := range [][]string{{}, {"--align", "bad"}, {"--direction", "bad"}, {"--line-spacing", "0"}, {"--space-above", "-1"}, {"--row", "0", "--align", "START"}, {"--row", "-1", "--col", "0", "--align", "START"}, {"--range", "8:0", "--align", "START"}} {
+		args := append([]string{"pres1", "shape1"}, opts...)
+		if err := runKong(t, &SlidesParagraphStyleCmd{}, args, ctx, &RootFlags{}); err == nil {
+			t.Fatalf("accepted invalid options %v", opts)
+		}
+	}
+	nan := math.NaN()
+	if _, _, err := (&SlidesParagraphStyleCmd{IndentStart: &nan}).paragraphStyle(); err == nil {
+		t.Fatal("accepted NaN")
+	}
+	if err := runKong(t, &SlidesParagraphStyleCmd{}, []string{"pres1", "shape1", "--align", "START"}, ctx, &RootFlags{DryRun: true}); err != nil && ExitCode(err) != 0 {
+		t.Fatal(err)
+	}
+}
+
+func TestSlidesParagraphStyleDryRunShowsValuesAndRange(t *testing.T) {
+	for _, tc := range []struct {
+		align, span, rangeType string
+		cell                   bool
+	}{{"START", "", "ALL", false}, {"END", "0:8", "FIXED_RANGE", true}} {
+		t.Run(tc.align, func(t *testing.T) {
+			var output bytes.Buffer
+			ctx := newCmdRuntimeJSONOutputContext(t, &output, io.Discard)
+			args := []string{"pres1", "target", "--align", tc.align, "--space-above", "0"}
+			if tc.span != "" {
+				args = append(args, "--range", tc.span)
+			}
+			if tc.cell {
+				args = append(args, "--row", "0", "--col", "0")
+			}
+			err := runKong(t, &SlidesParagraphStyleCmd{}, args, ctx, &RootFlags{DryRun: true})
+			if err != nil && ExitCode(err) != 0 {
+				t.Fatal(err)
+			}
+			var result struct {
+				Request struct {
+					BatchUpdate slides.BatchUpdatePresentationRequest `json:"batch_update"`
+				} `json:"request"`
+			}
+			if err := json.Unmarshal(output.Bytes(), &result); err != nil {
+				t.Fatal(err)
+			}
+			if len(result.Request.BatchUpdate.Requests) != 1 {
+				t.Fatalf("missing dry-run requests: %s", output.String())
+			}
+			request := result.Request.BatchUpdate.Requests[0].UpdateParagraphStyle
+			if request == nil || request.Style.Alignment != tc.align || request.TextRange.Type != tc.rangeType || request.Style.SpaceAbove == nil {
+				t.Fatalf("incomplete plan: %s", output.String())
+			}
+			if tc.cell && request.CellLocation == nil {
+				t.Fatal("missing cell target")
+			}
+		})
+	}
+}

--- a/safety-profiles/agent-safe.yaml
+++ b/safety-profiles/agent-safe.yaml
@@ -237,6 +237,7 @@ slides:
   update-notes: false
   replace-slide: false
   insert-text: false
+  paragraph-style: false
   replace-text: false
 
 chat:

--- a/safety-profiles/readonly.yaml
+++ b/safety-profiles/readonly.yaml
@@ -242,6 +242,7 @@ slides:
   update-notes: false
   replace-slide: false
   insert-text: false
+  paragraph-style: false
   replace-text: false
 
 chat:


### PR DESCRIPTION
Add `slides paragraph-style` for alignment, line spacing, paragraph spacing, indentation and direction on shapes or individual table cells. Optional UTF-16 ranges affect intersecting paragraphs; omitted ranges select all text. Only supplied fields are changed, including explicit zero dimensions.

Reuse the existing mutation helpers for complete auth-free dry-run plans and normal command guards. Cell targets are validated against the current table and protected by the presentation revision. The supplied baked profiles leave the new mutation disabled.

The built CLI passed live Google checks for range-scoped alignment while preserving the second paragraph, spacing reset to zero, hanging indentation, table-cell alignment/line spacing/direction and invalid-row refusal. The disposable presentation was trashed and verified. Tests cover field masks, wire-level zeros, ranges, validation, cell targeting/revision checks and complete dry-run values. Codex autoreview is clean through P2.

Closes #1098. Thanks @sebsnyk. The changelog entry is reserved for the final notes PR; exact-head CI proof will be posted before handoff.
