### PR TITLE
refactor(auth): remove obsolete forwarding helpers

### DIFF
--- a/internal/googleauth/accounts_manager.go
+++ b/internal/googleauth/accounts_manager.go
@@ -2,7 +2,6 @@ package googleauth
 
 import (
 	"context"
-	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
@@ -658,28 +657,6 @@ func FetchUserIdentity(ctx context.Context, tok *oauth2.Token) (Identity, error)
 	return fetchUserIdentityWithURL(ctx, tok.AccessToken, userinfoURL)
 }
 
-func fetchUserEmailDefault(ctx context.Context, tok *oauth2.Token) (string, error) {
-	identity, err := FetchUserIdentity(ctx, tok)
-	if err != nil {
-		return "", err
-	}
-
-	return identity.Email, nil
-}
-
-// fetchUserEmailWithURL retrieves the user's email from the specified userinfo URL.
-// This is separated for testability.
-//
-//nolint:unparam // retained for email-only tests and package callers.
-func fetchUserEmailWithURL(ctx context.Context, accessToken string, url string) (string, error) {
-	identity, err := fetchUserIdentityWithURL(ctx, accessToken, url)
-	if err != nil {
-		return "", err
-	}
-
-	return identity.Email, nil
-}
-
 func fetchUserIdentityWithURL(ctx context.Context, accessToken string, url string) (Identity, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
@@ -726,15 +703,6 @@ func fetchUserIdentityWithURL(ctx context.Context, accessToken string, url strin
 	}
 
 	return Identity{Subject: subject, Email: email}, nil
-}
-
-func emailFromIDToken(idToken string) (string, error) {
-	identity, err := IdentityFromIDToken(idToken)
-	if err != nil {
-		return "", err
-	}
-
-	return identity.Email, nil
 }
 
 func IdentityFromIDToken(idToken string) (Identity, error) {
@@ -784,10 +752,6 @@ func readHTTPBodySnippet(r io.Reader, limit int64) string {
 	return s
 }
 
-func generateCSRFToken() (string, error) {
-	return generateRandomHex(rand.Reader, 32)
-}
-
 func generateRandomHex(random io.Reader, size int) (string, error) {
 	b := make([]byte, size)
 	if _, err := io.ReadFull(random, b); err != nil {
@@ -815,21 +779,6 @@ func writeJSONError(w http.ResponseWriter, msg string, status int) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 	_ = json.NewEncoder(w).Encode(map[string]any{"error": msg})
-}
-
-// renderSuccessPageWithDetails renders the success template with email and services
-func renderSuccessPageWithDetails(w http.ResponseWriter, email string, services []string) {
-	renderSuccessPageWithDetailsAndCSRF(w, email, services, "")
-}
-
-func renderSuccessPageWithDetailsAndCSRF(w http.ResponseWriter, email string, services []string, csrfToken string) {
-	tmpl, err := template.New("success").Parse(successTemplate)
-	if err != nil {
-		_, _ = w.Write([]byte("Success! You can close this window."))
-		return
-	}
-
-	renderSuccessTemplate(w, tmpl, email, services, csrfToken)
 }
 
 func (app *ManagerApplication) renderSuccessPage(w http.ResponseWriter, email string, services []string) {

--- a/internal/googleauth/accounts_server_more_test.go
+++ b/internal/googleauth/accounts_server_more_test.go
@@ -52,12 +52,12 @@ func TestHandleAccountsPage(t *testing.T) {
 	}
 }
 
-func TestFetchUserEmailDefault(t *testing.T) {
-	if _, err := fetchUserEmailDefault(context.TODO(), nil); err == nil {
+func TestFetchUserIdentity_DefaultSource(t *testing.T) {
+	if _, err := FetchUserIdentity(context.TODO(), nil); err == nil {
 		t.Fatalf("expected missing token error")
 	}
 
-	if _, err := fetchUserEmailDefault(context.TODO(), &oauth2.Token{}); err == nil {
+	if _, err := FetchUserIdentity(context.TODO(), &oauth2.Token{}); err == nil {
 		t.Fatalf("expected missing access token error")
 	}
 
@@ -66,13 +66,13 @@ func TestFetchUserEmailDefault(t *testing.T) {
 	tok := &oauth2.Token{AccessToken: "access"}
 	tok = tok.WithExtra(map[string]any{"id_token": idToken})
 
-	email, err := fetchUserEmailDefault(context.TODO(), tok)
+	identity, err := FetchUserIdentity(context.TODO(), tok)
 	if err != nil {
-		t.Fatalf("fetchUserEmailDefault: %v", err)
+		t.Fatalf("FetchUserIdentity: %v", err)
 	}
 
-	if email != "a@b.com" {
-		t.Fatalf("unexpected email: %q", email)
+	if identity.Email != "a@b.com" {
+		t.Fatalf("unexpected email: %q", identity.Email)
 	}
 }
 
@@ -88,9 +88,9 @@ func TestReadHTTPBodySnippet(t *testing.T) {
 	}
 }
 
-func TestRenderSuccessPageWithDetails_More(t *testing.T) {
+func TestManagerRenderSuccessPage_Email(t *testing.T) {
 	rec := httptest.NewRecorder()
-	renderSuccessPageWithDetails(rec, "a@b.com", []string{"gmail"})
+	newTestManagerApplication(t, ManagerOptions{}, ManagerDependencies{}).renderSuccessPage(rec, "a@b.com", []string{"gmail"})
 
 	if !strings.Contains(rec.Body.String(), "a@b.com") {
 		t.Fatalf("expected email in success page")
@@ -224,7 +224,7 @@ func TestStartManageServerOpenStoreError(t *testing.T) {
 	}
 }
 
-func TestManageCredentialsReaderUsesContext(t *testing.T) {
+func TestReadOAuthClientCredentialsUsesContext(t *testing.T) {
 	origRead := readClientCredentials
 
 	t.Cleanup(func() { readClientCredentials = origRead })
@@ -238,7 +238,7 @@ func TestManageCredentialsReaderUsesContext(t *testing.T) {
 		return config.ClientCredentials{ClientID: "id", ClientSecret: "secret"}, nil
 	})
 
-	credentials, err := manageCredentialsReader(ctx, nil)("work")
+	credentials, err := readOAuthClientCredentials(ctx, "work")
 	if err != nil {
 		t.Fatalf("read credentials: %v", err)
 	}
@@ -250,12 +250,14 @@ func TestManageCredentialsReaderUsesContext(t *testing.T) {
 
 func TestManageCredentialsReaderPreservesOverride(t *testing.T) {
 	called := false
-	reader := manageCredentialsReader(context.Background(), func(client string) (config.ClientCredentials, error) {
-		called = true
-		return config.ClientCredentials{ClientID: client}, nil
+	app := newTestManagerApplication(t, ManagerOptions{}, ManagerDependencies{
+		ReadCredentials: func(client string) (config.ClientCredentials, error) {
+			called = true
+			return config.ClientCredentials{ClientID: client}, nil
+		},
 	})
 
-	credentials, err := reader("custom")
+	credentials, err := app.deps.ReadCredentials("custom")
 	if err != nil {
 		t.Fatalf("read credentials: %v", err)
 	}

--- a/internal/googleauth/accounts_server_test.go
+++ b/internal/googleauth/accounts_server_test.go
@@ -688,11 +688,9 @@ func TestManageServer_HandleListAccounts_Error(t *testing.T) {
 	}
 }
 
-func TestGenerateCSRFToken(t *testing.T) {
-	token, err := generateCSRFToken()
-	if err != nil {
-		t.Fatalf("generateCSRFToken: %v", err)
-	}
+func TestManagerCSRFToken(t *testing.T) {
+	app := newTestManagerApplication(t, ManagerOptions{}, ManagerDependencies{})
+	token := app.csrfToken
 
 	if len(token) != 64 {
 		t.Fatalf("unexpected token length: %d", len(token))
@@ -703,9 +701,9 @@ func TestGenerateCSRFToken(t *testing.T) {
 	}
 }
 
-func TestRenderSuccessPageWithDetails(t *testing.T) {
+func TestManagerRenderSuccessPage_Details(t *testing.T) {
 	rr := httptest.NewRecorder()
-	renderSuccessPageWithDetails(rr, "me@example.com", []string{"gmail", "drive"})
+	newTestManagerApplication(t, ManagerOptions{}, ManagerDependencies{}).renderSuccessPage(rr, "me@example.com", []string{"gmail", "drive"})
 
 	if body := rr.Body.String(); !strings.Contains(body, "me@example.com") {
 		t.Fatalf("expected email in body")
@@ -1184,7 +1182,7 @@ func TestManageServer_HandleOAuthCallback_Success_IDTokenEmail(t *testing.T) {
 	}
 }
 
-func TestFetchUserEmail(t *testing.T) {
+func TestFetchUserIdentity_Userinfo(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if auth := r.Header.Get("Authorization"); auth != "Bearer test-token" {
@@ -1196,13 +1194,13 @@ func TestFetchUserEmail(t *testing.T) {
 		}))
 		defer srv.Close()
 
-		email, err := fetchUserEmailWithURL(context.Background(), "test-token", srv.URL)
+		identity, err := fetchUserIdentityWithURL(context.Background(), "test-token", srv.URL)
 		if err != nil {
-			t.Fatalf("fetchUserEmail: %v", err)
+			t.Fatalf("fetchUserIdentity: %v", err)
 		}
 
-		if email != "user@test.com" {
-			t.Fatalf("expected user@test.com, got %q", email)
+		if identity.Email != "user@test.com" {
+			t.Fatalf("expected user@test.com, got %q", identity.Email)
 		}
 	})
 
@@ -1213,7 +1211,7 @@ func TestFetchUserEmail(t *testing.T) {
 		}))
 		defer srv.Close()
 
-		_, err := fetchUserEmailWithURL(context.Background(), "test-token", srv.URL)
+		_, err := fetchUserIdentityWithURL(context.Background(), "test-token", srv.URL)
 		if err == nil {
 			t.Fatal("expected error for empty email")
 		}
@@ -1229,7 +1227,7 @@ func TestFetchUserEmail(t *testing.T) {
 		}))
 		defer srv.Close()
 
-		_, err := fetchUserEmailWithURL(context.Background(), "test-token", srv.URL)
+		_, err := fetchUserIdentityWithURL(context.Background(), "test-token", srv.URL)
 		if err == nil {
 			t.Fatal("expected error for 401")
 		}
@@ -1246,29 +1244,20 @@ func TestFetchUserEmail(t *testing.T) {
 		}))
 		defer srv.Close()
 
-		_, err := fetchUserEmailWithURL(context.Background(), "test-token", srv.URL)
+		_, err := fetchUserIdentityWithURL(context.Background(), "test-token", srv.URL)
 		if err == nil {
 			t.Fatal("expected error for invalid json")
 		}
 	})
 }
 
-func TestEmailFromIDToken(t *testing.T) {
+func TestIdentityFromIDToken_Claims(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		idToken := strings.Join([]string{
 			base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none"}`)),
 			base64.RawURLEncoding.EncodeToString([]byte(`{"sub":"sub-123","email":"me@example.com"}`)),
 			"",
 		}, ".")
-
-		email, err := emailFromIDToken(idToken)
-		if err != nil {
-			t.Fatalf("emailFromIDToken: %v", err)
-		}
-
-		if email != "me@example.com" {
-			t.Fatalf("expected me@example.com, got %q", email)
-		}
 
 		identity, err := IdentityFromIDToken(idToken)
 		if err != nil {
@@ -1281,7 +1270,7 @@ func TestEmailFromIDToken(t *testing.T) {
 	})
 
 	t.Run("invalid token", func(t *testing.T) {
-		_, err := emailFromIDToken("nope")
+		_, err := IdentityFromIDToken("nope")
 		if err == nil {
 			t.Fatal("expected error")
 		}
@@ -1298,7 +1287,7 @@ func TestEmailFromIDToken(t *testing.T) {
 			"",
 		}, ".")
 
-		_, err := emailFromIDToken(idToken)
+		_, err := IdentityFromIDToken(idToken)
 		if err == nil {
 			t.Fatal("expected error")
 		}

--- a/internal/googleauth/oauth_flow.go
+++ b/internal/googleauth/oauth_flow.go
@@ -142,19 +142,6 @@ func readOAuthClientCredentials(ctx context.Context, client string) (config.Clie
 	return credentials, nil
 }
 
-func manageCredentialsReader(
-	ctx context.Context,
-	reader func(client string) (config.ClientCredentials, error),
-) func(client string) (config.ClientCredentials, error) {
-	if reader != nil {
-		return reader
-	}
-
-	return func(client string) (config.ClientCredentials, error) {
-		return readOAuthClientCredentials(ctx, client)
-	}
-}
-
 func newOAuthCallbackServer(handler http.Handler) *http.Server {
 	return &http.Server{
 		Handler:           handler,

--- a/internal/googleauth/oauth_flow_manual_redirect.go
+++ b/internal/googleauth/oauth_flow_manual_redirect.go
@@ -63,8 +63,3 @@ func parseRedirectURL(rawURL string) (code string, state string, redirectURI str
 
 	return code, state, redirectURI, nil
 }
-
-func extractCodeAndState(rawURL string) (code string, state string, err error) {
-	code, state, _, err = parseRedirectURL(rawURL)
-	return code, state, err
-}

--- a/internal/googleauth/service_test.go
+++ b/internal/googleauth/service_test.go
@@ -55,8 +55,8 @@ func TestParseService_Invalid(t *testing.T) {
 	}
 }
 
-func TestExtractCodeAndState(t *testing.T) {
-	code, state, err := extractCodeAndState("http://127.0.0.1:55555/oauth2/callback?code=abc&state=xyz")
+func TestParseRedirectURL(t *testing.T) {
+	code, state, _, err := parseRedirectURL("http://127.0.0.1:55555/oauth2/callback?code=abc&state=xyz")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -66,12 +66,12 @@ func TestExtractCodeAndState(t *testing.T) {
 	}
 }
 
-func TestExtractCodeAndState_Errors(t *testing.T) {
-	if _, _, err := extractCodeAndState("not a url"); err == nil {
+func TestParseRedirectURL_Errors(t *testing.T) {
+	if _, _, _, err := parseRedirectURL("not a url"); err == nil {
 		t.Fatalf("expected error")
 	}
 
-	if _, _, err := extractCodeAndState("http://127.0.0.1:55555/oauth2/callback?state=xyz"); err == nil {
+	if _, _, _, err := parseRedirectURL("http://127.0.0.1:55555/oauth2/callback?state=xyz"); err == nil {
 		t.Fatalf("expected error")
 	}
 }


### PR DESCRIPTION
The account manager now resolves stable identities and owns parsed templates and injected dependencies, but older private forwarding helpers survived only because tests still called them. Remove those email-only, CSRF, template-reparsing, credentials-reader, and redirect-tuple wrappers. Move their existing cases onto the active identity functions, manager constructor/rendering method, credential dependency, and full redirect parser.

OAuth scopes, authorization flows, token storage, identity migration, UI rendering, and public CLI behavior remain unchanged. No test cases are removed; the success-token test retains its email and subject assertions without redundantly calling an email-only adapter.

Validation:

- Isolated Codex autoreview: scoped clean through P2.
- `go test ./internal/googleauth` passed.
- Built-CLI proof: service listings and account-manager/account-add dry-run outputs match the base binary in three invocations, without performing OAuth authorization.
- Full `make ci` passed, including formatting, lint, deadcode, Go/script tests, docs and generated skills. Exact-head CI is required before merge.
