### PR TITLE
feat(slides): derive missing image dimensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.40.1 - Unreleased
 
+- Slides: derive either missing image dimension from local files or anonymously readable public HTTPS images, preserving explicit size pairs and documenting the public-fetch requirement. (#1112) — thanks @sebsnyk.
 - Apps Script: keep file names within one TSV field in `appscript content`, escaping line breaks instead of splitting output rows. (#1091) — thanks @haosdent.
 - Search Console: add `searchconsole inspect` for per-URL index status via the URL Inspection API (coverage state, indexing/page-fetch/robots.txt state, canonical, sitemaps, last crawl time), using the existing `webmasters` OAuth scope. (#1094) — thanks @laihenyi.
 - Search Console: preserve permission-denied exit codes when adding API setup or scope guidance. (#1094)

--- a/docs/commands.generated.md
+++ b/docs/commands.generated.md
@@ -690,7 +690,7 @@ Generated from `gog schema --json`.
       - [`gog slides (slide) element z-order --operation=STRING <presentationId> <objectId> ...`](commands/gog-slides-element-z-order.md) - Change element stacking order
     - [`gog slides (slide) export (download,dl) <presentationId> [flags]`](commands/gog-slides-export.md) - Export a Google Slides deck (pdf|pptx)
     - [`gog slides (slide) info (get,show) <presentationId>`](commands/gog-slides-info.md) - Get Google Slides presentation metadata
-    - [`gog slides (slide) insert-image --width=FLOAT-64 <presentationId> <slideId> [<image>] [flags]`](commands/gog-slides-insert-image.md) - Insert a local or public image at a position and size
+    - [`gog slides (slide) insert-image <presentationId> <slideId> [<image>] [flags]`](commands/gog-slides-insert-image.md) - Insert a local or public image at a position and size
     - [`gog slides (slide) insert-text <presentationId> <objectId> <text> [flags]`](commands/gog-slides-insert-text.md) - Insert text into an existing page element (shape or table) by objectId
     - [`gog slides (slide) link --range=STRING <presentationId> <objectId> [flags]`](commands/gog-slides-link.md) - Apply a hyperlink to a text range in one page element
     - [`gog slides (slide) list-slides <presentationId>`](commands/gog-slides-list-slides.md) - List all slides with their object IDs and skipped state

--- a/docs/commands/gog-slides-insert-image.md
+++ b/docs/commands/gog-slides-insert-image.md
@@ -7,7 +7,7 @@ Insert a local or public image at a position and size
 ## Usage
 
 ```bash
-gog slides (slide) insert-image --width=FLOAT-64 <presentationId> <slideId> [<image>] [flags]
+gog slides (slide) insert-image <presentationId> <slideId> [<image>] [flags]
 ```
 
 ## Parent
@@ -28,7 +28,7 @@ gog slides (slide) insert-image --width=FLOAT-64 <presentationId> <slideId> [<im
 | `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
 | `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
 | `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
-| `--height` | `float64` | 0 | Image height, in --unit; required with --url, local files preserve aspect ratio when omitted |
+| `--height` | `float64` | 0 | Image height, in --unit; derived from the source aspect ratio when only width is given |
 | `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
@@ -39,10 +39,10 @@ gog slides (slide) insert-image --width=FLOAT-64 <presentationId> <slideId> [<im
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
 | `--unit` | `string` | PT | Measurement unit for x/y/width/height (PT or EMU) |
-| `--url` | `string` |  | Public HTTPS image URL to insert directly |
+| `--url` | `string` |  | HTTPS image URL that Slides can fetch anonymously |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |
-| `--width` | `float64` |  | Image width, in --unit |
+| `--width` | `float64` | 0 | Image width, in --unit; derived from the source aspect ratio when only height is given |
 | `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
 | `--x` | `float64` | 0 | Left position of the image, in --unit |
 | `--y` | `float64` | 0 | Top position of the image, in --unit |

--- a/docs/slides-structure.md
+++ b/docs/slides-structure.md
@@ -122,3 +122,22 @@ duplicate IDs are rejected before submission. A single target retains the
 existing `objectId` JSON field; multiple targets return `objectIds` instead.
 Text replacement does not edit WordArt text. To replace a WordArt heading,
 delete its element and create a text box with the desired text.
+
+## Image proportions
+
+Provide either `--width` or `--height` when inserting a local image or a public
+HTTPS image. The omitted dimension follows the source aspect ratio; supplying
+both keeps the explicit size override.
+
+```bash
+gog slides insert-image <presentationId> <slideId> --url https://example.com/chart.png --width 400
+gog slides insert-image <presentationId> <slideId> chart.png --height 200
+```
+
+Google Slides must be able to fetch a URL image anonymously. Automatic sizing
+also needs an anonymous header fetch from the machine running `gog`, including
+in dry-run mode. That fetch is limited to 1 MiB and 15 seconds and rejects
+private or special-use network destinations. Metadata reads connect directly
+and ignore proxy environment variables so destination checks cannot be bypassed.
+Supply both dimensions to skip the local header fetch when the source or
+network cannot support it.

--- a/internal/app/runtime.go
+++ b/internal/app/runtime.go
@@ -77,6 +77,7 @@ type (
 	DriveDownloadFunc            func(context.Context, *drive.Service, string) (*http.Response, error)
 	DriveExportFunc              func(context.Context, *drive.Service, string, string) (*http.Response, error)
 	OpenURLFunc                  func(context.Context, string) error
+	PublicImageAspectFunc        func(context.Context, string) (float64, error)
 	OpenSecretsStoreFunc         func() (secrets.Store, error)
 	OpenSecretStoreFunc          func() (secrets.SecretStore, error)
 	AuthorizeGoogleFunc          func(context.Context, googleauth.AuthorizeOptions) (string, error)
@@ -93,47 +94,48 @@ type ZoomMeetingClient interface {
 }
 
 type Services struct {
-	AdminDirectory  AdminDirectoryServiceFactory
-	AdminOrgUnit    AdminDirectoryServiceFactory
-	AdSense         AdSenseServiceFactory
-	AppScript       AppScriptServiceFactory
-	AnalyticsAdmin  AnalyticsAdminServiceFactory
-	AnalyticsData   AnalyticsDataServiceFactory
-	Calendar        CalendarServiceFactory
-	Chat            ChatServiceFactory
-	ChatSearch      ChatSearchServiceFactory
-	Classroom       ClassroomServiceFactory
-	CloudIdentity   CloudIdentityServiceFactory
-	Docs            DocsServiceFactory
-	DocsHTTP        DocsHTTPClientFactory
-	Drive           DriveServiceFactory
-	DriveV2         DriveV2ServiceFactory
-	DriveActivity   DriveActivityServiceFactory
-	DriveLabels     DriveLabelsServiceFactory
-	Forms           FormsServiceFactory
-	Gmail           GmailServiceFactory
-	GmailDelete     GmailServiceFactory
-	Keep            KeepServiceAccountFactory
-	Meet            MeetServiceFactory
-	PeopleContacts  PeopleServiceFactory
-	PeopleDirectory PeopleServiceFactory
-	PeopleOther     PeopleServiceFactory
-	Photos          PhotosServiceFactory
-	PhotosPicker    PhotosPickerServiceFactory
-	SearchConsole   SearchConsoleServiceFactory
-	Sheets          SheetsServiceFactory
-	ConnectedSheets SheetsServiceFactory
-	SitesDrive      DriveServiceFactory
-	Slides          SlidesServiceFactory
-	Tasks           TasksServiceFactory
-	YouTubeAPIKey   YouTubeServiceFactory
-	YouTubeAccount  YouTubeServiceFactory
-	YouTubeComments YouTubeServiceFactory
-	YouTubeWrite    YouTubeServiceFactory
-	Zoom            ZoomMeetingClientFactory
-	DriveDownload   DriveDownloadFunc
-	DriveExport     DriveExportFunc
-	OpenURL         OpenURLFunc
+	AdminDirectory    AdminDirectoryServiceFactory
+	AdminOrgUnit      AdminDirectoryServiceFactory
+	AdSense           AdSenseServiceFactory
+	AppScript         AppScriptServiceFactory
+	AnalyticsAdmin    AnalyticsAdminServiceFactory
+	AnalyticsData     AnalyticsDataServiceFactory
+	Calendar          CalendarServiceFactory
+	Chat              ChatServiceFactory
+	ChatSearch        ChatSearchServiceFactory
+	Classroom         ClassroomServiceFactory
+	CloudIdentity     CloudIdentityServiceFactory
+	Docs              DocsServiceFactory
+	DocsHTTP          DocsHTTPClientFactory
+	Drive             DriveServiceFactory
+	DriveV2           DriveV2ServiceFactory
+	DriveActivity     DriveActivityServiceFactory
+	DriveLabels       DriveLabelsServiceFactory
+	Forms             FormsServiceFactory
+	Gmail             GmailServiceFactory
+	GmailDelete       GmailServiceFactory
+	Keep              KeepServiceAccountFactory
+	Meet              MeetServiceFactory
+	PeopleContacts    PeopleServiceFactory
+	PeopleDirectory   PeopleServiceFactory
+	PeopleOther       PeopleServiceFactory
+	Photos            PhotosServiceFactory
+	PhotosPicker      PhotosPickerServiceFactory
+	SearchConsole     SearchConsoleServiceFactory
+	Sheets            SheetsServiceFactory
+	ConnectedSheets   SheetsServiceFactory
+	SitesDrive        DriveServiceFactory
+	Slides            SlidesServiceFactory
+	Tasks             TasksServiceFactory
+	YouTubeAPIKey     YouTubeServiceFactory
+	YouTubeAccount    YouTubeServiceFactory
+	YouTubeComments   YouTubeServiceFactory
+	YouTubeWrite      YouTubeServiceFactory
+	Zoom              ZoomMeetingClientFactory
+	DriveDownload     DriveDownloadFunc
+	DriveExport       DriveExportFunc
+	OpenURL           OpenURLFunc
+	PublicImageAspect PublicImageAspectFunc
 
 	ConnectedSheetsWriter SheetsServiceFactory
 }

--- a/internal/cmd/runtime.go
+++ b/internal/cmd/runtime.go
@@ -37,10 +37,11 @@ func newDefaultRuntime() *app.Runtime {
 			Err: os.Stderr,
 		},
 		Services: app.Services{
-			Zoom:          newZoomMeetingClient,
-			DriveDownload: driveDownload,
-			DriveExport:   driveExportDownload,
-			OpenURL:       openPhotosPickerBrowser,
+			Zoom:              newZoomMeetingClient,
+			DriveDownload:     driveDownload,
+			DriveExport:       driveExportDownload,
+			OpenURL:           openPhotosPickerBrowser,
+			PublicImageAspect: readPublicImageAspectRatio,
 		},
 		Auth: app.AuthOperations{
 			AuthorizeGoogle:         googleauth.Authorize,
@@ -104,6 +105,9 @@ func normalizeManagedRuntimeServices(runtime *app.Runtime, defaults *app.Runtime
 	}
 	if runtime.Services.OpenURL == nil {
 		runtime.Services.OpenURL = defaults.Services.OpenURL
+	}
+	if runtime.Services.PublicImageAspect == nil {
+		runtime.Services.PublicImageAspect = defaults.Services.PublicImageAspect
 	}
 }
 

--- a/internal/cmd/runtime_services.go
+++ b/internal/cmd/runtime_services.go
@@ -465,6 +465,14 @@ func slidesService(ctx context.Context, account string) (*slides.Service, error)
 	return runtime.Services.Slides(ctx, account)
 }
 
+func publicImageAspect(ctx context.Context, imageURL string) (float64, error) {
+	runtime, err := runtimeWithService(ctx, "public image metadata")
+	if err != nil || runtime.Services.PublicImageAspect == nil {
+		return 0, serviceError(err, "public image metadata")
+	}
+	return runtime.Services.PublicImageAspect(ctx, imageURL)
+}
+
 func zoomMeetingClient(ctx context.Context, alias string) (app.ZoomMeetingClient, error) {
 	if googleapi.ReadOnly(ctx) {
 		return nil, fmt.Errorf("%w: Zoom meeting mutations are disabled", googleapi.ErrReadOnly)

--- a/internal/cmd/slides_image_dimensions.go
+++ b/internal/cmd/slides_image_dimensions.go
@@ -1,0 +1,191 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"image"
+	_ "image/gif"  // register GIF metadata decoder
+	_ "image/jpeg" // register JPEG metadata decoder
+	_ "image/png"  // register PNG metadata decoder
+	"io"
+	"math"
+	"net"
+	"net/http"
+	"net/netip"
+	"net/url"
+	"os"
+	"syscall"
+	"time"
+)
+
+const maxImageHeaderBytes = 1 << 20
+
+var errImageAddressNotPublic = errors.New("image metadata requires a public network address")
+
+var imageMetadataBlockedNetworks = []netip.Prefix{
+	netip.MustParsePrefix("0.0.0.0/8"),
+	netip.MustParsePrefix("100.64.0.0/10"),
+	netip.MustParsePrefix("192.0.0.0/24"),
+	netip.MustParsePrefix("192.0.2.0/24"),
+	netip.MustParsePrefix("192.88.99.0/24"),
+	netip.MustParsePrefix("198.18.0.0/15"),
+	netip.MustParsePrefix("198.51.100.0/24"),
+	netip.MustParsePrefix("203.0.113.0/24"),
+	netip.MustParsePrefix("240.0.0.0/4"),
+	netip.MustParsePrefix("2001:db8::/32"),
+	netip.MustParsePrefix("2001::/23"),
+	netip.MustParsePrefix("2002::/16"),
+	netip.MustParsePrefix("3fff::/20"),
+}
+
+var imageMetadataIPv6Global = netip.MustParsePrefix("2000::/3")
+
+func validateSlidesImageDimensions(width, height float64) error {
+	if math.IsNaN(width) || math.IsInf(width, 0) || math.IsNaN(height) || math.IsInf(height, 0) {
+		return usage("--width and --height must be finite")
+	}
+	if width < 0 || height < 0 {
+		return usage("--width and --height cannot be negative")
+	}
+	if width == 0 && height == 0 {
+		return usage("provide --width or --height greater than 0")
+	}
+	return nil
+}
+
+func resolveSlidesImageDimensions(ctx context.Context, source slidesImageSource, width, height float64) (float64, float64, error) {
+	if width > 0 && height > 0 {
+		return width, height, nil
+	}
+	var aspect float64
+	var err error
+	if source.imageURL == "" {
+		aspect, err = imageAspectRatio(source.localPath)
+	} else {
+		aspect, err = publicImageAspect(ctx, source.imageURL)
+	}
+	if err != nil {
+		return 0, 0, fmt.Errorf("determine image aspect ratio (provide both --width and --height to skip): %w", err)
+	}
+	if aspect <= 0 || math.IsNaN(aspect) || math.IsInf(aspect, 0) {
+		return 0, 0, fmt.Errorf("invalid image aspect ratio")
+	}
+	if width == 0 {
+		width = height / aspect
+	} else {
+		height = width * aspect
+	}
+	if err := validateSlidesImageDimensions(width, height); err != nil {
+		return 0, 0, err
+	}
+	if width == 0 || height == 0 {
+		return 0, 0, usage("resolved image dimensions must be greater than 0")
+	}
+	return width, height, nil
+}
+
+func imageAspectRatio(path string) (float64, error) {
+	file, err := os.Open(path) //nolint:gosec // explicit local image input
+	if err != nil {
+		return 0, fmt.Errorf("open image: %w", err)
+	}
+	defer file.Close()
+	return decodeImageAspectRatio(file)
+}
+
+func decodeImageAspectRatio(reader io.Reader) (float64, error) {
+	config, _, err := image.DecodeConfig(reader)
+	if err != nil {
+		return 0, fmt.Errorf("decode image config: %w", err)
+	}
+	if config.Width <= 0 || config.Height <= 0 {
+		return 0, fmt.Errorf("image dimensions must be greater than 0")
+	}
+	return float64(config.Height) / float64(config.Width), nil
+}
+
+func publicImageHTTPClient() *http.Client {
+	dialer := &net.Dialer{
+		Timeout: 10 * time.Second,
+		ControlContext: func(_ context.Context, _, address string, _ syscall.RawConn) error {
+			return checkPublicImageAddress(address)
+		},
+	}
+	// Validate every resolved peer, including redirects. Proxies are deliberately
+	// disabled: a CONNECT proxy would resolve the destination outside this guard.
+	transport := &http.Transport{
+		DialContext:         dialer.DialContext,
+		TLSHandshakeTimeout: 10 * time.Second, ResponseHeaderTimeout: 10 * time.Second,
+		ForceAttemptHTTP2: true,
+	}
+	return &http.Client{Transport: transport, Timeout: 15 * time.Second, CheckRedirect: checkPublicImageRedirect}
+}
+
+func readPublicImageAspectRatio(ctx context.Context, imageURL string) (float64, error) {
+	client := publicImageHTTPClient()
+	defer client.CloseIdleConnections()
+	return fetchImageAspectRatio(ctx, client, imageURL)
+}
+
+func checkPublicImageRedirect(request *http.Request, via []*http.Request) error {
+	request.Header.Del("Referer") // A signed source URL must not reach the redirect host.
+	if len(via) >= 10 {
+		return errors.New("too many image redirects")
+	}
+	_, err := resolveSlidesImageSource("", request.URL.String())
+	return err
+}
+
+func checkPublicImageAddress(address string) error {
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		return errImageAddressNotPublic
+	}
+	ip, err := netip.ParseAddr(host)
+	if err != nil {
+		return errImageAddressNotPublic
+	}
+	ip = ip.Unmap()
+	if !ip.IsGlobalUnicast() || ip.IsPrivate() {
+		return errImageAddressNotPublic
+	}
+	if ip.Is6() && !imageMetadataIPv6Global.Contains(ip) {
+		return errImageAddressNotPublic
+	}
+	for _, prefix := range imageMetadataBlockedNetworks {
+		if prefix.Contains(ip) {
+			return errImageAddressNotPublic
+		}
+	}
+	return nil
+}
+
+func fetchImageAspectRatio(ctx context.Context, client *http.Client, imageURL string) (float64, error) {
+	if _, err := resolveSlidesImageSource("", imageURL); err != nil {
+		return 0, err
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, imageURL, nil)
+	if err != nil {
+		return 0, fmt.Errorf("create image metadata request")
+	}
+	request.Header.Set("Range", fmt.Sprintf("bytes=0-%d", maxImageHeaderBytes-1))
+	response, err := client.Do(request)
+	if err != nil {
+		var urlErr *url.Error
+		if errors.As(err, &urlErr) {
+			err = urlErr.Err // Keep signed query parameters out of diagnostics.
+		}
+		return 0, fmt.Errorf("fetch image metadata: %w", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK && response.StatusCode != http.StatusPartialContent {
+		return 0, fmt.Errorf("image metadata request returned HTTP %d", response.StatusCode)
+	}
+	reader := &io.LimitedReader{R: response.Body, N: maxImageHeaderBytes}
+	aspect, err := decodeImageAspectRatio(reader)
+	if err != nil && reader.N == 0 {
+		return 0, fmt.Errorf("image dimensions not found within the %d-byte header budget", maxImageHeaderBytes)
+	}
+	return aspect, err
+}

--- a/internal/cmd/slides_image_dimensions_test.go
+++ b/internal/cmd/slides_image_dimensions_test.go
@@ -40,9 +40,9 @@ func TestPublicImageAddressPolicy(t *testing.T) {
 }
 
 func TestPublicImageRedirectPolicy(t *testing.T) {
-	redirect, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://cdn.example.com/image", nil)
-	if err != nil {
-		t.Fatal(err)
+	redirect, requestErr := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://cdn.example.com/image", nil)
+	if requestErr != nil {
+		t.Fatal(requestErr)
 	}
 	redirect.Header.Set("Referer", "https://example.com/image?signature=private-marker")
 	if err := checkPublicImageRedirect(redirect, nil); err != nil {

--- a/internal/cmd/slides_image_dimensions_test.go
+++ b/internal/cmd/slides_image_dimensions_test.go
@@ -1,0 +1,154 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"image"
+	"image/png"
+	"io"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/openclaw/gogcli/internal/app"
+)
+
+func TestPublicImageClientCannotUseProxyResolution(t *testing.T) {
+	client := publicImageHTTPClient()
+	defer client.CloseIdleConnections()
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok || transport.Proxy != nil {
+		t.Fatal("metadata transport must dial destinations directly so address validation cannot be bypassed through a proxy")
+	}
+}
+
+func TestPublicImageAddressPolicy(t *testing.T) {
+	for _, address := range []string{"8.8.8.8:443", "[2606:4700:4700::1111]:443"} {
+		if err := checkPublicImageAddress(address); err != nil {
+			t.Errorf("public %s: %v", address, err)
+		}
+	}
+	for _, address := range []string{"127.0.0.1:443", "10.0.0.1:443", "192.168.1.1:443", "169.254.169.254:443", "100.100.100.200:443", "0.1.2.3:443", "[::1]:443", "[::ffff:127.0.0.1]:443", "[fd00::1]:443", "[64:ff9b::7f00:1]:443", "[2002:7f00:1::]:443", "example.com:443"} {
+		if !errors.Is(checkPublicImageAddress(address), errImageAddressNotPublic) {
+			t.Errorf("accepted non-public %s", address)
+		}
+	}
+}
+
+func TestPublicImageRedirectPolicy(t *testing.T) {
+	redirect, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://cdn.example.com/image", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	redirect.Header.Set("Referer", "https://example.com/image?signature=private-marker")
+	if err := checkPublicImageRedirect(redirect, nil); err != nil {
+		t.Fatal(err)
+	}
+	if redirect.Header.Get("Referer") != "" {
+		t.Fatal("redirect leaked signed source URL")
+	}
+	for _, raw := range []string{"http://example.com/image", "https://user:secret@example.com/image"} {
+		parsed, err := url.Parse(raw)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := checkPublicImageRedirect(&http.Request{URL: parsed}, nil); err == nil {
+			t.Errorf("accepted unsafe redirect")
+		}
+	}
+	parsed, err := url.Parse("https://example.com/image")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := checkPublicImageRedirect(&http.Request{URL: parsed}, make([]*http.Request, 10)); err == nil {
+		t.Fatal("accepted redirect loop")
+	}
+}
+
+func TestFetchImageAspectRatioAnonymousAndBounded(t *testing.T) {
+	var pngData bytes.Buffer
+	if err := png.Encode(&pngData, image.NewRGBA(image.Rect(0, 0, 4, 2))); err != nil {
+		t.Fatal(err)
+	}
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "" || r.Header.Get("Cookie") != "" {
+			t.Error("metadata request carried credentials")
+		}
+		if r.Header.Get("Range") != "bytes=0-1048575" {
+			t.Errorf("unexpected Range: %s", r.Header.Get("Range"))
+		}
+		_, _ = w.Write(pngData.Bytes())
+	}))
+	defer srv.Close()
+	aspect, err := fetchImageAspectRatio(context.Background(), srv.Client(), srv.URL+"/image.png")
+	if err != nil || aspect != 0.5 {
+		t.Fatalf("aspect = %v, err = %v", aspect, err)
+	}
+	if _, err := readPublicImageAspectRatio(context.Background(), srv.URL); !errors.Is(err, errImageAddressNotPublic) {
+		t.Fatalf("loopback not blocked: %v", err)
+	}
+}
+
+type imageMetadataTransport func(*http.Request) (*http.Response, error)
+
+func (f imageMetadataTransport) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func TestImageMetadataDiagnosticsDoNotExposeSignedURL(t *testing.T) {
+	client := &http.Client{Transport: imageMetadataTransport(func(*http.Request) (*http.Response, error) { return nil, errors.New("connection failed") })}
+	_, err := fetchImageAspectRatio(context.Background(), client, "https://example.com/image?signature=private-marker")
+	if err == nil || strings.Contains(err.Error(), "private-marker") {
+		t.Fatalf("unsafe error: %v", err)
+	}
+}
+
+func TestImageMetadataReaderLimit(t *testing.T) {
+	// A JPEG may carry many APP segments before its dimensions. A header beyond
+	// the metadata budget must fail without reading the rest of the response.
+	segment := append([]byte{0xff, 0xe1, 0xff, 0xff}, make([]byte, 65533)...)
+	data := make([]byte, 2, 2+20*len(segment))
+	data[0], data[1] = 0xff, 0xd8
+	for range 20 {
+		data = append(data, segment...)
+	}
+	reader := &imageCountingReader{Reader: bytes.NewReader(data)}
+	client := &http.Client{Transport: imageMetadataTransport(func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(reader), Header: make(http.Header)}, nil
+	})}
+	if _, err := fetchImageAspectRatio(context.Background(), client, "https://example.com/image.jpg"); err == nil {
+		t.Fatal("accepted oversized metadata")
+	}
+	if reader.bytes > maxImageHeaderBytes {
+		t.Fatalf("read %d bytes", reader.bytes)
+	}
+}
+
+type imageCountingReader struct {
+	io.Reader
+	bytes int
+}
+
+func (r *imageCountingReader) Read(p []byte) (int, error) {
+	n, err := r.Reader.Read(p)
+	r.bytes += n
+	return n, err
+}
+
+func TestSlidesImageDimensionsRejectInvalidValues(t *testing.T) {
+	for _, pair := range [][2]float64{{0, 0}, {-1, 2}, {2, -1}, {math.NaN(), 2}, {2, math.Inf(1)}} {
+		if err := validateSlidesImageDimensions(pair[0], pair[1]); err == nil {
+			t.Fatalf("accepted %v", pair)
+		}
+	}
+}
+
+func TestRemoteImageAspectRequiresExplicitRuntimeService(t *testing.T) {
+	ctx := app.WithRuntime(context.Background(), &app.Runtime{})
+	_, _, err := resolveSlidesImageDimensions(ctx, slidesImageSource{imageURL: "https://example.com/image"}, 100, 0)
+	if !errors.Is(err, errRuntimeServiceRequired) {
+		t.Fatalf("missing runtime service did not fail closed: %v", err)
+	}
+}

--- a/internal/cmd/slides_insert_image.go
+++ b/internal/cmd/slides_insert_image.go
@@ -3,11 +3,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"image"
-	_ "image/gif"  // register GIF decoder for aspect detection
-	_ "image/jpeg" // register JPEG decoder for aspect detection
-	_ "image/png"  // register PNG decoder for aspect detection
-	"os"
 	"strings"
 	"time"
 
@@ -22,16 +17,17 @@ import (
 // slide), this places a sized element on a slide you already have, so callers
 // can build native decks via the Slides API and still drop in a logo, chart,
 // or badge at a precise location. Local files use the same temporary Drive
-// upload flow as add-slide; public HTTPS URLs are passed directly to Slides.
+// upload flow as add-slide. URL images remain remote; missing dimensions require
+// an anonymous header read before the URL is passed to Slides.
 type SlidesInsertImageCmd struct {
 	PresentationID string  `arg:"" name:"presentationId" help:"Presentation ID"`
 	SlideID        string  `arg:"" name:"slideId" help:"Slide object ID to place the image on"`
 	Image          string  `arg:"" optional:"" name:"image" help:"Local image file (PNG/JPG/GIF)" type:"existingfile"`
-	URL            string  `name:"url" help:"Public HTTPS image URL to insert directly"`
+	URL            string  `name:"url" help:"HTTPS image URL that Slides can fetch anonymously"`
 	X              float64 `name:"x" default:"0" help:"Left position of the image, in --unit"`
 	Y              float64 `name:"y" default:"0" help:"Top position of the image, in --unit"`
-	Width          float64 `name:"width" required:"" help:"Image width, in --unit"`
-	Height         float64 `name:"height" default:"0" help:"Image height, in --unit; required with --url, local files preserve aspect ratio when omitted"`
+	Width          float64 `name:"width" default:"0" help:"Image width, in --unit; derived from the source aspect ratio when only height is given"`
+	Height         float64 `name:"height" default:"0" help:"Image height, in --unit; derived from the source aspect ratio when only width is given"`
 	Unit           string  `name:"unit" enum:"PT,EMU" default:"PT" help:"Measurement unit for x/y/width/height (PT or EMU)"`
 }
 
@@ -46,11 +42,8 @@ func (c *SlidesInsertImageCmd) Run(ctx context.Context, flags *RootFlags) error 
 	if slideID == "" {
 		return usage("empty slideId")
 	}
-	if c.Width <= 0 {
-		return usage("--width must be greater than 0")
-	}
-	if c.Height < 0 {
-		return usage("--height cannot be negative")
+	if err := validateSlidesImageDimensions(c.Width, c.Height); err != nil {
+		return err
 	}
 
 	source, err := resolveSlidesImageSource(c.Image, c.URL)
@@ -58,17 +51,9 @@ func (c *SlidesInsertImageCmd) Run(ctx context.Context, flags *RootFlags) error 
 		return err
 	}
 
-	// Resolve height from the image's aspect ratio when not supplied.
-	height := c.Height
-	if height == 0 {
-		if source.imageURL != "" {
-			return usage("--height is required with --url")
-		}
-		ar, aspectErr := imageAspectRatio(source.localPath)
-		if aspectErr != nil {
-			return fmt.Errorf("determine image aspect ratio (pass --height to skip): %w", aspectErr)
-		}
-		height = c.Width * ar
+	width, height, err := resolveSlidesImageDimensions(ctx, source, c.Width, c.Height)
+	if err != nil {
+		return err
 	}
 
 	dryRunPayload := map[string]any{
@@ -76,7 +61,7 @@ func (c *SlidesInsertImageCmd) Run(ctx context.Context, flags *RootFlags) error 
 		"slide_id":        slideID,
 		"x":               c.X,
 		"y":               c.Y,
-		"width":           c.Width,
+		"width":           width,
 		"height":          height,
 		"unit":            c.Unit,
 	}
@@ -127,7 +112,7 @@ func (c *SlidesInsertImageCmd) Run(ctx context.Context, flags *RootFlags) error 
 					ElementProperties: &slides.PageElementProperties{
 						PageObjectId: slideID,
 						Size: &slides.Size{
-							Width:  &slides.Dimension{Magnitude: c.Width, Unit: c.Unit},
+							Width:  &slides.Dimension{Magnitude: width, Unit: c.Unit},
 							Height: &slides.Dimension{Magnitude: height, Unit: c.Unit},
 						},
 						Transform: &slides.AffineTransform{
@@ -160,22 +145,4 @@ func (c *SlidesInsertImageCmd) Run(ctx context.Context, flags *RootFlags) error 
 	u.Out().Linef("image\t%s", imageID)
 	u.Out().Linef("link\t%s", link)
 	return nil
-}
-
-// imageAspectRatio returns height/width for the given image file.
-func imageAspectRatio(path string) (float64, error) {
-	f, err := os.Open(path) //nolint:gosec // user-provided local image path is the command input.
-	if err != nil {
-		return 0, fmt.Errorf("open image: %w", err)
-	}
-	defer f.Close()
-
-	cfg, _, err := image.DecodeConfig(f)
-	if err != nil {
-		return 0, fmt.Errorf("decode image config: %w", err)
-	}
-	if cfg.Width <= 0 {
-		return 0, fmt.Errorf("image has zero width")
-	}
-	return float64(cfg.Height) / float64(cfg.Width), nil
 }

--- a/internal/cmd/slides_insert_image_test.go
+++ b/internal/cmd/slides_insert_image_test.go
@@ -16,6 +16,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/openclaw/gogcli/internal/app"
+
 	"google.golang.org/api/drive/v3"
 	"google.golang.org/api/option"
 	"google.golang.org/api/slides/v1"
@@ -218,23 +220,6 @@ func TestSlidesInsertImage_URLSkipsDrive(t *testing.T) {
 	}
 }
 
-func TestSlidesInsertImage_URLRequiresHeight(t *testing.T) {
-	t.Parallel()
-
-	err := (&SlidesInsertImageCmd{
-		PresentationID: "pres1",
-		SlideID:        "slide1",
-		URL:            "https://example.com/image.png",
-		Width:          120,
-	}).Run(newCmdRuntimeOutputContext(t, io.Discard, io.Discard), &RootFlags{Account: "a@b.com"})
-	if err == nil || !strings.Contains(err.Error(), "--height is required with --url") {
-		t.Fatalf("expected URL height error, got %v", err)
-	}
-	if ExitCode(err) != 2 {
-		t.Fatalf("expected usage exit code 2, got %d", ExitCode(err))
-	}
-}
-
 func TestSlidesInsertImage_URLDryRunSkipsServices(t *testing.T) {
 	t.Parallel()
 
@@ -381,5 +366,41 @@ func TestImageAspectRatio(t *testing.T) {
 	}
 	if ar != 0.5 {
 		t.Errorf("expected aspect ratio 0.5, got %v", ar)
+	}
+}
+
+func TestSlidesInsertImageURLDerivesMissingDimension(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		args          []string
+		width, height float64
+		wantReads     int
+	}{
+		{name: "width only", args: []string{"--width", "200"}, width: 200, height: 100, wantReads: 1},
+		{name: "height only", args: []string{"--height", "100"}, width: 200, height: 100, wantReads: 1},
+		{name: "explicit pair", args: []string{"--width", "200", "--height", "75"}, width: 200, height: 75},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			reads := 0
+			ctx := withTestRuntime(newCmdRuntimeJSONOutputContext(t, &stdout, &stderr), func(runtime *app.Runtime) {
+				runtime.Services.PublicImageAspect = func(context.Context, string) (float64, error) { reads++; return 0.5, nil }
+			})
+			args := append([]string{"pres1", "slide1", "--url", "https://example.com/image.png"}, tc.args...)
+			err := runKong(t, &SlidesInsertImageCmd{}, args, ctx, &RootFlags{DryRun: true, NoInput: true})
+			var exitErr *ExitError
+			if !errors.As(err, &exitErr) || exitErr.Code != 0 {
+				t.Fatalf("dry run: %v", err)
+			}
+			var output struct {
+				Request struct{ Width, Height float64 } `json:"request"`
+			}
+			if err := json.Unmarshal(stdout.Bytes(), &output); err != nil {
+				t.Fatal(err)
+			}
+			if output.Request.Width != tc.width || output.Request.Height != tc.height || reads != tc.wantReads {
+				t.Fatalf("size = %v x %v, reads = %d", output.Request.Width, output.Request.Height, reads)
+			}
+		})
 	}
 }


### PR DESCRIPTION
`slides insert-image` now accepts either width or height for local and public-URL images and derives the missing dimension from the source aspect ratio. Supplying both keeps the existing explicit size and avoids metadata reads. This resolves #1112; thanks @sebsnyk for the report.

Google Slides rejected omitted dimensions in live probes, so URL sizing needs an anonymous local metadata read. The new path connects directly over HTTPS, validates resolved public peers on every connection, strips redirect Referer headers, and limits metadata to 1 MiB and 15 seconds. Proxy environment variables are deliberately ignored because proxy-side DNS would bypass destination checks. Help and workflow documentation explain anonymous Google fetches, dry-run network access, and the explicit-size alternative.

Validation: full local `make ci`; isolated Codex review through P2, including fixes for proxy destination bypass and redirect Referer leakage; regression coverage for both sizing directions, explicit-size bypass, invalid dimensions, missing runtime services, network boundaries, signed-URL diagnostics, redirects and header limits.

Live proof used the signed, compiled candidate and the repository's public 1200×630 social-card image in a disposable Google presentation. API read-back verified width-only 400×210 PT and height-only 200×105 PT within 0.01 PT; the presentation was trashed. The compiled dry-run also resolved 400×210. No scopes, API settings or deployment changed.
