### PR TITLE
feat(gmail): support raw RFC822 drafts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.40.1 - Unreleased
 
+- Gmail: stage and replace raw RFC822 drafts, retrieve their MIME, and preview safely offline; bound raw draft/send input to 35 MiB while preserving no-send policies. (#1126) — thanks @darkamenosa.
 - Apps Script: keep file names within one TSV field in `appscript content`, escaping line breaks instead of splitting output rows. (#1091) — thanks @haosdent.
 - Search Console: add `searchconsole inspect` for per-URL index status via the URL Inspection API (coverage state, indexing/page-fetch/robots.txt state, canonical, sitemaps, last crawl time), using the existing `webmasters` OAuth scope. (#1094) — thanks @laihenyi.
 - Search Console: preserve permission-denied exit codes when adding API setup or scope guidance. (#1094)

--- a/docs/commands/gog-gmail-drafts-create.md
+++ b/docs/commands/gog-gmail-drafts-create.md
@@ -44,6 +44,7 @@ gog gmail (mail,email) drafts (draft) create (add,new) [flags]
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
 | `--quota-project` | `string` |  | Google Cloud project to bill for API usage (sent as X-Goog-User-Project; some APIs require it with --access-token or ADC) |
 | `--quote` | `bool` |  | Include quoted original message in reply (requires --reply-to-message-id or --thread-id) |
+| `--raw-file` | `string` |  | Create a draft from an exact RFC822 message file, or '-' for stdin (cannot be combined with compose flags) |
 | `--readonly` | `bool` | false | Block mutating API requests at runtime; auth add also requests read-only OAuth scopes |
 | `--reply-all` | `bool` |  | Auto-populate recipients from original message (requires --reply-to-message-id or --thread-id) |
 | `--reply-to` | `string` |  | Reply-To header address |
@@ -51,7 +52,7 @@ gog gmail (mail,email) drafts (draft) create (add,new) [flags]
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
 | `--subject` | `string` |  | Subject (required) |
-| `--thread-id` | `string` |  | Reply within a Gmail thread (uses latest message for headers) |
+| `--thread-id` | `string` |  | Reply within a Gmail thread (uses latest message for headers; raw mode sets only the thread ID) |
 | `--to` | `string` |  | Recipients (comma-separated) |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |

--- a/docs/commands/gog-gmail-drafts-get.md
+++ b/docs/commands/gog-gmail-drafts-get.md
@@ -28,6 +28,7 @@ gog gmail (mail,email) drafts (draft) get (info,show) <draftId> [flags]
 | `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
 | `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
 | `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
+| `--format` | `string` | full | Draft format: full\|raw (raw emits RFC822 bytes in text mode) |
 | `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
 | `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |

--- a/docs/commands/gog-gmail-drafts-update.md
+++ b/docs/commands/gog-gmail-drafts-update.md
@@ -46,6 +46,7 @@ gog gmail (mail,email) drafts (draft) update (edit,set) <draftId> [flags]
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
 | `--quota-project` | `string` |  | Google Cloud project to bill for API usage (sent as X-Goog-User-Project; some APIs require it with --access-token or ADC) |
 | `--quote` | `bool` |  | Include quoted original message in reply |
+| `--raw-file` | `string` |  | Replace the entire draft with an exact RFC822 message file, or '-' for stdin (cannot be combined with compose flags) |
 | `--readonly` | `bool` | false | Block mutating API requests at runtime; auth add also requests read-only OAuth scopes |
 | `--reply-all` | `bool` |  | Auto-populate recipients from original message (requires --reply-to-message-id or --thread-id) |
 | `--reply-to` | `string` |  | Reply-To header address |
@@ -53,7 +54,7 @@ gog gmail (mail,email) drafts (draft) update (edit,set) <draftId> [flags]
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
 | `--subject` | `string` |  | Subject (required) |
-| `--thread-id` | `string` |  | Reply within a Gmail thread (uses latest message for headers); overrides the draft's existing thread |
+| `--thread-id` | `string` |  | Reply within a Gmail thread (raw mode sets only the thread ID); overrides the draft's existing thread |
 | `--to` | `*string` |  | Recipients (comma-separated; omit to keep existing) |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |

--- a/docs/gmail-workflows.md
+++ b/docs/gmail-workflows.md
@@ -99,6 +99,66 @@ This creates an HTML draft; it does not change plain-text MIME behavior. Check
 the draft and recipient-client rendering before relying on the workaround for
 a particular workflow.
 
+## Stage an exact RFC822 message as a draft
+
+Use the same prebuilt MIME file as `gmail send --raw-file` to stage a draft
+without rebuilding its headers, multipart alternatives, or CID inline images:
+
+```bash
+gog --account you@example.com --gmail-no-send gmail drafts create --raw-file approved.eml --json
+gog --account you@example.com --gmail-no-send gmail drafts update DRAFT_ID --raw-file approved.eml --json
+gog --account you@example.com --gmail-no-send gmail drafts create --raw-file - < approved.eml
+```
+
+Raw create and update submit the input bytes unchanged. Raw update replaces the
+entire message: it does not merge the old recipients, attachments, thread ID, or
+reply headers. The draft ID stays stable, but Gmail replaces the nested message
+ID. JSON retains the normal `draftId`, `message`, `threadId`, `inReplyTo`,
+`references`, and `replyContextSource` fields. Text output includes `draft_id`
+and `message_id`.
+
+Rules:
+
+- Supply a non-empty, parseable RFC822 message with exactly one valid `From`
+  address matching the account or a verified send-as alias. The caller's
+  display name is not replaced. Alias validation requires Gmail settings access.
+- Recipients may be omitted for a draft; any supplied recipient addresses must
+  be valid. Direct access tokens and ADC require an explicit `--account`.
+- Compose flags cannot be combined with raw input, including body, recipient,
+  attachment, sender, reply, quote, and update's clear flags. If
+  `GOG_GMAIL_AUTO_FROM_ADDRESSED_ALIAS` is enabled, disable it for raw mode with
+  `--auto-from-addressed-alias=false`.
+- Optional `--thread-id` sets only `message.threadId`; it does not fetch a reply
+  target or rewrite headers. Gmail thread URLs are accepted. To join a thread,
+  the raw message must also contain suitable `In-Reply-To` and `References`
+  headers and a matching subject.
+- Input is limited to 36,700,160 bytes (35 MiB), before the outer base64url
+  encoding. Files and stdin are bounded; oversize inputs fail before any API
+  call. Gmail can still reject messages for other server-side limits.
+- Global and per-account no-send policies permit draft create and update.
+  `--readonly` blocks these mutations before authentication. `--dry-run` works
+  offline, even with `--readonly`, and reports only the source, byte count,
+  SHA-256, optional thread ID, and update's draft ID, never message content.
+- Draft writes need `gmail.compose`, `gmail.modify`, or `mail.google.com` OAuth
+  scope. A token with only `gmail.send` cannot create or update drafts.
+
+Retrieve the stored MIME for verification:
+
+```bash
+gog --account you@example.com --readonly gmail drafts get DRAFT_ID --format raw --plain > stored.eml
+gog --account you@example.com --readonly gmail drafts get DRAFT_ID --format raw --json
+```
+
+Raw text output contains only the decoded RFC822 bytes, without a heading or
+added newline. JSON retains the `draft` envelope with `draft.message.raw` in
+base64url form. The default `--format full` is unchanged. Raw retrieval cannot
+be combined with `--download` or `--use-indexed-attachment-ids`. Omit
+`--wrap-untrusted` when comparing bytes, since text wrapping changes output.
+
+The CLI guarantees unchanged bytes at submission, not unchanged Gmail storage
+or Gmail web editing. Compare the retrieved MIME and inspect the draft in the
+intended mail client before relying on it as a review artifact.
+
 ## Send Guardrails
 
 Block send operations globally for one run:
@@ -138,6 +198,7 @@ can send only from its own account. Direct access tokens and ADC require an
 explicit `--account`. Read-only and global/per-account no-send policies still
 apply. A dry-run validates the RFC822 structure without authentication and
 reports only the source, byte count, SHA-256 digest, and optional thread ID.
+Raw send uses the same 35 MiB input bound as raw drafts.
 
 Command page: [`gog gmail send`](commands/gog-gmail-send.md).
 

--- a/internal/cmd/gmail_drafts.go
+++ b/internal/cmd/gmail_drafts.go
@@ -103,6 +103,7 @@ func (c *GmailDraftsListCmd) Run(ctx context.Context, flags *RootFlags) error {
 
 type GmailDraftsGetCmd struct {
 	DraftID                 string `arg:"" name:"draftId" help:"Draft ID"`
+	Format                  string `name:"format" help:"Draft format: full|raw (raw emits RFC822 bytes in text mode)" default:"full" enum:"full,raw"`
 	UseIndexedAttachmentIDs bool   `name:"use-indexed-attachment-ids" help:"Use 0-based indexes as attachment ids everywhere (output, the download argument, and saved filenames)" env:"GOG_GMAIL_USE_INDEXED_ATTACHMENT_IDS"`
 	Download                bool   `name:"download" help:"Download draft attachments"`
 }
@@ -115,6 +116,16 @@ func (c *GmailDraftsGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	attachDir := ""
+	format := strings.TrimSpace(c.Format)
+	if format == "" {
+		format = gmailFormatFull
+	}
+	if format != gmailFormatFull && format != gmailFormatRaw {
+		return usagef("invalid --format: %q (expected full|raw)", format)
+	}
+	if format == gmailFormatRaw && (c.Download || c.UseIndexedAttachmentIDs) {
+		return usage("--format raw cannot be combined with --download or --use-indexed-attachment-ids")
+	}
 	if c.Download {
 		layout, err := commandLayout(ctx, config.PathKindConfig)
 		if err != nil {
@@ -131,7 +142,7 @@ func (c *GmailDraftsGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return err
 	}
 
-	draft, err := svc.Users.Drafts.Get("me", draftID).Format("full").Do()
+	draft, err := svc.Users.Drafts.Get("me", draftID).Format(format).Context(ctx).Do()
 	if err != nil {
 		return err
 	}
@@ -144,6 +155,21 @@ func (c *GmailDraftsGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	msg := draft.Message
+	if format == gmailFormatRaw {
+		if outfmt.IsJSON(ctx) {
+			return outfmt.WriteJSON(ctx, stdoutWriter(ctx), map[string]any{"draft": draft})
+		}
+		decoded, decodeErr := decodeGmailRaw(msg.Raw)
+		if decodeErr != nil {
+			return decodeErr
+		}
+		if opts, wrap := outfmt.UntrustedWrapperFromContext(ctx); wrap {
+			_, err = fmt.Fprint(stdoutWriter(ctx), outfmt.WrapUntrustedContent(string(decoded), opts))
+		} else {
+			_, err = stdoutWriter(ctx).Write(decoded)
+		}
+		return err
+	}
 	attachments := collectAttachments(msg.Payload)
 	if msg.Id == "" || len(attachments) == 0 {
 		attachDir = ""
@@ -269,6 +295,7 @@ func (c *GmailDraftsSendCmd) Run(ctx context.Context, flags *RootFlags) error {
 }
 
 type GmailDraftsCreateCmd struct {
+	RawFile                string   `name:"raw-file" help:"Create a draft from an exact RFC822 message file, or '-' for stdin (cannot be combined with compose flags)"`
 	To                     string   `name:"to" help:"Recipients (comma-separated)"`
 	Cc                     string   `name:"cc" help:"CC recipients (comma-separated)"`
 	Bcc                    string   `name:"bcc" help:"BCC recipients (comma-separated)"`
@@ -278,7 +305,7 @@ type GmailDraftsCreateCmd struct {
 	BodyHTML               string   `name:"body-html" help:"Body (HTML; optional)"`
 	BodyHTMLFile           string   `name:"body-html-file" help:"HTML body file path ('-' for stdin)"`
 	ReplyToMessageID       string   `name:"reply-to-message-id" help:"Reply to Gmail message ID (sets In-Reply-To/References and thread)"`
-	ThreadID               string   `name:"thread-id" help:"Reply within a Gmail thread (uses latest message for headers)"`
+	ThreadID               string   `name:"thread-id" help:"Reply within a Gmail thread (uses latest message for headers; raw mode sets only the thread ID)"`
 	ReplyAll               bool     `name:"reply-all" help:"Auto-populate recipients from original message (requires --reply-to-message-id or --thread-id)"`
 	ReplyTo                string   `name:"reply-to" help:"Reply-To header address"`
 	Quote                  bool     `name:"quote" help:"Include quoted original message in reply (requires --reply-to-message-id or --thread-id)"`
@@ -722,6 +749,12 @@ func messageFromMatchesAccount(msg *gmail.Message, account string) bool {
 }
 
 func (c *GmailDraftsCreateCmd) Run(ctx context.Context, flags *RootFlags) error {
+	if strings.TrimSpace(c.RawFile) != "" {
+		if conflict := c.rawModeConflict(); conflict != "" {
+			return usagef("--raw-file cannot be combined with %s", conflict)
+		}
+		return runRawGmailDraft(ctx, flags, c.RawFile, c.ThreadID, "")
+	}
 	u := ui.FromContext(ctx)
 
 	body, htmlBody, err := resolveComposeBodyInputs(ctx, c.Body, c.BodyFile, c.BodyHTML, c.BodyHTMLFile)
@@ -809,6 +842,7 @@ func (c *GmailDraftsCreateCmd) Run(ctx context.Context, flags *RootFlags) error 
 
 type GmailDraftsUpdateCmd struct {
 	DraftID          string   `arg:"" name:"draftId" help:"Draft ID"`
+	RawFile          string   `name:"raw-file" help:"Replace the entire draft with an exact RFC822 message file, or '-' for stdin (cannot be combined with compose flags)"`
 	To               *string  `name:"to" help:"Recipients (comma-separated; omit to keep existing)"`
 	Cc               string   `name:"cc" help:"CC recipients (comma-separated)"`
 	Bcc              string   `name:"bcc" help:"BCC recipients (comma-separated)"`
@@ -818,7 +852,7 @@ type GmailDraftsUpdateCmd struct {
 	BodyHTML         string   `name:"body-html" help:"Body (HTML; optional)"`
 	BodyHTMLFile     string   `name:"body-html-file" help:"HTML body file path ('-' for stdin)"`
 	ReplyToMessageID string   `name:"reply-to-message-id" help:"Reply to Gmail message ID (sets In-Reply-To/References and thread)"`
-	ThreadID         string   `name:"thread-id" help:"Reply within a Gmail thread (uses latest message for headers); overrides the draft's existing thread"`
+	ThreadID         string   `name:"thread-id" help:"Reply within a Gmail thread (raw mode sets only the thread ID); overrides the draft's existing thread"`
 	ReplyAll         bool     `name:"reply-all" help:"Auto-populate recipients from original message (requires --reply-to-message-id or --thread-id)"`
 	ReplyTo          string   `name:"reply-to" help:"Reply-To header address"`
 	Quote            bool     `name:"quote" help:"Include quoted original message in reply"`
@@ -831,12 +865,18 @@ type GmailDraftsUpdateCmd struct {
 }
 
 func (c *GmailDraftsUpdateCmd) Run(ctx context.Context, flags *RootFlags) error {
+	if strings.TrimSpace(c.RawFile) != "" {
+		return c.runRaw(ctx, flags)
+	}
+	return c.runCompose(ctx, flags)
+}
+
+func (c *GmailDraftsUpdateCmd) runCompose(ctx context.Context, flags *RootFlags) error {
 	u := ui.FromContext(ctx)
 	draftID := strings.TrimSpace(c.DraftID)
 	if draftID == "" {
 		return usage("empty draftId")
 	}
-
 	to := ""
 	toWasSet := false
 	if c.To != nil {

--- a/internal/cmd/gmail_drafts_raw.go
+++ b/internal/cmd/gmail_drafts_raw.go
@@ -1,0 +1,135 @@
+package cmd
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"strings"
+
+	"github.com/alecthomas/kong"
+	"google.golang.org/api/gmail/v1"
+
+	"github.com/openclaw/gogcli/internal/googleapi"
+	"github.com/openclaw/gogcli/internal/ui"
+)
+
+func (c *GmailDraftsCreateCmd) AfterApply(kctx *kong.Context) error {
+	return validateRawDraftFlagPresence(kctx, c.RawFile)
+}
+
+func (c *GmailDraftsUpdateCmd) AfterApply(kctx *kong.Context) error {
+	return validateRawDraftFlagPresence(kctx, c.RawFile)
+}
+
+// Reject even explicitly empty compose inputs. Boolean false is allowed so a
+// caller can disable automatic alias selection inherited from the environment.
+func validateRawDraftFlagPresence(kctx *kong.Context, source string) error {
+	if strings.TrimSpace(source) == "" {
+		if flagProvided(kctx, "raw-file") {
+			return usage("--raw-file requires a file path or '-' for stdin")
+		}
+		return nil
+	}
+	for _, flag := range []string{
+		"to", "cc", "bcc", "subject", "body", "body-file", "body-html", "body-html-file",
+		"attach", "from", "reply-to", "reply-to-message-id",
+	} {
+		if flagProvided(kctx, flag) {
+			return usagef("--raw-file cannot be combined with --%s", flag)
+		}
+	}
+	return nil
+}
+
+func (c *GmailDraftsCreateCmd) rawModeConflict() string {
+	if c.AutoFromAddressedAlias {
+		return "--auto-from-addressed-alias"
+	}
+	compose := GmailSendCmd{
+		To: c.To, Cc: c.Cc, Bcc: c.Bcc, Subject: c.Subject,
+		Body: c.Body, BodyFile: c.BodyFile, BodyHTML: c.BodyHTML, BodyHTMLFile: c.BodyHTMLFile,
+		ReplyToMessageID: c.ReplyToMessageID, ReplyAll: c.ReplyAll, ReplyTo: c.ReplyTo,
+		Attach: c.Attach, From: c.From, Quote: c.Quote,
+	}
+	return compose.rawModeConflict()
+}
+
+func (c *GmailDraftsUpdateCmd) rawModeConflict() string {
+	if c.To != nil {
+		return "--to"
+	}
+	if c.ClearAttachments {
+		return "--clear-attachments"
+	}
+	if c.ClearReplyContext {
+		return "--clear-reply-context"
+	}
+	compose := GmailDraftsCreateCmd{
+		Cc: c.Cc, Bcc: c.Bcc, Subject: c.Subject,
+		Body: c.Body, BodyFile: c.BodyFile, BodyHTML: c.BodyHTML, BodyHTMLFile: c.BodyHTMLFile,
+		ReplyToMessageID: c.ReplyToMessageID, ReplyAll: c.ReplyAll, ReplyTo: c.ReplyTo,
+		Attach: c.Attach, From: c.From, Quote: c.Quote, AutoFromAddressedAlias: c.AutoFromAddressedAlias,
+	}
+	return compose.rawModeConflict()
+}
+
+func (c *GmailDraftsUpdateCmd) runRaw(ctx context.Context, flags *RootFlags) error {
+	draftID := strings.TrimSpace(c.DraftID)
+	if draftID == "" {
+		return usage("empty draftId")
+	}
+	if conflict := c.rawModeConflict(); conflict != "" {
+		return usagef("--raw-file cannot be combined with %s", conflict)
+	}
+	return runRawGmailDraft(ctx, flags, c.RawFile, c.ThreadID, draftID)
+}
+
+func runRawGmailDraft(ctx context.Context, flags *RootFlags, source, threadID, draftID string) error {
+	raw, plan, err := readRawGmailInput(ctx, source, threadID, false)
+	if err != nil {
+		return err
+	}
+	op := "gmail.drafts.create"
+	if draftID != "" {
+		op = "gmail.drafts.update"
+	}
+	request := struct {
+		gmailRawMessagePlan
+		DraftID string `json:"draft_id,omitempty"`
+	}{plan, draftID}
+	if dryRunErr := dryRunExit(ctx, flags, op, request); dryRunErr != nil {
+		return dryRunErr
+	}
+	if googleapi.ReadOnly(ctx) {
+		return fmt.Errorf("%w: Gmail draft mutations are disabled", googleapi.ErrReadOnly)
+	}
+	// Deliberately not requireGmailSendService: staging a draft is permitted
+	// under global and per-account no-send policies.
+	account, svc, err := requireGmailService(ctx, flags)
+	if err != nil {
+		return err
+	}
+	if senderErr := validateRawGmailSender(ctx, svc, account, plan); senderErr != nil {
+		return senderErr
+	}
+	input := &gmail.Draft{Message: &gmail.Message{
+		Raw: base64.RawURLEncoding.EncodeToString(raw), ThreadId: plan.ThreadID,
+	}}
+	var draft *gmail.Draft
+	if draftID == "" {
+		draft, err = svc.Users.Drafts.Create("me", input).Context(ctx).Do()
+	} else {
+		// Raw update is a complete replacement. Do not fetch or merge the old
+		// draft's recipients, attachments, thread, or reply headers.
+		draft, err = svc.Users.Drafts.Update("me", draftID, input).Context(ctx).Do()
+	}
+	if err != nil {
+		return err
+	}
+	threading := draftThreading{InReplyTo: plan.inReplyTo, References: plan.references}
+	if strings.TrimSpace(plan.inReplyTo) != "" || strings.TrimSpace(plan.references) != "" {
+		threading.Source = replyContextCaller
+	}
+	// Report the API's actual thread, which can differ from the requested one.
+	return writeDraftResult(ctx, ui.FromContext(ctx), draft, threading, nil)
+}

--- a/internal/cmd/gmail_drafts_raw_test.go
+++ b/internal/cmd/gmail_drafts_raw_test.go
@@ -1,0 +1,506 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/gmail/v1"
+
+	"github.com/openclaw/gogcli/internal/app"
+	"github.com/openclaw/gogcli/internal/config"
+	"github.com/openclaw/gogcli/internal/googleapi"
+)
+
+// Both alternatives, a custom display name, folded reply headers, and a CID
+// image must survive without MIME reconstruction or header normalization.
+const testRawDraftEML = "From: Tom from InpaintKit <owner@example.com>\r\n" +
+	"To: Recipient <recipient@example.com>\r\n" +
+	"Subject: Review this image\r\n" +
+	"Message-ID: <review@example.com>\r\n" +
+	"In-Reply-To: <parent@example.com>\r\n" +
+	"References: <first@example.com>\r\n\t<parent@example.com>\r\n" +
+	"MIME-Version: 1.0\r\n" +
+	"Content-Type: multipart/related; boundary=related\r\n\r\n" +
+	"--related\r\nContent-Type: multipart/alternative; boundary=alternative\r\n\r\n" +
+	"--alternative\r\nContent-Type: text/plain; charset=utf-8\r\n\r\nSee the image.\r\n" +
+	"--alternative\r\nContent-Type: text/html; charset=utf-8\r\n\r\n" +
+	"<p>See the image.</p><img src=\"cid:demo@example.com\">\r\n" +
+	"--alternative--\r\n" +
+	"--related\r\nContent-Type: image/png\r\nContent-ID: <demo@example.com>\r\n" +
+	"Content-Disposition: inline; filename=demo.png\r\nContent-Transfer-Encoding: base64\r\n\r\n" +
+	"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+jRZkAAAAASUVORK5CYII=\r\n" +
+	"--related--\r\n\r\n"
+
+func rawDraftArgs(operation, source string) []string {
+	args := []string{"gmail", "drafts", operation}
+	if operation == "update" {
+		args = append(args, "draft-1")
+	}
+	return append(args, "--raw-file", source)
+}
+
+func writeRawDraftFixture(t *testing.T, input string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "message.eml")
+	if err := os.WriteFile(path, []byte(input), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestGmailDraftsRawPreservesMIMEAndSafety(t *testing.T) {
+	for _, operation := range []string{"create", "update"} {
+		for _, stdin := range []bool{false, true} {
+			for _, jsonMode := range []bool{false, true} {
+				t.Run(fmt.Sprintf("%s/stdin=%v/json=%v", operation, stdin, jsonMode), func(t *testing.T) {
+					calls := 0
+					svc, cleanup := newGmailServiceForTest(t, func(w http.ResponseWriter, r *http.Request) {
+						calls++
+						wantMethod, wantPath := http.MethodPost, "/gmail/v1/users/me/drafts"
+						if operation == "update" {
+							wantMethod, wantPath = http.MethodPut, wantPath+"/draft-1"
+						}
+						if r.Method != wantMethod || r.URL.Path != wantPath {
+							t.Errorf("unexpected API request: %s %s", r.Method, r.URL.Path)
+							http.Error(w, "unexpected request", http.StatusBadRequest)
+							return
+						}
+						var posted gmail.Draft
+						if err := json.NewDecoder(r.Body).Decode(&posted); err != nil || posted.Message == nil {
+							t.Errorf("decode draft: %v", err)
+							return
+						}
+						decoded, err := base64.RawURLEncoding.DecodeString(posted.Message.Raw)
+						if err != nil || string(decoded) != testRawDraftEML {
+							t.Errorf("MIME bytes changed: %v", err)
+						}
+						if posted.Message.ThreadId != "18abcdef123" {
+							t.Errorf("thread = %q", posted.Message.ThreadId)
+						}
+						_ = json.NewEncoder(w).Encode(&gmail.Draft{Id: "draft-1", Message: &gmail.Message{
+							Id: "replacement-message", ThreadId: "actual-thread",
+						}})
+					})
+					defer cleanup()
+					source := "-"
+					if !stdin {
+						source = writeRawDraftFixture(t, testRawDraftEML)
+					}
+					store := config.NewConfigStore(config.Layout{ConfigDir: t.TempDir()})
+					if err := store.Write(config.File{GmailNoSend: true, NoSendAccounts: map[string]bool{"owner@example.com": true}}); err != nil {
+						t.Fatal(err)
+					}
+					args := append(rawDraftArgs(operation, source),
+						"--account", "owner@example.com", "--no-input", "--gmail-no-send",
+						"--enable-commands-exact=gmail.drafts."+operation,
+						"--thread-id", "https://mail.google.com/mail/u/0/#inbox/18abcdef123")
+					if jsonMode {
+						args = append(args, "--json", "--results-only")
+					}
+					var out, diagnostics bytes.Buffer
+					err := executeWithRuntime(args, &app.Runtime{
+						Config: store, KeyringOptions: testKeyringOptions(),
+						IO:       app.IO{In: strings.NewReader(testRawDraftEML), Out: &out, Err: &diagnostics},
+						Services: app.Services{Gmail: func(context.Context, string) (*gmail.Service, error) { return svc, nil }},
+					})
+					if err != nil || calls != 1 {
+						t.Fatalf("draft: err=%v calls=%d stderr=%s", err, calls, diagnostics.String())
+					}
+					if jsonMode {
+						var got map[string]any
+						if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+							t.Fatal(err)
+						}
+						message, ok := got["message"].(map[string]any)
+						if !ok || message["id"] != "replacement-message" || got["draftId"] != "draft-1" ||
+							got["threadId"] != "actual-thread" || got["inReplyTo"] != "<parent@example.com>" ||
+							got["references"] != "<first@example.com> <parent@example.com>" || got["replyContextSource"] != "caller" || len(got) != 6 {
+							t.Fatalf("wrong draft output contract: %s", out.String())
+						}
+					} else {
+						for _, line := range []string{"draft_id\tdraft-1", "message_id\treplacement-message", "thread_id\tactual-thread"} {
+							if !strings.Contains(out.String(), line) {
+								t.Fatalf("missing %q in %s", line, out.String())
+							}
+						}
+					}
+				})
+			}
+		}
+	}
+}
+
+func TestGmailDraftsRawDryRunIsOfflineAndContentSafe(t *testing.T) {
+	path := writeRawDraftFixture(t, testRawDraftEML)
+	for _, operation := range []string{"create", "update"} {
+		t.Run(operation, func(t *testing.T) {
+			args := append(rawDraftArgs(operation, path), "--dry-run", "--json", "--readonly", "--gmail-no-send", "--thread-id", "thread-1")
+			result := executeWithTestRuntime(t, args, &app.Runtime{Services: app.Services{
+				Gmail: func(context.Context, string) (*gmail.Service, error) {
+					t.Fatal("dry-run must not authenticate")
+					return nil, errors.New("unexpected authentication")
+				},
+			}})
+			if result.err != nil {
+				t.Fatal(result.err)
+			}
+			var got struct {
+				Op      string         `json:"op"`
+				Request map[string]any `json:"request"`
+			}
+			if err := json.Unmarshal([]byte(result.stdout), &got); err != nil {
+				t.Fatal(err)
+			}
+			if got.Op != "gmail.drafts."+operation || got.Request["source"] != path ||
+				got.Request["sha256"] != fmt.Sprintf("%x", sha256.Sum256([]byte(testRawDraftEML))) ||
+				got.Request["bytes"] != float64(len(testRawDraftEML)) || got.Request["thread_id"] != "thread-1" {
+				t.Fatalf("unexpected plan: %s", result.stdout)
+			}
+			wantFields := 4
+			if operation == "update" {
+				wantFields++
+				if got.Request["draft_id"] != "draft-1" {
+					t.Fatalf("missing update target: %s", result.stdout)
+				}
+			}
+			if len(got.Request) != wantFields {
+				t.Fatalf("extra dry-run fields: %s", result.stdout)
+			}
+			for _, secret := range []string{"owner@example.com", "Review this image", "demo.png", "parent@example.com", "iVBOR"} {
+				if strings.Contains(result.stdout+result.stderr, secret) {
+					t.Fatalf("dry-run leaked %q", secret)
+				}
+			}
+		})
+	}
+}
+
+func TestGmailDraftsRawRejectsComposeFlags(t *testing.T) {
+	common := [][]string{
+		{"--to", "r@example.com"},
+		{"--to="},
+		{"--cc", "r@example.com"},
+		{"--bcc", "r@example.com"},
+		{"--subject", "s"},
+		{"--subject="},
+		{"--body", "b"},
+		{"--body="},
+		{"--body-file", "-"},
+		{"--body-html", "<p>b</p>"},
+		{"--body-html-file", "-"},
+		{"--attach", "not-a-file"},
+		{"--from", "a@example.com"},
+		{"--reply-to", "a@example.com"},
+		{"--reply-to-message-id", "m"},
+		{"--reply-all"},
+		{"--quote"},
+		{"--auto-from-addressed-alias"},
+	}
+	for _, operation := range []string{"create", "update"} {
+		cases := append([][]string(nil), common...)
+		if operation == "update" {
+			cases = append(cases, []string{"--clear-attachments"}, []string{"--clear-reply-context"})
+		}
+		for _, flags := range cases {
+			t.Run(operation+"/"+strings.Join(flags, " "), func(t *testing.T) {
+				// Neither the missing raw file nor compose stdin should be read.
+				args := append(rawDraftArgs(operation, "does-not-exist.eml"), "--dry-run")
+				result := executeWithTestRuntime(t, append(args, flags...), &app.Runtime{})
+				if result.err == nil || !strings.Contains(result.err.Error(), "cannot be combined") {
+					t.Fatalf("conflict: %v", result.err)
+				}
+			})
+		}
+	}
+}
+
+func TestGmailDraftsRawInvalidBeforeAuth(t *testing.T) {
+	inputs := map[string]string{
+		"empty": "", "malformed": "not a header\r\n\r\nbody", "no separator": "From: a@example.com\r\n",
+		"missing from":   "To: a@example.com\r\n\r\nbody",
+		"duplicate from": "From: a@example.com\r\nFrom: b@example.com\r\n\r\nbody",
+		"invalid from":   "From: invalid\r\n\r\nbody", "invalid recipient": "From: a@example.com\r\nTo: invalid\r\n\r\nbody",
+	}
+	for _, operation := range []string{"create", "update"} {
+		for name, input := range inputs {
+			t.Run(operation+"/"+name, func(t *testing.T) {
+				path := writeRawDraftFixture(t, input)
+				result := executeWithTestRuntime(t, rawDraftArgs(operation, path), &app.Runtime{})
+				if result.err == nil || !strings.Contains(result.err.Error(), "RFC822") {
+					t.Fatalf("invalid input: %v", result.err)
+				}
+			})
+		}
+		t.Run(operation+"/empty flag", func(t *testing.T) {
+			result := executeWithTestRuntime(t, rawDraftArgs(operation, ""), &app.Runtime{})
+			if result.err == nil || !strings.Contains(result.err.Error(), "--raw-file requires") {
+				t.Fatalf("empty flag: %v", result.err)
+			}
+		})
+	}
+}
+
+func TestGmailDraftsRawReadOnlyBeforeAuth(t *testing.T) {
+	path := writeRawDraftFixture(t, testRawDraftEML)
+	for _, operation := range []string{"create", "update"} {
+		args := append(rawDraftArgs(operation, path), "--readonly", "--account", "owner@example.com")
+		result := executeWithTestRuntime(t, args, &app.Runtime{Services: app.Services{
+			Gmail: func(context.Context, string) (*gmail.Service, error) {
+				t.Fatal("readonly must block before authentication")
+				return nil, errors.New("unexpected authentication")
+			},
+		}})
+		if !errors.Is(result.err, googleapi.ErrReadOnly) {
+			t.Fatalf("readonly: %v", result.err)
+		}
+	}
+}
+
+func TestGmailDraftsRawAllowsMissingRecipientsAndDoesNotMerge(t *testing.T) {
+	input := "From: Custom <owner@example.com>\r\n\r\nbody\r\n"
+	path := writeRawDraftFixture(t, input)
+	for _, operation := range []string{"create", "update"} {
+		t.Run(operation, func(t *testing.T) {
+			calls := 0
+			svc, cleanup := newGmailServiceForTest(t, func(w http.ResponseWriter, r *http.Request) {
+				calls++
+				if r.Method == http.MethodGet {
+					t.Error("must not fetch the existing draft or infer reply headers")
+				}
+				var posted gmail.Draft
+				if err := json.NewDecoder(r.Body).Decode(&posted); err != nil || posted.Message == nil {
+					t.Errorf("decode: %v", err)
+					return
+				}
+				raw, err := base64.RawURLEncoding.DecodeString(posted.Message.Raw)
+				if err != nil || string(raw) != input || posted.Message.ThreadId != "" {
+					t.Errorf("message unexpectedly modified: %v, %s", err, raw)
+				}
+				_ = json.NewEncoder(w).Encode(&gmail.Draft{Id: "draft-1", Message: &gmail.Message{Id: "message-2", ThreadId: "new-thread"}})
+			})
+			defer cleanup()
+			args := append(rawDraftArgs(operation, path), "--account", "owner@example.com", "--json")
+			result := executeWithGmailTestService(t, args, svc)
+			if result.err != nil || calls != 1 {
+				t.Fatalf("draft: %v calls=%d", result.err, calls)
+			}
+			var got map[string]any
+			if err := json.Unmarshal([]byte(result.stdout), &got); err != nil {
+				t.Fatal(err)
+			}
+			if got["inReplyTo"] != nil || got["references"] != nil || got["replyContextSource"] != nil {
+				t.Fatalf("unexpected reply context: %s", result.stdout)
+			}
+		})
+	}
+}
+
+func TestGmailDraftsRawSenderValidation(t *testing.T) {
+	path := writeRawDraftFixture(t, testRawDraftEML)
+	for _, operation := range []string{"create", "update"} {
+		for _, status := range []string{"accepted", "pending", "missing"} {
+			t.Run(operation+"/"+status, func(t *testing.T) {
+				writes := 0
+				svc, cleanup := newGmailServiceForTest(t, func(w http.ResponseWriter, r *http.Request) {
+					if r.URL.Path == "/gmail/v1/users/me/settings/sendAs" {
+						aliases := []*gmail.SendAs{}
+						if status != "missing" {
+							aliases = append(aliases, &gmail.SendAs{SendAsEmail: "owner@example.com", VerificationStatus: status, DisplayName: "Do not substitute"})
+						}
+						_ = json.NewEncoder(w).Encode(&gmail.ListSendAsResponse{SendAs: aliases})
+						return
+					}
+					writes++
+					var posted gmail.Draft
+					_ = json.NewDecoder(r.Body).Decode(&posted)
+					if posted.Message == nil || posted.Message.Raw != base64.RawURLEncoding.EncodeToString([]byte(testRawDraftEML)) {
+						t.Error("alias lookup changed the MIME")
+					}
+					_ = json.NewEncoder(w).Encode(&gmail.Draft{Id: "draft-1", Message: &gmail.Message{Id: "m1"}})
+				})
+				defer cleanup()
+				args := append(rawDraftArgs(operation, path), "--account", "another@example.com")
+				result := executeWithGmailTestService(t, args, svc)
+				if status == "accepted" {
+					if result.err != nil || writes != 1 {
+						t.Fatalf("verified alias: %v writes=%d", result.err, writes)
+					}
+				} else if result.err == nil || writes != 0 {
+					t.Fatalf("invalid alias: %v writes=%d", result.err, writes)
+				}
+			})
+		}
+	}
+}
+
+func TestGmailDraftsRawDirectTokenRequiresAccount(t *testing.T) {
+	path := writeRawDraftFixture(t, testRawDraftEML)
+	svc, cleanup := newGmailServiceForTest(t, func(http.ResponseWriter, *http.Request) {
+		t.Error("direct token without account must not call Gmail")
+	})
+	defer cleanup()
+	for _, operation := range []string{"create", "update"} {
+		args := append(rawDraftArgs(operation, path), "--access-token", "invalid-token")
+		result := executeWithGmailTestService(t, args, svc)
+		if result.err == nil || !strings.Contains(result.err.Error(), "explicit --account") {
+			t.Fatalf("direct token: %v", result.err)
+		}
+	}
+}
+
+func TestGmailDraftsRawSchema(t *testing.T) {
+	for _, operation := range []string{"create", "update"} {
+		doc := schemaForCommand(t, "gmail drafts "+operation)
+		flag := schemaFlagByName(t, doc.Command, "raw-file")
+		if flag.Type != "string" || !strings.Contains(flag.Help, "exact RFC822") {
+			t.Fatalf("raw-file schema: %#v", flag)
+		}
+	}
+	doc := schemaForCommand(t, "gmail drafts get")
+	flag := schemaFlagByName(t, doc.Command, "format")
+	if !strings.Contains(flag.Help, "full|raw") {
+		t.Fatalf("format schema: %#v", flag)
+	}
+}
+
+func TestGmailDraftsGetRaw(t *testing.T) {
+	for _, jsonMode := range []bool{false, true} {
+		t.Run(fmt.Sprintf("json=%v", jsonMode), func(t *testing.T) {
+			svc, cleanup := newGmailServiceForTest(t, func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodGet || r.URL.Path != "/gmail/v1/users/me/drafts/draft-1" || r.URL.Query().Get("format") != "raw" {
+					t.Errorf("unexpected raw get: %s %s", r.Method, r.URL)
+				}
+				_ = json.NewEncoder(w).Encode(&gmail.Draft{Id: "draft-1", Message: &gmail.Message{
+					Id: "m1", ThreadId: "thread-1", Raw: base64.URLEncoding.EncodeToString([]byte(testRawDraftEML)),
+				}})
+			})
+			defer cleanup()
+			args := []string{"--readonly", "--account", "owner@example.com", "gmail", "drafts", "get", "draft-1", "--format", "raw"}
+			if jsonMode {
+				args = append(args, "--json")
+			}
+			result := executeWithGmailTestService(t, args, svc)
+			if result.err != nil {
+				t.Fatal(result.err)
+			}
+			if jsonMode {
+				var got struct {
+					Draft gmail.Draft `json:"draft"`
+				}
+				if err := json.Unmarshal([]byte(result.stdout), &got); err != nil || got.Draft.Message == nil {
+					t.Fatalf("raw JSON: %v", err)
+				}
+				raw, err := decodeGmailRaw(got.Draft.Message.Raw)
+				if err != nil || string(raw) != testRawDraftEML || got.Draft.Id != "draft-1" {
+					t.Fatalf("raw JSON changed message: %v", err)
+				}
+			} else if result.stdout != testRawDraftEML {
+				t.Fatal("raw text output must contain only exact RFC822 bytes, including trailing newlines")
+			}
+		})
+	}
+}
+
+func TestGmailDraftsGetRawRejectsAttachmentFlags(t *testing.T) {
+	for _, flag := range []string{"--download", "--use-indexed-attachment-ids"} {
+		result := executeWithTestRuntime(t, []string{"gmail", "drafts", "get", "draft-1", "--format", "raw", flag}, &app.Runtime{})
+		if result.err == nil || !strings.Contains(result.err.Error(), "cannot be combined") {
+			t.Fatalf("raw get conflict: %v", result.err)
+		}
+	}
+}
+
+func TestGmailRawInputSizeBoundary(t *testing.T) {
+	header := "From: owner@example.com\r\nTo: recipient@example.com\r\n\r\n"
+	input := header + strings.Repeat("x", int(maxGmailRawMessageBytes)-len(header))
+	ctx := newCmdRuntimeIOContext(t, strings.NewReader(input), io.Discard, io.Discard)
+	raw, plan, err := readRawGmailInput(ctx, "-", "", false)
+	if err != nil || len(raw) != int(maxGmailRawMessageBytes) || plan.Bytes != len(raw) {
+		t.Fatalf("exact limit rejected: %v bytes=%d", err, len(raw))
+	}
+	input += "x"
+	path := writeRawDraftFixture(t, input)
+	for _, source := range []string{path, "-"} {
+		for _, operation := range []string{"create", "update", "send"} {
+			t.Run(operation+"/"+filepath.Base(source), func(t *testing.T) {
+				var out, diagnostics bytes.Buffer
+				args := rawDraftArgs(operation, source)
+				if operation == "send" {
+					args = []string{"gmail", "send", "--raw-file", source}
+				}
+				err := executeWithRuntime(args, &app.Runtime{KeyringOptions: testKeyringOptions(), IO: app.IO{
+					In: strings.NewReader(input), Out: &out, Err: &diagnostics,
+				}})
+				if err == nil || !strings.Contains(err.Error(), "exceeds maximum size of 36700160 bytes") {
+					t.Fatalf("oversize: %v", err)
+				}
+			})
+		}
+	}
+}
+
+func TestGmailRawInvalidDryRunDoesNotLeakContent(t *testing.T) {
+	secret := "PRIVATE_CONTENT_WITHOUT_COLON"
+	for _, operation := range []string{"create", "update", "send"} {
+		for _, input := range []string{
+			secret + "\r\n\r\nbody",
+			"From: " + secret + "\r\n\r\nbody",
+			"From: owner@example.com\r\nTo: " + secret + "\r\n\r\nbody",
+		} {
+			path := writeRawDraftFixture(t, input)
+			args := rawDraftArgs(operation, path)
+			if operation == "send" {
+				args = []string{"gmail", "send", "--raw-file", path}
+			}
+			result := executeWithTestRuntime(t, append(args, "--dry-run", "--json"), &app.Runtime{})
+			if result.err == nil || !strings.Contains(result.err.Error(), "RFC822") {
+				t.Fatalf("invalid preview: %v", result.err)
+			}
+			if strings.Contains(result.stdout+result.stderr+result.err.Error(), secret) {
+				t.Fatalf("%s leaked invalid message content", operation)
+			}
+		}
+	}
+}
+
+func TestGmailDraftsRawAutomaticAliasEnvironment(t *testing.T) {
+	t.Setenv("GOG_GMAIL_AUTO_FROM_ADDRESSED_ALIAS", "true")
+	path := writeRawDraftFixture(t, testRawDraftEML)
+	for _, operation := range []string{"create", "update"} {
+		args := append(rawDraftArgs(operation, path), "--dry-run", "--json")
+		result := executeWithTestRuntime(t, args, &app.Runtime{})
+		if result.err == nil || !strings.Contains(result.err.Error(), "--auto-from-addressed-alias") {
+			t.Fatalf("alias env should conflict: %v", result.err)
+		}
+		result = executeWithTestRuntime(t, append(args, "--auto-from-addressed-alias=false"), &app.Runtime{})
+		if result.err != nil {
+			t.Fatalf("explicit false should disable alias env: %v", result.err)
+		}
+	}
+}
+
+func TestGmailDraftsRawAPIFailureDoesNotReportSuccess(t *testing.T) {
+	path := writeRawDraftFixture(t, testRawDraftEML)
+	svc, cleanup := newGmailServiceForTest(t, func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "draft rejected", http.StatusBadRequest)
+	})
+	defer cleanup()
+	for _, operation := range []string{"create", "update"} {
+		args := append(rawDraftArgs(operation, path), "--account", "owner@example.com", "--json")
+		result := executeWithGmailTestService(t, args, svc)
+		if result.err == nil || result.stdout != "" {
+			t.Fatalf("API failure: err=%v stdout=%s", result.err, result.stdout)
+		}
+	}
+}

--- a/internal/cmd/gmail_import.go
+++ b/internal/cmd/gmail_import.go
@@ -113,23 +113,38 @@ func (c *GmailImportCmd) readAndPlan(ctx context.Context) ([]byte, gmailImportPl
 }
 
 func readRFC822Input(ctx context.Context, source string) ([]byte, *mail.Message, error) {
+	return readRFC822InputWithLimit(ctx, source, 0)
+}
+
+// A zero limit retains the import path's existing behavior. Raw send and draft
+// inputs use a bounded reader, including for stdin and non-regular files.
+func readRFC822InputWithLimit(ctx context.Context, source string, limit int64) ([]byte, *mail.Message, error) {
 	if source == "" {
 		return nil, nil, usage("RFC822/EML file is required")
 	}
 
-	var raw []byte
-	var err error
-	if source == "-" {
-		raw, err = io.ReadAll(stdinReader(ctx))
-	} else {
+	reader := stdinReader(ctx)
+	if source != "-" {
 		path, expandErr := config.ExpandPath(source)
 		if expandErr != nil {
 			return nil, nil, expandErr
 		}
-		raw, err = os.ReadFile(path) //nolint:gosec // user-provided RFC822 message path
+		file, err := os.Open(path) //nolint:gosec // user-provided RFC822 message path
+		if err != nil {
+			return nil, nil, err
+		}
+		defer file.Close()
+		reader = file
 	}
+	if limit > 0 {
+		reader = io.LimitReader(reader, limit+1)
+	}
+	raw, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, nil, err
+	}
+	if limit > 0 && int64(len(raw)) > limit {
+		return nil, nil, usagef("RFC822/EML input exceeds maximum size of %d bytes (35 MiB)", limit)
 	}
 	if len(raw) == 0 {
 		return nil, nil, usage("RFC822/EML input is empty")
@@ -137,7 +152,9 @@ func readRFC822Input(ctx context.Context, source string) ([]byte, *mail.Message,
 
 	message, err := mail.ReadMessage(bytes.NewReader(raw))
 	if err != nil {
-		return nil, nil, usagef("invalid RFC822/EML input: %v", err)
+		// Parser errors may quote entire header lines. Never expose message
+		// content through diagnostics, including failed offline previews.
+		return nil, nil, usage("invalid RFC822/EML input: malformed message headers")
 	}
 
 	return raw, message, nil

--- a/internal/cmd/gmail_raw_input.go
+++ b/internal/cmd/gmail_raw_input.go
@@ -1,0 +1,85 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"net/mail"
+	"strings"
+
+	"google.golang.org/api/gmail/v1"
+)
+
+// Gmail's discovery document limits draft and send media uploads to 35 MiB.
+const maxGmailRawMessageBytes int64 = 35 * 1024 * 1024
+
+// Only content-safe metadata is exported for offline dry runs.
+type gmailRawMessagePlan struct {
+	Source     string `json:"source"`
+	Bytes      int    `json:"bytes"`
+	SHA256     string `json:"sha256"`
+	ThreadID   string `json:"thread_id,omitempty"`
+	sender     *mail.Address
+	from       string
+	inReplyTo  string
+	references string
+}
+
+func readRawGmailInput(ctx context.Context, source, threadID string, requireRecipients bool) ([]byte, gmailRawMessagePlan, error) {
+	source = strings.TrimSpace(source)
+	raw, message, err := readRFC822InputWithLimit(ctx, source, maxGmailRawMessageBytes)
+	if err != nil {
+		return nil, gmailRawMessagePlan{}, err
+	}
+	if !bytes.Contains(raw, []byte("\r\n\r\n")) && !bytes.Contains(raw, []byte("\n\n")) {
+		return nil, gmailRawMessagePlan{}, usage("invalid RFC822 input: missing header/body separator")
+	}
+	fromHeaders := message.Header["From"]
+	if len(fromHeaders) == 0 || strings.TrimSpace(fromHeaders[0]) == "" {
+		return nil, gmailRawMessagePlan{}, usage("invalid RFC822 input: missing From header")
+	}
+	if len(fromHeaders) != 1 {
+		return nil, gmailRawMessagePlan{}, usage("invalid RFC822 input: exactly one From header is required")
+	}
+	sender, addressErr := mail.ParseAddress(fromHeaders[0])
+	if addressErr != nil {
+		return nil, gmailRawMessagePlan{}, usage("invalid RFC822 input: invalid From header")
+	}
+	if requireRecipients && strings.TrimSpace(message.Header.Get("To")) == "" && strings.TrimSpace(message.Header.Get("Cc")) == "" && strings.TrimSpace(message.Header.Get("Bcc")) == "" {
+		return nil, gmailRawMessagePlan{}, usage("invalid RFC822 input: missing recipient header")
+	}
+	for _, header := range []string{"To", "Cc", "Bcc"} {
+		for _, value := range message.Header[header] {
+			if strings.TrimSpace(value) == "" {
+				continue
+			}
+			if _, addressErr := mail.ParseAddressList(value); addressErr != nil {
+				return nil, gmailRawMessagePlan{}, usagef("invalid RFC822 input: invalid %s header", header)
+			}
+		}
+	}
+	threadID = normalizeGmailThreadID(threadID)
+	if strings.ContainsAny(threadID, " \t\r\n") {
+		return nil, gmailRawMessagePlan{}, usage("invalid --thread-id")
+	}
+	digest := sha256.Sum256(raw)
+	return raw, gmailRawMessagePlan{
+		Source: source, Bytes: len(raw), SHA256: fmt.Sprintf("%x", digest), ThreadID: threadID,
+		sender: sender, from: fromHeaders[0],
+		inReplyTo: message.Header.Get("In-Reply-To"), references: message.Header.Get("References"),
+	}, nil
+}
+
+// Validate the address without replacing the caller's display name or headers.
+// No-send policy belongs to the send command, not to sender validation.
+func validateRawGmailSender(ctx context.Context, svc *gmail.Service, account string, plan gmailRawMessagePlan) error {
+	if account == accessTokenPlaceholderAccount || account == adcPlaceholderAccount {
+		return usage("--raw-file requires an explicit --account with direct access tokens or ADC")
+	}
+	if !strings.EqualFold(account, plan.sender.Address) {
+		_, err := resolveComposeSender(ctx, svc, account, plan.sender.Address)
+		return err
+	}
+	return nil
+}

--- a/internal/cmd/gmail_send.go
+++ b/internal/cmd/gmail_send.go
@@ -1,13 +1,10 @@
 package cmd
 
 import (
-	"bytes"
 	"context"
-	"crypto/sha256"
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"net/mail"
 	"os"
 	"strings"
 
@@ -246,20 +243,11 @@ func (c *GmailSendCmd) Run(ctx context.Context, flags *RootFlags) error {
 	return writeSendResults(ctx, u, from.header, results, attachmentMetadata)
 }
 
-type gmailRawSendPlan struct {
-	Source   string `json:"source"`
-	Bytes    int    `json:"bytes"`
-	SHA256   string `json:"sha256"`
-	ThreadID string `json:"thread_id,omitempty"`
-	sender   *mail.Address
-	from     string
-}
-
 func (c *GmailSendCmd) runRaw(ctx context.Context, flags *RootFlags) error {
 	if conflict := c.rawModeConflict(); conflict != "" {
 		return usagef("--raw-file cannot be combined with %s", conflict)
 	}
-	raw, plan, err := readRawSendInput(ctx, c.RawFile, c.ThreadID)
+	raw, plan, err := readRawGmailInput(ctx, c.RawFile, c.ThreadID, true)
 	if err != nil {
 		return err
 	}
@@ -276,13 +264,8 @@ func (c *GmailSendCmd) runRaw(ctx context.Context, flags *RootFlags) error {
 	if err != nil {
 		return err
 	}
-	if account == accessTokenPlaceholderAccount || account == adcPlaceholderAccount {
-		return usage("--raw-file requires an explicit --account with direct access tokens or ADC")
-	}
-	if !strings.EqualFold(account, plan.sender.Address) {
-		if _, senderErr := resolveComposeSender(ctx, svc, account, plan.sender.Address); senderErr != nil {
-			return senderErr
-		}
+	if senderErr := validateRawGmailSender(ctx, svc, account, plan); senderErr != nil {
+		return senderErr
 	}
 	message := &gmail.Message{Raw: base64.RawURLEncoding.EncodeToString(raw), ThreadId: plan.ThreadID}
 	sent, err := svc.Users.Messages.Send("me", message).Context(ctx).Do()
@@ -326,49 +309,6 @@ func (c *GmailSendCmd) rawModeConflict() string {
 		}
 	}
 	return ""
-}
-
-func readRawSendInput(ctx context.Context, source, threadID string) ([]byte, gmailRawSendPlan, error) {
-	source = strings.TrimSpace(source)
-	raw, message, err := readRFC822Input(ctx, source)
-	if err != nil {
-		return nil, gmailRawSendPlan{}, err
-	}
-	if !bytes.Contains(raw, []byte("\r\n\r\n")) && !bytes.Contains(raw, []byte("\n\n")) {
-		return nil, gmailRawSendPlan{}, usage("invalid RFC822 input: missing header/body separator")
-	}
-	fromHeaders := message.Header["From"]
-	if len(fromHeaders) == 0 || strings.TrimSpace(fromHeaders[0]) == "" {
-		return nil, gmailRawSendPlan{}, usage("invalid RFC822 input: missing From header")
-	}
-	if len(fromHeaders) != 1 {
-		return nil, gmailRawSendPlan{}, usage("invalid RFC822 input: exactly one From header is required")
-	}
-	sender, addressErr := mail.ParseAddress(fromHeaders[0])
-	if addressErr != nil {
-		return nil, gmailRawSendPlan{}, usagef("invalid RFC822 input: invalid From header: %v", addressErr)
-	}
-	if strings.TrimSpace(message.Header.Get("To")) == "" && strings.TrimSpace(message.Header.Get("Cc")) == "" && strings.TrimSpace(message.Header.Get("Bcc")) == "" {
-		return nil, gmailRawSendPlan{}, usage("invalid RFC822 input: missing recipient header")
-	}
-	for _, header := range []string{"To", "Cc", "Bcc"} {
-		value := strings.TrimSpace(message.Header.Get(header))
-		if value == "" {
-			continue
-		}
-		if _, addressErr := mail.ParseAddressList(value); addressErr != nil {
-			return nil, gmailRawSendPlan{}, usagef("invalid RFC822 input: invalid %s header: %v", header, addressErr)
-		}
-	}
-	threadID = normalizeGmailThreadID(threadID)
-	if strings.ContainsAny(threadID, " \t\r\n") {
-		return nil, gmailRawSendPlan{}, usage("invalid --thread-id")
-	}
-	digest := sha256.Sum256(raw)
-	return raw, gmailRawSendPlan{
-		Source: source, Bytes: len(raw), SHA256: fmt.Sprintf("%x", digest), ThreadID: threadID,
-		sender: sender, from: fromHeaders[0],
-	}, nil
 }
 
 func (c *GmailSendCmd) resolveTrackingConfig(ctx context.Context, account string, toRecipients, ccRecipients, bccRecipients []string, htmlBody string) (*tracking.Config, error) {


### PR DESCRIPTION
Stage a prebuilt RFC822 message with `gmail drafts create/update --raw-file PATH|-`, then retrieve the stored MIME with `gmail drafts get --format raw`. Draft creation permits absent recipients; raw update replaces the whole message and never merges old recipients, attachments or reply state. Caller MIME bytes are submitted unchanged, with sender and recipient-header validation shared with raw send.

No-send policies continue to permit draft staging. Read-only mode blocks writes before authentication; offline dry-runs expose only source, byte count, SHA-256 and IDs. Raw send and drafts use a bounded 35 MiB reader, including stdin; import retains its existing input contract. Text retrieval emits decoded RFC822 without an added newline, while JSON retains the draft envelope. Compose conflicts, sender aliases, direct-token account selection, input bounds and safe diagnostics have regression coverage.

The contributor's implementation was brought onto current main, retaining the concise architecture guide and updating the current changelog. Human credit: Tuyen <hxtxmu@gmail.com> (@darkamenosa).

Validation: full `make ci`, generated command references, and isolated Codex review through P2. A signed compiled CLI created a recipient-free multipart draft in an existing authorized Google account, verified its custom display name, alternatives and CID bytes, compared plain raw output with decoded JSON, replaced it through stdin, and verified stable draft ID/new message ID with old attachment and reply state absent. The draft was deleted. No messages were sent; every operation used `--gmail-no-send`. Gmail may normalize stored MIME; exact upload bytes are verified by request-level regressions. This does not claim to fix Gmail web-send wrapping in #1058.
