### PR TITLE
docs: update 0.39.2 Unreleased notes for API and Slides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 ## 0.39.2 - Unreleased
 
-**Highlights:** Duplicate spreadsheet tabs before editing, inspect one tab at a time, and choose how Drive files are sorted.
+**Highlights:** Preserve Slides styling, format paragraphs, and reuse cached Discovery documents; duplicate or inspect individual spreadsheet tabs and sort Drive files.
 
+- Slides: preserve leading text styling during `insert-text --replace`, including template inheritance, with revision protection and correct empty-target and UTF-16 handling. (#1111, #1122) — thanks @sebsnyk.
+- Slides: add `paragraph-style` for shape and table-cell alignment, spacing, indentation, and direction, with explicit field masks and zero-value support. (#1098, #1123) — thanks @sebsnyk.
+- API: cache Discovery documents for 24 hours with bounded disk usage, isolated endpoint/version keys, and explicit `--no-cache` bypass; keep API responses and authorization checks uncached. (#1106, #1121) — thanks @gurgeous.
 - Sheets: duplicate a tab within its spreadsheet, with an explicit destination name and optional insertion index. (#1102, #1116) — thanks @gurgeous.
 - Sheets: filter raw API reads by exact tab title with `--sheet`, including A1-like names and apostrophes, while retaining spreadsheet metadata and the grid-data opt-in. (#1104, #1115) — thanks @gurgeous.
 - Drive: add opt-in `ls --sort` and `--order` controls while preserving the existing modification-time default and native pagination. (#1105, #1117) — thanks @gurgeous.
@@ -11,6 +14,7 @@
 - Sheets: preserve zero-valued dimension indices so inserting before the first row or column succeeds. (#1107, #1114) — thanks @gurgeous.
 - Docs: replace the reserved `default` alias command with the account manager's **Set default** action and explain account-selection precedence. (#1092, #1093) — thanks @gianpaj and @goutamadwant.
 - Dependencies: refresh Go networking, authentication and cryptography modules and tracking-worker tooling, including the patched Sharp dependency, while retaining Go 1.26 compatibility and the worker's 24-hour release-age policy.
+- Tooling: refresh goimports and deadcode to x/tools v0.50.0 while retaining the Go 1.26 minimum. (#1120)
 
 ## 0.39.1 - 2026-09-05
 


### PR DESCRIPTION
Update the existing 0.39.2 Unreleased section with the template-style repair, paragraph formatting, Discovery cache, and x/tools refresh. Retain every batch-1 detailed entry and include both batches in Highlights; released sections and version files are unchanged.

Land LAST after #1122, #1121, #1123 and #1120. Each implementation remains on an independent branch without changelog edits. Contributor thanks are recorded here for @sebsnyk and @gurgeous.

Validation: one Unreleased heading, released-section comparison unchanged, diff whitespace check, and clean Codex autoreview through P2. This is release-note preparation only; no merge, tag or release has been performed.
